### PR TITLE
fix deploy action

### DIFF
--- a/.github/actions/deploy-to-env/action.yml
+++ b/.github/actions/deploy-to-env/action.yml
@@ -11,6 +11,15 @@ inputs:
     web-app-name:
         description: Azure Web App name
         required: true
+    azure-client-id:
+        description: Azure Client ID
+        required: true
+    azure-tenant-id:
+        description: Azure Tenant ID
+        required: true
+    azure-subscription-id:
+        description: Azure Subscription ID
+        required: true
 
 runs:
     using: composite
@@ -22,9 +31,9 @@ runs:
         - name: Login to Azure
           uses: azure/login@v1
           with:
-              client-id: ${{ secrets.AZURE_CLIENT_ID }}
-              tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-              subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+              client-id: ${{ inputs.azure-client-id }}
+              tenant-id: ${{ inputs.azure-tenant-id }}
+              subscription-id: ${{ inputs.azure-subscription-id }}
         - name: Make migration script executable
           run: chmod +x ./build/Migrate
           shell: bash

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -61,6 +61,9 @@ jobs:
                   environment: dev
                   connection-url: ${{ vars.DB_CONNECTION_URL_DEV }}
                   web-app-name: ${{ vars.AZURE_WEB_APP_NAME_DEV }}
+                  azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+                  azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+                  azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     deploy_to_qa:
         if: github.ref == 'refs/heads/master' || github.event.inputs.environment == 'qa'
@@ -79,6 +82,9 @@ jobs:
                   environment: qa
                   connection-url: ${{ vars.DB_CONNECTION_URL_QA }}
                   web-app-name: ${{ vars.AZURE_WEB_APP_NAME_QA }}
+                  azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+                  azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+                  azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     deploy_to_prod:
         if: github.ref == 'refs/heads/master' || github.event.inputs.environment == 'prod'
@@ -99,6 +105,9 @@ jobs:
                   environment: prod
                   connection-url: ${{ vars.DB_CONNECTION_URL_PROD }}
                   web-app-name: ${{ vars.AZURE_WEB_APP_NAME_PROD }}
+                  azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+                  azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+                  azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     create_release:
         name: Create release


### PR DESCRIPTION
An action is not able to reference any of the workflow's context, only the inputs that are passed in. This refactors the action to take the azure ids as inputs.