### PR TITLE
Remove extra assign editor policy

### DIFF
--- a/src/Aquifer.API/Modules/AdminResources/AdminResourcesModule.cs
+++ b/src/Aquifer.API/Modules/AdminResources/AdminResourcesModule.cs
@@ -25,7 +25,7 @@ public class AdminResourcesModule : IModule
             .RequireAuthorization(PermissionName.PublishContent);
 
         group.MapPost("content/{contentId:int}/assign-editor", AssignmentEndpoints.AssignEditor)
-            .RequireAuthorization([PermissionName.AssignOverride, PermissionName.AssignContent]);
+            .RequireAuthorization(PermissionName.AssignContent);
 
         group.MapPost("content/{contentId:int}/send-review", ResourceReviewEndpoints.SendToReview)
             .RequireAuthorization(PermissionName.SendReviewContent);


### PR DESCRIPTION
There were two policies on assign-editor. These are an AND relationship, not an OR. Because the need for the override policy was already programmatic, just removing the extra policy should fix.