### PR TITLE
update assigned user to null when publishing

### DIFF
--- a/src/Aquifer.API/Modules/Resources/ResourceContentSummary/GetResourceContentSummaryEndpoints.cs
+++ b/src/Aquifer.API/Modules/Resources/ResourceContentSummary/GetResourceContentSummaryEndpoints.cs
@@ -61,6 +61,7 @@ public static class GetResourceContentSummaryEndpoints
         var resourceContentVersion = await dbContext.ResourceContentVersions
             .Where(x => x.ResourceContentId == resourceContentId)
             .OrderBy(x => x.IsDraft ? 0 : x.IsPublished ? 1 : 2) // TODO: make request specific to draft vs published. for now, return the draft first if it exists
+            .OrderByDescending(x => x.Version)
             .Include(x => x.AssignedUser).FirstOrDefaultAsync(cancellationToken);
 
         if (resourceContentVersion is null)

--- a/src/Aquifer.API/Modules/Resources/ResourcesSummary/UpdateResourcesSummaryEndpoints.cs
+++ b/src/Aquifer.API/Modules/Resources/ResourcesSummary/UpdateResourcesSummaryEndpoints.cs
@@ -19,7 +19,6 @@ public class UpdateResourcesSummaryEndpoints
         var entity = await dbContext.ResourceContentVersions
             .Where(x => x.IsDraft)
             .Where(x => x.ResourceContentId == resourceContentId)
-            .Include(x => x.ResourceContent.Resource)
             .SingleOrDefaultAsync(cancellationToken);
         if (entity is null)
         {
@@ -38,7 +37,6 @@ public class UpdateResourcesSummaryEndpoints
         entity.Content = JsonUtilities.DefaultSerialize(item.Content);
         entity.DisplayName = item.DisplayName;
         entity.ContentSize = Encoding.UTF8.GetByteCount(entity.Content);
-        entity.ResourceContent.Updated = DateTime.UtcNow;
         entity.Updated = DateTime.UtcNow;
 
         await dbContext.SaveChangesAsync(cancellationToken);


### PR DESCRIPTION
This addresses some things with the publish and unpublish workflow. Making sure that the user history is kept up to date when publishing, showing the correct content when something is unpublished, and handling updating the resource content `Updated` column in a couple places.