### PR TITLE
Revert "switch to ParentResourceId instead of ShortName for identifying parent resources (#287)"

### DIFF
--- a/src/Aquifer.API/Common/Constants.cs
+++ b/src/Aquifer.API/Common/Constants.cs
@@ -8,9 +8,8 @@ public static class Constants
     public const string PermissionsClaim = "permissions";
     public const string RolesClaim = "bnRoles";
 
-    // Some guide types have predetermined passages (rather than freeform "select any Bible section").
-    // ID 1 = FIA (formerly known as CBBT-ER)
-    public static readonly ReadOnlyCollection<int> PredeterminedPassageGuideIds = new([1]);
+    // this represents the resource types that we allow to be accessed as the starting point when viewing content
+    public static readonly ReadOnlyCollection<string> RootParentResourceNames = new(["CBBTER"]);
 
     // this represents the media types that we default to English for
     public static readonly ReadOnlyCollection<ResourceContentMediaType> FallbackToEnglishForMediaTypes =

--- a/src/Aquifer.API/Endpoints/Resources/Content/AvailableChapters/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/AvailableChapters/List/Endpoint.cs
@@ -19,7 +19,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IEnumerabl
             INNER JOIN ParentResources pr ON pr.Id = r.ParentResourceId
             INNER JOIN VerseResources vr ON vr.ResourceId = r.Id
         WHERE
-            rc.LanguageId = @LanguageId AND pr.Id = @ParentResourceId
+            rc.LanguageId = @LanguageId AND pr.ShortName = @ParentResourceName
 
         UNION
 
@@ -34,7 +34,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IEnumerabl
             INNER JOIN Passages p ON p.Id = pasr.PassageId
             INNER JOIN Verses v ON v.Id BETWEEN p.StartVerseId AND p.EndVerseId
         WHERE
-            rc.LanguageId = @LanguageId AND parr.Id = @ParentResourceId
+            rc.LanguageId = @LanguageId AND parr.ShortName = @ParentResourceName
 
         ORDER BY
             Book, Chapter
@@ -51,7 +51,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IEnumerabl
         var rows = await dbContext.Database
             .SqlQueryRaw<BookAndChapterRow>(Query,
                 new SqlParameter("LanguageId", request.LanguageId),
-                new SqlParameter("ParentResourceId", request.ParentResourceId))
+                new SqlParameter("ParentResourceName", request.ParentResourceName))
             .ToListAsync(ct);
 
         var response = rows.GroupBy(row => row.Book).Select(row => new Response

--- a/src/Aquifer.API/Endpoints/Resources/Content/AvailableChapters/List/Request.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/AvailableChapters/List/Request.cs
@@ -3,5 +3,5 @@ namespace Aquifer.API.Endpoints.Resources.Content.AvailableChapters.List;
 public record Request
 {
     public int LanguageId { get; set; }
-    public int ParentResourceId { get; set; }
+    public string ParentResourceName { get; set; } = null!;
 }

--- a/src/Aquifer.API/Endpoints/Resources/Content/AvailableChapters/List/Validator.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/AvailableChapters/List/Validator.cs
@@ -8,6 +8,6 @@ public class Validator : Validator<Request>
     public Validator()
     {
         RuleFor(x => x.LanguageId).NotEmpty();
-        RuleFor(x => x.ParentResourceId).NotEmpty();
+        RuleFor(x => x.ParentResourceName).NotEmpty();
     }
 }

--- a/src/Aquifer.API/Endpoints/Resources/Content/GroupedByVerse/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/GroupedByVerse/List/Endpoint.cs
@@ -18,7 +18,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
         var (startVerseId, endVerseId) =
-            BibleUtilities.VerseRangeForBookAndChapters(request.BookCode, request.Chapter, request.Chapter)!.Value;
+                    BibleUtilities.VerseRangeForBookAndChapters(request.BookCode, request.Chapter, request.Chapter)!.Value;
 
         var fallbackMediaTypesSqlArray = string.Join(',', Constants.FallbackToEnglishForMediaTypes.Select(t => (int)t));
 
@@ -28,7 +28,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
                 vr.VerseId,
                 COALESCE(rc.MediaType, rce.MediaType) AS MediaType,
                 pr.ResourceType,
-                pr.Id AS ParentResourceId
+                pr.ShortName
             FROM
                 VerseResources vr
                 INNER JOIN Resources r ON vr.ResourceId = r.Id
