### PR TITLE
fix project item list for newly created projects

### DIFF
--- a/src/Aquifer.API/Endpoints/Projects/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Projects/Get/Endpoint.cs
@@ -84,16 +84,16 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
                              INNER JOIN ParentResources PR ON PR.Id = R.ParentResourceId
                              CROSS APPLY (
                                  SELECT TOP 1
-                                     SNAP.WordCount,
+                                     COALESCE(RCVS.WordCount, RCV.WordCount) AS WordCount,
                                      CASE
                                          WHEN RCV.AssignedUserId IS NULL THEN NULL
                                          ELSE U.FirstName + ' ' + U.LastName
                                      END AS AssignedUserName
-                                 FROM ResourceContentVersionSnapshots SNAP
-                                 INNER JOIN ResourceContentVersions RCV ON RCV.ResourceContentId = RC.Id
+                                 FROM ResourceContentVersions RCV
+                                 LEFT JOIN ResourceContentVersionSnapshots RCVS ON RCVS.ResourceContentVersionId = RCV.Id
                                  LEFT JOIN Users U ON U.Id = RCV.AssignedUserId
-                                 WHERE ResourceContentVersionId = RCV.Id
-                                 ORDER BY SNAP.Created ASC
+                                 WHERE RCV.ResourceContentId = RC.Id
+                                 ORDER BY RCVS.Created ASC, RCV.Version DESC
                              ) Snapshots
                              WHERE RC.Id IN (
                                  SELECT ResourceContentId


### PR DESCRIPTION
The problem was that we were relying on the ResourceContentVersionSnapshots table always having a snapshot for a resource, but this is a wrong assumption for newly created projects. By making the snapshot a left join and then falling back to the ResourceContentVersion for word count if there's no snapshot, we can ensure all items get displayed.