### PR TITLE
return permissions from /users/self endpoint for frontend SSR logic

### DIFF
--- a/src/Aquifer.API/Modules/Users/UserContracts.cs
+++ b/src/Aquifer.API/Modules/Users/UserContracts.cs
@@ -5,3 +5,8 @@ public class UserResponse
     public int Id { get; set; }
     public required string Name { get; set; }
 }
+
+public class CurrentUserResponse : UserResponse
+{
+    public required IEnumerable<string> Permissions { get; set; }
+}

--- a/src/Aquifer.API/Modules/Users/UsersModule.cs
+++ b/src/Aquifer.API/Modules/Users/UsersModule.cs
@@ -29,7 +29,7 @@ public class UsersModule : IModule
         return TypedResults.Ok(users);
     }
 
-    private async Task<Results<Ok<UserResponse>, NotFound>> GetCurrentUser(AquiferDbContext dbContext,
+    private async Task<Results<Ok<CurrentUserResponse>, NotFound>> GetCurrentUser(AquiferDbContext dbContext,
         ClaimsPrincipal claimsPrincipal,
         CancellationToken cancellationToken)
     {
@@ -41,10 +41,13 @@ public class UsersModule : IModule
             return TypedResults.NotFound();
         }
 
-        return TypedResults.Ok(new UserResponse
+        var permissions = claimsPrincipal.FindAll("permissions").Select(c => c.Value).ToList();
+
+        return TypedResults.Ok(new CurrentUserResponse
         {
             Id = user.Id,
-            Name = $"{user.FirstName} {user.LastName}"
+            Name = $"{user.FirstName} {user.LastName}",
+            Permissions = permissions
         });
     }
 }


### PR DESCRIPTION
There's a need on the frontend for knowing if a user has permission to fetch a given resource. If we were just doing a SPA this would be straightforward because we have access to an Auth0 JS instance. However, since these fetches are also done during SSR, it would be nice to have the insight as the page is loading and be able to conditionally make fetches.

The big use case right now is for the `/admin/users` endpoint, since that requires `read:values` authorization.