### PR TITLE
Sort related content on resources page

### DIFF
--- a/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
@@ -68,6 +68,8 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
             return;
         }
 
+        resourceContent.AssociatedResources = resourceContent.AssociatedResources.OrderBy(x => x.EnglishLabel);
+
         resourceContent.VerseReferences = await dbContext.VerseResources
             .Where(x => x.ResourceId == resourceContent.ResourceId)
             .Select(vr => new VerseReferenceResponse { VerseId = vr.VerseId }).ToListAsync(ct);


### PR DESCRIPTION
EF wasn't happy with me trying to sort it deep in the selects, so just did it after pulling the data.

![image](https://github.com/BiblioNexusStudio/aquifer-server/assets/138067194/c796904a-19e3-4909-9c49-01e4ffc73a64)
