### PR TITLE
fixes for tracking resource requests

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -19,6 +19,6 @@ jobs:
               with:
                   dotnet-version: '8.x'
             - name: Build
-              run: dotnet build --no-incremental --configuration Release /p:WarningsAsErrors=true
+              run: dotnet build --no-incremental --configuration Release /p:WarningsAsErrors=true /warnaserror
             - name: Test
               run: dotnet test

--- a/src/Aquifer.API/Middleware/TrackResourceContentRequestMiddleware.cs
+++ b/src/Aquifer.API/Middleware/TrackResourceContentRequestMiddleware.cs
@@ -14,17 +14,20 @@ public class TrackResourceContentRequestMiddleware(RequestDelegate _next, ITrack
 
         try
         {
-            var path = context.Request.Path.Value ?? "";
+            if (context.Response.StatusCode == 200)
+            {
+                var path = context.Request.Path.Value ?? "";
 
-            if (ResourcePathRegex.IsMatch(path))
-            {
-                var resourceId = int.Parse(ResourcePathRegex.Match(path).Groups[1].Value);
-                await _trackerService.TrackResourceContentRequest([resourceId], context.Request.HttpContext);
-            }
-            else if (BatchResourcesPathRegex.IsMatch(path))
-            {
-                var ids = context.Request.Query["ids[]"].Where(s => !string.IsNullOrEmpty(s)).Select(int.Parse!).ToList();
-                await _trackerService.TrackResourceContentRequest(ids, context.Request.HttpContext);
+                if (ResourcePathRegex.IsMatch(path))
+                {
+                    var resourceId = int.Parse(ResourcePathRegex.Match(path).Groups[1].Value);
+                    await _trackerService.TrackResourceContentRequest([resourceId], context.Request.HttpContext);
+                }
+                else if (BatchResourcesPathRegex.IsMatch(path))
+                {
+                    var ids = context.Request.Query["ids[]"].Where(s => !string.IsNullOrEmpty(s)).Select(int.Parse!).ToList();
+                    await _trackerService.TrackResourceContentRequest(ids, context.Request.HttpContext);
+                }
             }
         }
         catch (Exception ex)

--- a/src/Aquifer.Jobs/TrackResourceContentRequestJob.cs
+++ b/src/Aquifer.Jobs/TrackResourceContentRequestJob.cs
@@ -20,7 +20,7 @@ public class TrackResourceContentRequestJob(ILogger<TrackResourceContentRequestJ
             var trackingMetadata = JsonSerializer.Deserialize<TrackResourceContentRequestMessage>(message.MessageText);
             if (trackingMetadata == null)
             {
-                _logger.LogError($"Failed to deserialize the message: {message.MessageText}");
+                _logger.LogError("Failed to deserialize the message: {MessageText}", message.MessageText);
                 return;
             }
 
@@ -37,8 +37,8 @@ public class TrackResourceContentRequestJob(ILogger<TrackResourceContentRequestJ
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, $"An error occurred while processing the message: {message.MessageText}");
-            throw ex;
+            _logger.LogError(ex, "An error occurred while processing the message: {MessageText}", message.MessageText);
+            throw;
         }
     }
 }

--- a/src/Aquifer.Public.API/Middleware/TrackResourceContentRequestMiddleware.cs
+++ b/src/Aquifer.Public.API/Middleware/TrackResourceContentRequestMiddleware.cs
@@ -3,7 +3,8 @@ using Aquifer.Public.API.Services;
 
 namespace Aquifer.Public.API.Middleware;
 
-public class TrackResourceContentRequestMiddleware(RequestDelegate _next, ITrackResourceContentRequestService _trackerService, ILogger<TrackResourceContentRequestMiddleware> _logger)
+public class TrackResourceContentRequestMiddleware(RequestDelegate _next, ITrackResourceContentRequestService _trackerService,
+    ILogger<TrackResourceContentRequestMiddleware> _logger)
 {
     private static readonly Regex ResourcePathRegex = new("^/resources/(\\d+)$");
 
@@ -13,12 +14,15 @@ public class TrackResourceContentRequestMiddleware(RequestDelegate _next, ITrack
 
         try
         {
-            var path = context.Request.Path.Value ?? "";
-
-            if (ResourcePathRegex.IsMatch(path))
+            if (context.Response.StatusCode == 200)
             {
-                var resourceId = int.Parse(ResourcePathRegex.Match(path).Groups[1].Value);
-                await _trackerService.TrackResourceContentRequest([resourceId], context.Request.HttpContext);
+                var path = context.Request.Path.Value ?? "";
+
+                if (ResourcePathRegex.IsMatch(path))
+                {
+                    var resourceId = int.Parse(ResourcePathRegex.Match(path).Groups[1].Value);
+                    await _trackerService.TrackResourceContentRequest([resourceId], context.Request.HttpContext);
+                }
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
Only log requests if they're successful (so we don't get 404s) and also grab the forwarded for header.