### PR TITLE
increase migration timeout for copying resource content between tables

### DIFF
--- a/src/Aquifer.Data/Migrations/20231204192959_CopyContentToVersionsTable.cs
+++ b/src/Aquifer.Data/Migrations/20231204192959_CopyContentToVersionsTable.cs
@@ -10,6 +10,8 @@ namespace Aquifer.Data.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.Sql("SET COMMAND_TIMEOUT = 300"); // 5 minutes
+
             migrationBuilder.Sql(@"
                 INSERT INTO [dbo].[ResourceContentVersions] (
                     [ResourceContentId],


### PR DESCRIPTION
The migration failed because it takes more than 30 seconds to copy the data between the tables.