### PR TITLE
Updated Actions Listed On Warnins in deployments

### DIFF
--- a/.github/actions/deploy-to-env/action.yml
+++ b/.github/actions/deploy-to-env/action.yml
@@ -27,12 +27,12 @@ inputs:
 runs:
     using: composite
     steps:
-        - uses: actions/download-artifact@v3
+        - uses: actions/download-artifact@v4
           with:
               name: build
               path: build
         - name: Login to Azure
-          uses: azure/login@v1
+          uses: azure/login@v2
           with:
               client-id: ${{ inputs.azure-client-id }}
               tenant-id: ${{ inputs.azure-tenant-id }}
@@ -45,7 +45,7 @@ runs:
           shell: bash
         - name: Deploy to staging slot if not dev
           if: inputs.environment != 'dev'
-          uses: azure/webapps-deploy@v2
+          uses: azure/webapps-deploy@v3
           with:
               app-name: ${{ inputs.web-app-name }}
               slot-name: staging
@@ -56,7 +56,7 @@ runs:
           shell: bash
         - name: Deploy directly to production if dev
           if: inputs.environment == 'dev'
-          uses: azure/webapps-deploy@v2
+          uses: azure/webapps-deploy@v3
           with:
               app-name: ${{ inputs.web-app-name }}
               package: ./build/Build.zip

--- a/.github/workflows/post-merge-internal-api.yml
+++ b/.github/workflows/post-merge-internal-api.yml
@@ -25,9 +25,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Setup .NET
-              uses: actions/setup-dotnet@v3
+              uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: '8.x'
             - name: Install NuGet packages (linux)
@@ -43,7 +43,7 @@ jobs:
             - name: Bundle migrations
               run: dotnet ef migrations bundle --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --output build/Migrate --self-contained
             - name: Publish artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: build
                   path: build
@@ -58,7 +58,7 @@ jobs:
             url: ${{ vars.URL_DEV }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - uses: ./.github/actions/deploy-to-env
               id: deploy
               with:
@@ -80,7 +80,7 @@ jobs:
             url: ${{ vars.URL_QA }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - uses: ./.github/actions/deploy-to-env
               id: deploy
               with:
@@ -102,7 +102,7 @@ jobs:
             url: ${{ vars.URL_PROD }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
             - uses: ./.github/actions/deploy-to-env
@@ -122,7 +122,7 @@ jobs:
         needs: deploy_internal_api_to_dev
         steps:
             - name: Checkout E2E test code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: BiblioNexusStudio/well-e2e
                   ssh-key: ${{ secrets.WELL_E2E_DEPLOY_KEY }}

--- a/.github/workflows/post-merge-jobs.yml
+++ b/.github/workflows/post-merge-jobs.yml
@@ -25,9 +25,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Setup .NET
-              uses: actions/setup-dotnet@v3
+              uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: '8.x'
             - name: Make build directory
@@ -38,7 +38,7 @@ jobs:
                 dotnet build --configuration Release --output ../../build --runtime win-x64
                 cd ../..
             - name: Publish artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: build
                   path: build
@@ -51,7 +51,7 @@ jobs:
         environment:
             name: dev-qa-jobs
         steps:
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: build
                   path: build
@@ -70,7 +70,7 @@ jobs:
         environment:
             name: prod-jobs
         steps:
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: build
                   path: build

--- a/.github/workflows/post-merge-public-api.yml
+++ b/.github/workflows/post-merge-public-api.yml
@@ -25,9 +25,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Setup .NET
-              uses: actions/setup-dotnet@v3
+              uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: '8.x'
             - name: Install NuGet packages (linux)
@@ -43,7 +43,7 @@ jobs:
             - name: Bundle migrations
               run: dotnet ef migrations bundle --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --output build/Migrate --self-contained
             - name: Publish artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: build
                   path: build
@@ -58,7 +58,7 @@ jobs:
             url: ${{ vars.URL_DEV }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - uses: ./.github/actions/deploy-to-env
               id: deploy
               with:
@@ -80,7 +80,7 @@ jobs:
             url: ${{ vars.URL_QA }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - uses: ./.github/actions/deploy-to-env
               id: deploy
               with:
@@ -102,7 +102,7 @@ jobs:
             url: ${{ vars.URL_PROD }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
             - uses: ./.github/actions/deploy-to-env

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -11,11 +11,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
             - name: Setup .NET
-              uses: actions/setup-dotnet@v3
+              uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: '8.x'
             - name: Build


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-dotnet@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

and 

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/download-artifact@v3, azure/login@v1, azure/webapps-deploy@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
