### PR TITLE
Fix bundle migrations error

### DIFF
--- a/src/Aquifer.API/appsettings.json
+++ b/src/Aquifer.API/appsettings.json
@@ -1,9 +1,12 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "AllowedHosts": "*",
+    "ConnectionStrings": {
+        "BiblioNexusDb": ""
     }
-  },
-  "AllowedHosts": "*"
 }


### PR DESCRIPTION
Resolve pipeline issue with bundle migrations. By adding the appsettings value, `configuration.ConnectionStrings` won't be null anymore.

Configuration gets set to null if there are no configurations to match the ConfigurationOptions object. Since there were no config values for this in the pipeline, it was blowing up.