@@ -47,7 +47,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
                 v.Id AS VerseId,
                 COALESCE(rc.MediaType, rce.MediaType) AS MediaType,
                 parr.ResourceType,
-                parr.Id AS ParentResourceId
+                parr.ShortName
             FROM
                 Resources r
                 INNER JOIN ParentResources parr ON parr.Id = r.ParentResourceId
@@ -80,7 +80,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
                     {
                         Id = row.Id,
                         MediaType = row.MediaType.ToString(),
-                        ParentResourceId = row.ParentResourceId,
+                        ParentResource = row.ShortName,
                         ResourceType = row.ResourceType.ToString()
                     })
                         .DistinctBy(row => row.Id)
@@ -98,5 +98,5 @@ public record ResourceContentRow
     public required int VerseId { get; set; }
     public required ResourceContentMediaType MediaType { get; set; }
     public required ResourceType ResourceType { get; set; }
-    public required int ParentResourceId { get; set; }
+    public required string ShortName { get; set; }
 }

--- a/src/Aquifer.API/Endpoints/Resources/Content/GroupedByVerse/List/Response.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/GroupedByVerse/List/Response.cs
@@ -15,6 +15,6 @@ public record ResourceContentResponse
 {
     public required int Id { get; set; }
     public required string MediaType { get; set; }
-    public required int ParentResourceId { get; set; }
+    public required string ParentResource { get; set; }
     public required string ResourceType { get; set; }
 }

--- a/src/Aquifer.API/Modules/Passages/PassagesModule.cs
+++ b/src/Aquifer.API/Modules/Passages/PassagesModule.cs
@@ -12,23 +12,25 @@ public class PassagesModule : IModule
     public IEndpointRouteBuilder MapEndpoints(IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup("passages").WithTags("Passages");
-        group.MapGet("language/{languageId:int}/resource/{parentResourceId:int}", GetPassagesByLanguageAndResource);
+        group.MapGet("language/{languageId:int}/resource/{parentResourceName}", GetPassagesByLanguageAndResource);
         group.MapGet("{passageId:int}/language/{languageId:int}", GetPassageDetailsForLanguage);
         return endpoints;
     }
 
     private async Task<Results<Ok<List<PassagesByBookResponse>>, NotFound>> GetPassagesByLanguageAndResource(
         int languageId,
-        int parentResourceId,
+        string parentResourceName,
         AquiferDbContext dbContext,
         CancellationToken cancellationToken)
     {
-        if (!Constants.PredeterminedPassageGuideIds.Contains(parentResourceId))
+        if (!Constants.RootParentResourceNames.Contains(parentResourceName))
         {
             return TypedResults.NotFound();
         }
 
-        var parentResource = await dbContext.ParentResources.SingleOrDefaultAsync(pr => pr.Id == parentResourceId, cancellationToken);
+        var parentResource =
+            await dbContext.ParentResources.SingleOrDefaultAsync(rt => rt.ShortName == parentResourceName,
+                cancellationToken);
 
         var passagesByBook = (await dbContext.Passages
                 .Where(p => p.PassageResources.Any(pr =>
@@ -74,19 +76,19 @@ public class PassagesModule : IModule
         }
 
         var englishLanguageId = (await dbContext.Languages.Where(language => language.ISO6393Code.ToLower() == "eng")
-                                    .FirstOrDefaultAsync(cancellationToken))?.Id ??
-                                -1;
+                .FirstOrDefaultAsync(cancellationToken))?.Id ??
+            -1;
 
         var passageResourceContent = await dbContext.PassageResources
             // find all passages that overlap with the current passage
             .Where(pr => (pr.Passage.StartVerseId >= passage.StartVerseId &&
-                          pr.Passage.StartVerseId <= passage.EndVerseId) ||
-                         (pr.Passage.EndVerseId >= passage.StartVerseId &&
-                          pr.Passage.EndVerseId <= passage.EndVerseId))
+                    pr.Passage.StartVerseId <= passage.EndVerseId) ||
+                (pr.Passage.EndVerseId >= passage.StartVerseId &&
+                    pr.Passage.EndVerseId <= passage.EndVerseId))
             .SelectMany(pr => pr.Resource.ResourceContents
                 .Where(rc => rc.LanguageId == languageId ||
-                             (rc.LanguageId == englishLanguageId &&
-                              Constants.FallbackToEnglishForMediaTypes.Contains(rc.MediaType)))
+                    (rc.LanguageId == englishLanguageId &&
+                        Constants.FallbackToEnglishForMediaTypes.Contains(rc.MediaType)))
                 .SelectMany(rc => rc.Versions.Where(rcv => rcv.IsPublished)
                     .Select(rcv =>
                         new
@@ -96,6 +98,7 @@ public class PassagesModule : IModule
                             MediaTypeName = rc.MediaType,
                             rc.LanguageId,
                             pr.ResourceId,
+                            ParentResourceName = pr.Resource.ParentResource.ShortName,
                             ParentResourceId = pr.Resource.ParentResource.Id
                         })))
             .ToListAsync(cancellationToken);
