### PR TITLE
Create projects with same word count as listing

### DIFF
--- a/src/Aquifer.API/Endpoints/Projects/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Projects/Create/Endpoint.cs
@@ -71,7 +71,9 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService)
         var resourceContents = await CreateOrFindResourceContentFromResourceIds(language, request, user, ct);
 
         var wordCount = await dbContext.ResourceContentVersions
-            .Where(rcv => request.ResourceIds.Contains(rcv.ResourceContent.ResourceId) && rcv.IsPublished)
+            .Where(rcv => request.ResourceIds.Contains(rcv.ResourceContent.ResourceId) &&
+                rcv.IsPublished &&
+                rcv.ResourceContent.LanguageId == 1)
             .Select(rcv => rcv.WordCount ?? 0)
             .SumAsync(ct);
 


### PR DESCRIPTION
When listing the word count to create a project, it takes the counts of the English published. When it's actually created, if a draft already exists, it will use that word count instead. This technically isn't right, since even if it was previously translated and pre-loaded into the system, the source word count should still be the English published.

I also realize that I'm making an extra call to the DB that isn't strictly necessarily, but it makes this change much smaller and this endpoint isn't called often.