### PR TITLE
Add Swagger/OpenAPI support

### DIFF
--- a/src/Aquifer.API/Aquifer.API.csproj
+++ b/src/Aquifer.API/Aquifer.API.csproj
@@ -11,11 +11,13 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0-beta3"/>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.10"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.10"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.9">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.9"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Aquifer.API/Program.cs
+++ b/src/Aquifer.API/Program.cs
@@ -1,6 +1,7 @@
 using Aquifer.API.Configuration;
 using Aquifer.API.Data;
 using Aquifer.API.Modules;
+using Aquifer.API.Services;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -8,6 +9,7 @@ var configuration = builder.Configuration.Get<ConfigurationOptions>();
 
 builder.Services
     //.AddAuth(configuration)
+    .AddSwagger()
     .AddApplicationInsightsTelemetry()
     .AddDbContext<AquiferDbContext>(options =>
         options.UseSqlServer(configuration?.ConnectionStrings?.BiblioNexusDb))
@@ -16,5 +18,6 @@ builder.Services
 var app = builder.Build();
 
 //app.UseAuth();
+app.UseSwaggerWithUi();
 app.MapEndpoints();
 app.Run();

--- a/src/Aquifer.API/Properties/launchSettings.json
+++ b/src/Aquifer.API/Properties/launchSettings.json
@@ -1,37 +1,40 @@
 ﻿{
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:52654",
-      "sslPort": 44310
-    }
-  },
-  "profiles": {
-    "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "http://localhost:5257",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+    "iisSettings": {
+        "windowsAuthentication": false,
+        "anonymousAuthentication": true,
+        "iisExpress": {
+            "applicationUrl": "http://localhost:52654",
+            "sslPort": 44310
+        }
     },
-    "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:7236;http://localhost:5257",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+    "profiles": {
+        "http": {
+            "commandName": "Project",
+            "dotnetRunMessages": true,
+            "launchBrowser": true,
+            "applicationUrl": "http://localhost:5257",
+            "launchUrl": "swagger",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        },
+        "https": {
+            "commandName": "Project",
+            "dotnetRunMessages": true,
+            "launchBrowser": true,
+            "launchUrl": "swagger",
+            "applicationUrl": "https://localhost:7236;http://localhost:5257",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        },
+        "IIS Express": {
+            "commandName": "IISExpress",
+            "launchBrowser": true,
+            "launchUrl": "swagger",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        }
     }
-  }
 }

--- a/src/Aquifer.API/Services/SwaggerService.cs
+++ b/src/Aquifer.API/Services/SwaggerService.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.OpenApi.Models;
+
+namespace Aquifer.API.Services;
+
+public static class SwaggerService
+{
+    public static IServiceCollection AddSwagger(this IServiceCollection services)
+    {
+        services.AddEndpointsApiExplorer();
+        services.AddSwaggerGen(x =>
+        {
+            x.AddSecurityDefinition("Bearer",
+                new OpenApiSecurityScheme
+                {
+                    Description = "JWT Authorization header using the bearer scheme",
+                    Name = "Authorization",
+                    In = ParameterLocation.Header,
+                    Type = SecuritySchemeType.ApiKey
+                });
+
+            x.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "Bearer"
+                        }
+                    },
+                    new List<string>()
+                }
+            });
+        });
+
+        return services;
+    }
+
+    public static void UseSwaggerWithUi(this WebApplication app)
+    {
+        app.UseSwagger();
+        app.UseSwaggerUI();
+    }
+}


### PR DESCRIPTION
Add a swagger service. Can be viewed from `/swagger`. More fine-tuned options can be set per endpoint if desired, but without setting any additional options it does a good job.

I also added logic for adding an auth token to example requests for future endpoints that will need it.

It's also worth noting that the size of some of our responses seems to overwhelm the javascript that's running to display responses, and it can freeze up the browser.