### PR TITLE
fallback to English for images/videos if missing in current language

### DIFF
--- a/src/Aquifer.API/Common/Constants.cs
+++ b/src/Aquifer.API/Common/Constants.cs
@@ -7,4 +7,9 @@ public static class Constants
 {
     // this represents the resource types that we allow to be accessed as the starting point when viewing content
     public static readonly ReadOnlyCollection<string> RootResourceTypes = new List<string> { "CBBTER" }.AsReadOnly();
+
+    // this represents the media types that we default to English for
+    public static readonly ReadOnlyCollection<ResourceContentMediaType> FallbackToEnglishForMediaTypes =
+        new List<ResourceContentMediaType> { ResourceContentMediaType.Image, ResourceContentMediaType.Video }
+            .AsReadOnly();
 }


### PR DESCRIPTION
Long term we will probably need to make this opt-in, but getting this done quickly for now. This updates the resource queries so that we fallback to English for images/videos for both the file manager and passages page.