### PR TITLE
only return other languages on resource page that match the current content's media type

### DIFF
--- a/src/Aquifer.API/Modules/Resources/ResourceContentSummary/GetResourceContentSummaryEndpoints.cs
+++ b/src/Aquifer.API/Modules/Resources/ResourceContentSummary/GetResourceContentSummaryEndpoints.cs
@@ -33,7 +33,7 @@ public static class GetResourceContentSummaryEndpoints
                 HasAudio = rc.Resource.ResourceContents.Any(orc => orc.LanguageId == rc.LanguageId
                         && orc.MediaType == Data.Entities.ResourceContentMediaType.Audio),
                 OtherLanguageContentIds = rc.Resource.ResourceContents
-                    .Where(orc => orc.LanguageId != rc.LanguageId)
+                    .Where(orc => orc.LanguageId != rc.LanguageId && orc.MediaType == rc.MediaType)
                     .Select(orc => new ResourceContentSummaryContentIdWithLanguageId
                     {
                         ContentId = orc.Id,


### PR DESCRIPTION
When on a resource that has audio and text, this `OtherLanguageContentIds` was including every media type for the other languages. This doesn't make sense because the user will want to see the same media type that they're currently viewing, just in a different language. This small update to the `Where` clause fixes that.