### PR TITLE
add separate migrations project that has 10 minute db timeout

### DIFF
--- a/.github/actions/deploy-to-env/action.yml
+++ b/.github/actions/deploy-to-env/action.yml
@@ -38,7 +38,7 @@ runs:
           run: chmod +x ./build/Migrate
           shell: bash
         - name: Run migrations
-          run: cd build && ./Migrate --connection '${{ inputs.connection-url }}'
+          run: ./build/Migrate --connection '${{ inputs.connection-url }}'
           shell: bash
         - name: Upload package
           uses: azure/webapps-deploy@v2

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -34,12 +34,10 @@ jobs:
               run: mkdir ./build
             - name: Build API
               run: dotnet publish src/Aquifer.API --output ./Aquifer.API --configuration Release --runtime win-x64 --self-contained
-            - name: Copy appsettings (for use in migration)
-              run: cp src/Aquifer.API/appsettings.json build/appsettings.json
             - name: Zip API
               run: cd ./Aquifer.API && zip ../build/Aquifer.API.zip *
             - name: Bundle migrations
-              run: dotnet ef migrations bundle --startup-project src/Aquifer.API --project src/Aquifer.Data --output build/Migrate --self-contained
+              run: dotnet ef migrations bundle --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --output build/Migrate --self-contained
             - name: Publish artifact
               uses: actions/upload-artifact@v3
               with:

--- a/.gitignore
+++ b/.gitignore
@@ -398,4 +398,5 @@ FodyWeavers.xsd
 *.sln.iml
 *.DotSettings.user
 src/Aquifer.API/appsettings.Development.json
+src/Aquifer.Migrations/appsettings.Development.json
 .idea/

--- a/Aquifer.sln
+++ b/Aquifer.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aquifer.API", "src\Aquifer.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aquifer.Data", "src\Aquifer.Data\Aquifer.Data.csproj", "{2CE9009D-784B-4A78-BBA9-8B0043AA9277}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aquifer.Migrations", "src\Aquifer.Migrations\Aquifer.Migrations.csproj", "{47A55D6A-68CE-4DAE-82BD-6DC78CF701F1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,6 +27,10 @@ Global
 		{2CE9009D-784B-4A78-BBA9-8B0043AA9277}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2CE9009D-784B-4A78-BBA9-8B0043AA9277}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2CE9009D-784B-4A78-BBA9-8B0043AA9277}.Release|Any CPU.Build.0 = Release|Any CPU
+		{47A55D6A-68CE-4DAE-82BD-6DC78CF701F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{47A55D6A-68CE-4DAE-82BD-6DC78CF701F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{47A55D6A-68CE-4DAE-82BD-6DC78CF701F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{47A55D6A-68CE-4DAE-82BD-6DC78CF701F1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -32,6 +38,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{831A381B-68CF-4ED8-A5FC-FD2A4D94F18B} = {795E7203-D40F-4962-837D-DD39BAF2C930}
 		{2CE9009D-784B-4A78-BBA9-8B0043AA9277} = {795E7203-D40F-4962-837D-DD39BAF2C930}
+		{47A55D6A-68CE-4DAE-82BD-6DC78CF701F1} = {795E7203-D40F-4962-837D-DD39BAF2C930}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8E32492B-EA66-40E4-A7A8-67E4ABA14A53}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ in the project and the current state of the database.
 
 To create a new migration:
 ```bash
-dotnet ef migrations add --startup-project src/Aquifer.API --project src/Aquifer.Data MigrationNameHere
+dotnet ef migrations add --startup-project src/Aquifer.Migrations --project src/Aquifer.Data MigrationNameHere
 ```
 
 If you run that command and the new migration file is empty, that means there
@@ -62,7 +62,7 @@ this to your advantage to create empty migrations and add your own custom code.
 
 To run migrations:
 ```bash
-dotnet ef database update --startup-project src/Aquifer.API --project src/Aquifer.Data
+dotnet ef database update --startup-project src/Aquifer.Migrations --project src/Aquifer.Data
 ```
 
 ## Test

--- a/src/Aquifer.Data/Migrations/20231204192959_CopyContentToVersionsTable.cs
+++ b/src/Aquifer.Data/Migrations/20231204192959_CopyContentToVersionsTable.cs
@@ -10,8 +10,6 @@ namespace Aquifer.Data.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql("SET COMMAND_TIMEOUT = 300"); // 5 minutes
-
             migrationBuilder.Sql(@"
                 INSERT INTO [dbo].[ResourceContentVersions] (
                     [ResourceContentId],

--- a/src/Aquifer.Migrations/Aquifer.Migrations.csproj
+++ b/src/Aquifer.Migrations/Aquifer.Migrations.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Aquifer.Data\Aquifer.Data.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Aquifer.Migrations/Configuration/ConfigurationOptions.cs
+++ b/src/Aquifer.Migrations/Configuration/ConfigurationOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace Aquifer.Migrations.Configuration;
+
+public class ConfigurationOptions
+{
+    public required ConnectionStringOptions ConnectionStrings { get; init; }
+}
+
+public class ConnectionStringOptions
+{
+    public required string BiblioNexusDb { get; init; }
+}

--- a/src/Aquifer.Migrations/Program.cs
+++ b/src/Aquifer.Migrations/Program.cs
@@ -1,0 +1,19 @@
+using Aquifer.Data;
+using Aquifer.Migrations.Configuration;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+var configuration = builder.Configuration.Get<ConfigurationOptions>();
+
+builder.Services
+    .AddDbContext<AquiferDbContext>(options =>
+        options.UseSqlServer(configuration?.ConnectionStrings?.BiblioNexusDb,
+            providerOptions =>
+            {
+                providerOptions.EnableRetryOnFailure(3);
+                providerOptions.CommandTimeout(600);
+            }));
+
+var app = builder.Build();
+
+app.Run();

--- a/src/Aquifer.Migrations/appsettings.example.json
+++ b/src/Aquifer.Migrations/appsettings.example.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "BiblioNexusDb": "Database connection string using Azure identity. Either get local or grab from dev app service config"
+  }
+}

--- a/src/Aquifer.Migrations/appsettings.json
+++ b/src/Aquifer.Migrations/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "BiblioNexusDb": ""
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
This is an idea from a conversation we had a few weeks ago when we ran into issues with deploying due to the migration not getting application config. We discussed that the long term best solution was to have a separate migration project that's used for generating/running the migrations, so that non-database config values aren't needed at runtime for the migrations.

A recent migration that copies lots of data from one table to another is currently timing out and by doing this separate project we can kill two birds with one stone. The separate migration project is configured with a 10 minute DB timeout while still keeping the default DB timeout for the regular API project.j