### PR TITLE
prevent non-assigned users from assigning in-review content

### DIFF
--- a/src/Aquifer.API/Modules/AdminResources/Assignment/AssignmentEndpoints.cs
+++ b/src/Aquifer.API/Modules/AdminResources/Assignment/AssignmentEndpoints.cs
@@ -43,6 +43,11 @@ public class AssignmentEndpoints
             return TypedResults.BadRequest("Unable to assign user");
         }
 
+        if (draftVersion.ResourceContent.Status == ResourceContentStatus.AquiferizeInReview && draftVersion.AssignedUserId != user.Id)
+        {
+            return TypedResults.BadRequest("Must be assigned the in-review content in order to assign to another user");
+        }
+
         draftVersion.AssignedUserId = postBody.AssignedUserId;
         draftVersion.Updated = DateTime.UtcNow;
 


### PR DESCRIPTION
Per our initial requirements, we should only be allowing currently assigned publishers to use the
Send Back button on in-review content. Right now anyone with assign or assign override permissions
is allowed to use the button.
