### PR TITLE
allow editing content that is not published

### DIFF
--- a/src/Aquifer.API/Common/Constants.cs
+++ b/src/Aquifer.API/Common/Constants.cs
@@ -13,15 +13,26 @@ public static class Constants
     public static readonly ReadOnlyCollection<ResourceContentMediaType> FallbackToEnglishForMediaTypes =
         new List<ResourceContentMediaType> { ResourceContentMediaType.Image, ResourceContentMediaType.Video }
             .AsReadOnly();
+
+    public static readonly string PermissionsClaim = "permissions";
+
+    public static readonly ReadOnlyCollection<string> AllPermissions =
+        new List<string> {
+            PermissionName.ReadUsers,
+            PermissionName.EditContent,
+            PermissionName.PublishContent,
+            PermissionName.AssignContent,
+            PermissionName.AssignOverride,
+            PermissionName.AquiferizeContent
+        }.AsReadOnly();
 }
 
 public static class PermissionName
 {
-    public const string Read = "read",
-        Write = "write",
-        Publish = "publish",
-        Aquiferize = "aquiferize",
+    public const string ReadUsers = "read:users",
+        EditContent = "edit:content",
+        PublishContent = "publish:content",
+        AquiferizeContent = "aquiferize:content",
         AssignContent = "assign:content",
-        AssignOverride = "assign:override",
-        Permissions = "permissions";
+        AssignOverride = "assign:override";
 }

--- a/src/Aquifer.API/Modules/Admin/AdminModule.cs
+++ b/src/Aquifer.API/Modules/Admin/AdminModule.cs
@@ -10,11 +10,11 @@ public class AdminModule : IModule
     {
         var group = endpoints.MapGroup("admin");
         group.MapPost("resources/content/{contentId:int}/aquiferize", AquiferizationEndpoints.Aquiferize)
-            .RequireAuthorization(PermissionName.Aquiferize);
+            .RequireAuthorization(PermissionName.AquiferizeContent);
         group.MapPost("resources/content/{contentId:int}/publish", AquiferizationEndpoints.Publish)
-            .RequireAuthorization(PermissionName.Publish);
+            .RequireAuthorization(PermissionName.PublishContent);
         group.MapPost("resources/content/{contentId:int}/unpublish", AquiferizationEndpoints.UnPublish)
-            .RequireAuthorization(PermissionName.Publish);        
+            .RequireAuthorization(PermissionName.PublishContent);
         group.MapPost("resources/content/{contentId:int}/assign-editor", AssignmentEndpoints.AssignEditor)
             .RequireAuthorization([PermissionName.AssignOverride, PermissionName.AssignContent]);
 

--- a/src/Aquifer.API/Modules/Admin/Assignment/AssignmentEndpoints.cs
+++ b/src/Aquifer.API/Modules/Admin/Assignment/AssignmentEndpoints.cs
@@ -42,7 +42,7 @@ public class AssignmentEndpoints
             return TypedResults.BadRequest("Assigned user not found");
         }
 
-        // get the requesting user from User table using the provider id from the claims principal 
+        // get the requesting user from User table using the provider id from the claims principal
         string providerId = claimsPrincipal.FindFirst(ClaimTypes.NameIdentifier)?.Value!;
         var user = await dbContext.Users.FirstOrDefaultAsync(u => u.ProviderId == providerId, cancellationToken) ??
                    throw new ArgumentNullException();
@@ -60,7 +60,7 @@ public class AssignmentEndpoints
         // check to see if claimsPrincipal user has override permissions
         bool claimsPrincipalHasAssignOverridePermission =
             claimsPrincipal.HasClaim(c =>
-                c.Type == PermissionName.Permissions && c.Value == PermissionName.AssignOverride);
+                c.Type == Constants.PermissionsClaim && c.Value == PermissionName.AssignOverride);
 
         // if the user has the assign override permission, then assign the resource to the given user
         if (claimsPrincipalHasAssignOverridePermission)

--- a/src/Aquifer.API/Modules/Resources/ResourceContentSummary/ResourceContentSummaryContracts.cs
+++ b/src/Aquifer.API/Modules/Resources/ResourceContentSummary/ResourceContentSummaryContracts.cs
@@ -63,7 +63,7 @@ public record ResourceContentSummaryPassageById
     public string EndBook => BookCodes.FullNameFromId(EndTranslatedVerse.BookId);
     public int EndChapter => EndTranslatedVerse.Chapter;
     public int EndVerse => EndTranslatedVerse.Verse;
-                        
+
 }
 
 public record ResourceContentSummaryAssignedUser
@@ -81,6 +81,5 @@ public record ResourceContentSummaryContentIdWithLanguageId
 public record ResourceContentSummaryItemUpdate
 {
     public List<object> Content { get; init; } = new();
-    public ResourceContentStatus Status { get; init; }
     public string DisplayName { get; init; } = null!;
 }

--- a/src/Aquifer.API/Modules/Resources/ResourcesModule.cs
+++ b/src/Aquifer.API/Modules/Resources/ResourcesModule.cs
@@ -27,7 +27,7 @@ public class ResourcesModule : IModule
             GetResourceContentSummaryEndpoints.GetByResourceContentId);
         adminGroup.MapPut("content/summary/{resourceContentId:int}",
                 UpdateResourcesSummaryEndpoints.UpdateResourceContentSummaryItem)
-            .RequireAuthorization(PermissionName.Write);
+            .RequireAuthorization(PermissionName.EditContent);
         adminGroup.MapGet("content/statuses", ResourceContentStatusEndpoints.GetList)
             .CacheOutput(x => x.Expire(TimeSpan.FromHours(1)));
         adminGroup.MapGet("list", ResourcesListEndpoints.Get);

