### PR TITLE
don't restrict supporting resource lookups parent checks

### DIFF
--- a/src/Aquifer.API/Modules/Resources/ResourcesModule.cs
+++ b/src/Aquifer.API/Modules/Resources/ResourcesModule.cs
@@ -88,7 +88,6 @@ public class ResourcesModule : IModule
         var supportingResourceContent = await dbContext.PassageResources
             // find all passages that overlap with the current book
             .Where(pr => Constants.RootResourceTypes.Contains(pr.Resource.Type.ShortName) &&
-                         resourceTypeEntities.Contains(pr.Resource.Type) &&
                          ((pr.Passage.StartVerseId > BibleUtilities.LowerBoundOfBook(bookId) &&
                            pr.Passage.StartVerseId < BibleUtilities.UpperBoundOfBook(bookId)) ||
                           (pr.Passage.EndVerseId > BibleUtilities.LowerBoundOfBook(bookId) &&


### PR DESCRIPTION
Previously on the resources endpoint, when fetching associated resources, we were filtering the parent resources down to whatever resourceTypes were passed. In the case of UbsImages (linked to CBBTER resources), this meant you couldn't just pass UbsImages without also passing CBBTER or you would get empty results.

By removing the filtering of parent resources, we ensure that regardless of what type the associated resources are linked to, they'll be returned.