### PR TITLE
update .editorconfig

### DIFF
--- a/src/Aquifer.API/.editorconfig
+++ b/src/Aquifer.API/.editorconfig
@@ -19,6 +19,9 @@ insert_final_newline = false
 
 #### .NET Coding Conventions ####
 
+# Attributes on lines above
+place_attribute_on_same_line = false
+
 # Organize usings
 dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = false


### PR DESCRIPTION
This updates the place_attribute_on_same_line=false in the .editorconfig, which is a more sane default to the style we've been going with.