### PR TITLE
switch resource status enum serialization from int to string for ease of use with frontend code

### DIFF
--- a/src/Aquifer.API/Modules/Resources/ResourceContent/ResourceContentContracts.cs
+++ b/src/Aquifer.API/Modules/Resources/ResourceContent/ResourceContentContracts.cs
@@ -1,11 +1,9 @@
 using Aquifer.Data.Entities;
-using System.Text.Json.Serialization;
 
 namespace Aquifer.API.Modules.Resources.ResourceContent;
 
 public class ResourceContentStatusResponse
 {
-    [JsonConverter(typeof(JsonNumberEnumConverter<ResourceContentStatus>))]
     public ResourceContentStatus Status { get; init; }
     public string DisplayName { get; init; } = null!;
 }

--- a/src/Aquifer.Data/Entities/ResourceContentEntity.cs
+++ b/src/Aquifer.Data/Entities/ResourceContentEntity.cs
@@ -30,7 +30,6 @@ public class ResourceContentEntity
     public ResourceEntity Resource { get; set; } = null!;
 }
 
-[JsonConverter(typeof(JsonConverter))]
 public enum ResourceContentMediaType
 {
     None = 0,


### PR DESCRIPTION
In a previous PR when I added the resource statuses endpoint I was returning the int enum values for status. I realized this was causing redundancy in the frontend code as we'd need to store the int to enum mapping in both the frontend and backend code.