--- a/src/Aquifer.API/Modules/Resources/ResourcesSummary/UpdateResourcesSummaryEndpoints.cs
+++ b/src/Aquifer.API/Modules/Resources/ResourcesSummary/UpdateResourcesSummaryEndpoints.cs
@@ -1,23 +1,23 @@
+using Aquifer.API.Common;
 using Aquifer.API.Utilities;
 using Aquifer.Data;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
 using System.Text;
 
 namespace Aquifer.API.Modules.Resources.ResourceContentSummary;
 
 public class UpdateResourcesSummaryEndpoints
 {
-    public static async Task<Results<NoContent, NotFound>> UpdateResourceContentSummaryItem(int resourceContentId,
+    public static async Task<Results<NoContent, BadRequest<string>, NotFound>> UpdateResourceContentSummaryItem(int resourceContentId,
         ResourceContentSummaryItemUpdate item,
         AquiferDbContext dbContext,
+        ClaimsPrincipal claimsPrincipal,
         CancellationToken cancellationToken)
     {
-        // When needed, inject ClaimsPrincipal claimsPrincipal to get the user information
-        // string userClaim = claimsPrincipal.Claims.Single(x => x.Type == "user").Value;
-
         var entity = await dbContext.ResourceContentVersions
-            .Where(x => x.IsPublished) // TODO: swap this with IsDraft once we can create drafts
+            .Where(x => x.IsDraft)
             .Where(x => x.ResourceContentId == resourceContentId)
             .Include(x => x.ResourceContent.Resource)
             .SingleOrDefaultAsync(cancellationToken);
@@ -26,9 +26,17 @@ public class UpdateResourcesSummaryEndpoints
             return TypedResults.NotFound();
         }
 
+        string providerId = claimsPrincipal.FindFirst(ClaimTypes.NameIdentifier)?.Value!;
+        var user = await dbContext.Users.FirstOrDefaultAsync(u => u.ProviderId == providerId, cancellationToken) ??
+            throw new ArgumentNullException();
+
+        if (user.Id != entity.AssignedUserId)
+        {
+            return TypedResults.BadRequest("Not allowed to edit this resource");
+        }
+
         entity.Content = JsonUtilities.DefaultSerialize(item.Content);
         entity.DisplayName = item.DisplayName;
-        entity.ResourceContent.Status = item.Status;
         entity.ContentSize = Encoding.UTF8.GetByteCount(entity.Content);
         entity.ResourceContent.Updated = DateTime.UtcNow;
         entity.Updated = DateTime.UtcNow;

--- a/src/Aquifer.API/Modules/Users/UsersModule.cs
+++ b/src/Aquifer.API/Modules/Users/UsersModule.cs
@@ -11,7 +11,7 @@ public class UsersModule : IModule
     public IEndpointRouteBuilder MapEndpoints(IEndpointRouteBuilder endpoints)
     {
         var adminGroup = endpoints.MapGroup("admin/users").WithTags("Users (Admin)");
-        adminGroup.MapGet("/", GetAllUsers).RequireAuthorization(PermissionName.Read);
+        adminGroup.MapGet("/", GetAllUsers).RequireAuthorization(PermissionName.ReadUsers);
         adminGroup.MapGet("/self", GetCurrentUser).RequireAuthorization();
 
         return endpoints;

--- a/src/Aquifer.API/Services/AuthService.cs
+++ b/src/Aquifer.API/Services/AuthService.cs
@@ -21,25 +21,12 @@ public static class AuthService
                     new TokenValidationParameters { NameClaimType = ClaimTypes.NameIdentifier };
             });
 
-        // this is an example of how a policy can be added, where the permissions
-        // are set in Auth0 for the given user
-        services.AddAuthorization(options => options.AddPolicy(PermissionName.Write,
-            p => p.RequireClaim("user").RequireClaim("permissions", "write:values")));
-
-        services.AddAuthorization(options => options.AddPolicy(PermissionName.Read,
-            p => p.RequireClaim("user").RequireClaim("permissions", "read:values")));
-
-        services.AddAuthorization(options => options.AddPolicy(PermissionName.Aquiferize,
-            p => p.RequireClaim("user").RequireClaim("permissions", "aquiferize:content")));
-
-        services.AddAuthorization(options => options.AddPolicy(PermissionName.Publish,
-            p => p.RequireClaim("user").RequireClaim("permissions", "publish:content")));
-
-        services.AddAuthorization(options => options.AddPolicy(PermissionName.AssignContent,
-            p => p.RequireClaim("user").RequireClaim("permissions", "assign:content")));
-
-        services.AddAuthorization(options => options.AddPolicy(PermissionName.AssignOverride,
-            p => p.RequireClaim("user").RequireClaim("permissions", "assign:override")));
+        foreach (var permissionName in Constants.AllPermissions)
+        {
+            services.AddAuthorization(options =>
+                    options.AddPolicy(permissionName,
+                        policy => policy.RequireClaim("user").RequireClaim("permissions", permissionName)));
+        }
 
         return services;
     }


### PR DESCRIPTION
Currently the published version of a resource gets updated when edits are made. We want to make sure we're only
editing the draft version. Also this adds permission checks to make sure the user is allowed to edit
content (i.e. they're assigned).

Also:
* Renames the `read:values` and `write:values` permissions to be more relevant to our app.
* Put permissions in a list so they can be automatically added to the auth context
* Stops allowing status to be updated when making content and display name updates
