### PR TITLE
allow same user to be assigned as editor to a resource

### DIFF
--- a/src/Aquifer.API/Endpoints/Resources/Content/AssignEditor/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/AssignEditor/Endpoint.cs
@@ -52,7 +52,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
             var allowedToAssign = (hasAssignOverridePermission && (assignedUserIsInCompany || hasAssignOutsideCompanyPermission)) ||
                                   currentUserIsAssigned;
 
-            if (!allowedToAssign || draftVersion.AssignedUserId == request.AssignedUserId)
+            if (!allowedToAssign)
             {
                 ThrowError($"Unable to assign user for id {draftVersion.ResourceContentId}");
             }
@@ -67,7 +67,10 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
                     $"Must be assigned the in-review content in order to assign to another user for id {draftVersion.ResourceContentId}");
             }
 
-            await historyService.AddAssignedUserHistoryAsync(draftVersion, request.AssignedUserId, user.Id, ct);
+            if (draftVersion.AssignedUserId != request.AssignedUserId)
+            {
+                await historyService.AddAssignedUserHistoryAsync(draftVersion, request.AssignedUserId, user.Id, ct);
+            }
 
             draftVersion.AssignedUserId = request.AssignedUserId;
             draftVersion.Updated = DateTime.UtcNow;


### PR DESCRIPTION
There's no reason to have the check in place, and it was causing issues with the bulk assignment functionality.