@@ -105,8 +108,8 @@ public class PassagesModule : IModule
             .Where(vr => vr.VerseId >= passage.StartVerseId && vr.VerseId <= passage.EndVerseId)
             .SelectMany(vr => vr.Resource.ResourceContents
                 .Where(rc => rc.LanguageId == languageId ||
-                             (rc.LanguageId == englishLanguageId &&
-                              Constants.FallbackToEnglishForMediaTypes.Contains(rc.MediaType)))
+                    (rc.LanguageId == englishLanguageId &&
+                        Constants.FallbackToEnglishForMediaTypes.Contains(rc.MediaType)))
                 .SelectMany(rc => rc.Versions.Where(rcv => rcv.IsPublished)
                     .Select(rcv =>
                         new
@@ -116,6 +119,7 @@ public class PassagesModule : IModule
                             MediaTypeName = rc.MediaType,
                             rc.LanguageId,
                             vr.ResourceId,
+                            ParentResourceName = vr.Resource.ParentResource.ShortName,
                             ParentResourceId = vr.Resource.ParentResource.Id
                         })))
             .ToListAsync(cancellationToken);
@@ -124,8 +128,8 @@ public class PassagesModule : IModule
             .SelectMany(pr => pr.Resource.AssociatedResourceChildren
                 .SelectMany(sr => sr.ResourceContents
                     .Where(rc => rc.LanguageId == languageId ||
-                                 (rc.LanguageId == englishLanguageId &&
-                                  Constants.FallbackToEnglishForMediaTypes.Contains(rc.MediaType)))
+                        (rc.LanguageId == englishLanguageId &&
+                            Constants.FallbackToEnglishForMediaTypes.Contains(rc.MediaType)))
                     .SelectMany(rc => rc.Versions.Where(rcv => rcv.IsPublished)
                         .Select(rcv =>
                             new
@@ -135,6 +139,7 @@ public class PassagesModule : IModule
                                 MediaTypeName = rc.MediaType,
                                 rc.LanguageId,
                                 ResourceId = sr.Id,
+                                ParentResourceName = sr.ParentResource.ShortName,
                                 ParentResourceId = sr.ParentResource.Id
                             }))))
             .ToListAsync(cancellationToken);
@@ -143,7 +148,11 @@ public class PassagesModule : IModule
         // This filters them by grouping appropriately and selecting the current language resource (if available) then falling back to English.
         var filteredDownToOneLanguage = passageResourceContent.Concat(verseResourceContent)
             .Concat(associatedResourceContent)
-            .GroupBy(rc => new { rc.MediaTypeName, rc.ResourceId })
+            .GroupBy(rc => new
+            {
+                rc.MediaTypeName,
+                rc.ResourceId
+            })
             .Select(grc =>
             {
                 var first = grc.OrderBy(rc => rc.LanguageId == languageId ? 0 : 1).First();
@@ -152,6 +161,7 @@ public class PassagesModule : IModule
                     ContentId = first.ContentId,
                     ContentSize = first.ContentSize,
                     MediaTypeName = first.MediaTypeName,
+                    ParentResourceName = first.ParentResourceName,
                     ParentResourceId = first.ParentResourceId
                 };
             });

--- a/src/Aquifer.API/Modules/Resources/ResourceContracts.cs
+++ b/src/Aquifer.API/Modules/Resources/ResourceContracts.cs
@@ -16,6 +16,7 @@ public class ResourceItemsWithChapterNumberResponse
 public class ResourceItemResponse
 {
     public int ContentId { get; set; }
+    public string ParentResourceName { get; set; } = null!;
     public int ParentResourceId { get; set; }
     public ResourceContentMediaType MediaTypeName { get; set; }
     public int ContentSize { get; set; }


### PR DESCRIPTION
This is needed in order to get a deployment out for content-manager. Without reverting this we have a breaking Well change and we're waiting on a Well deployment.

This reverts commit 682a3ad2ba9a2c82796b005b3154933f3f2ec610.