### PR TITLE
change middleware order so 401s don't have CORS errors

### DIFF
--- a/src/Aquifer.API/Program.cs
+++ b/src/Aquifer.API/Program.cs
@@ -28,9 +28,9 @@ builder.Services
 
 var app = builder.Build();
 
+app.UseCors(b => b.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod()); // need to expand on this
 app.UseAuth();
 app.UseSwaggerWithUi();
-app.UseCors(b => b.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod()); // need to expand on this
 app.UseOutputCache();
 app.UseHealthChecks("/_health");
 app.MapEndpoints();


### PR DESCRIPTION
Currently if there are 401s in local development, it causes a CORS error. This is because the order of the CORS and auth middleware were reversed. By switching the order we can receive the 401 error itself without the red herring CORS error.