### PR TITLE
make all ResponseCaches vary by wildcard query key

### DIFF
--- a/src/Aquifer.API/Endpoints/Bibles/Texts/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Bibles/Texts/Get/Endpoint.cs
@@ -10,7 +10,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
     public override void Configure()
     {
         Get("/bibles/{BibleId}/texts");
-        ResponseCache(EndpointHelpers.OneDayInSeconds, varyByQueryKeys: ["*"]);
+        ResponseCache(EndpointHelpers.OneDayInSeconds);
         AllowAnonymous();
     }
 

--- a/src/Aquifer.API/Endpoints/Marketing/ParentResourceStatuses/BibleBooks/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Marketing/ParentResourceStatuses/BibleBooks/Get/Endpoint.cs
@@ -15,7 +15,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, List<Respo
     {
         Get("/marketing/parent-resource-statuses/bible-books");
         Options(EndpointHelpers.ServerCacheInSeconds(EndpointHelpers.OneHourInSeconds));
-        ResponseCache(EndpointHelpers.OneHourInSeconds, varyByQueryKeys: [nameof(Request.LanguageId), nameof(Request.ParentResourceId)]);
+        ResponseCache(EndpointHelpers.OneHourInSeconds);
         AllowAnonymous();
     }
 
@@ -114,11 +114,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, List<Respo
     {
         return BibleBookCodeUtilities.GetAll()
             .Where(x => x.BookId <= BookId.BookREV)
-            .Select(x => new BookRow
-            {
-                BookName = x.BookFullName,
-                BibleBookId = ((int)x.BookId).ToString("D3")
-            })
+            .Select(x => new BookRow { BookName = x.BookFullName, BibleBookId = ((int)x.BookId).ToString("D3") })
             .ToList();
     }
 }

--- a/src/Aquifer.API/Endpoints/Marketing/ParentResourceStatuses/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Marketing/ParentResourceStatuses/List/Endpoint.cs
@@ -16,7 +16,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IEnumerabl
     {
         Get("/marketing/parent-resource-statuses");
         Options(EndpointHelpers.ServerCacheInSeconds(EndpointHelpers.OneHourInSeconds));
-        ResponseCache(EndpointHelpers.OneHourInSeconds, varyByQueryKeys: ["languageId"]);
+        ResponseCache(EndpointHelpers.OneHourInSeconds);
         AllowAnonymous();
     }
 

--- a/src/Aquifer.API/Endpoints/Resources/ParentResources/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/ParentResources/List/Endpoint.cs
@@ -13,7 +13,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, List<Respo
     {
         Get("/resources/parent-resources");
         AllowAnonymous();
-        ResponseCache(EndpointHelpers.TenMinutesInSeconds, varyByQueryKeys: ["*"]);
+        ResponseCache(EndpointHelpers.TenMinutesInSeconds);
         Options(EndpointHelpers.ServerCacheInSeconds(EndpointHelpers.TenMinutesInSeconds));
     }
 

--- a/src/Aquifer.API/Program.cs
+++ b/src/Aquifer.API/Program.cs
@@ -6,6 +6,7 @@ using Aquifer.API.Modules;
 using Aquifer.API.Services;
 using Aquifer.API.Telemetry;
 using Aquifer.Common.Services;
+using Aquifer.Common.Middleware;
 using Aquifer.Data;
 using FastEndpoints;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -67,6 +68,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseResponseCaching().UseFastEndpoints(config => config.Serializer.Options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase);
+
+app.UseResponseCachingVaryByAllQueryKeys();
 
 app.MapEndpoints();
 app.Run();

--- a/src/Aquifer.Common/Middleware/ResponseCachingVaryByAllQueryKeys.cs
+++ b/src/Aquifer.Common/Middleware/ResponseCachingVaryByAllQueryKeys.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.ResponseCaching;
+
+namespace Aquifer.Common.Middleware;
+
+public static class ResponseCachingVaryByAllQueryKeysExtensions
+{
+    public static IApplicationBuilder UseResponseCachingVaryByAllQueryKeys(this IApplicationBuilder app)
+    {
+        return app.UseMiddleware<ResponseCachingVaryByAllQueryKeysMiddleware>();
+    }
+}
+
+public class ResponseCachingVaryByAllQueryKeysMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public ResponseCachingVaryByAllQueryKeysMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        context.Features.Set<IResponseCachingFeature>(new ResponseCachingFeature
+        {
+            VaryByQueryKeys = ["*"]
+        });
+
+        await _next(context);
+    }
+}

--- a/src/Aquifer.Public.API/Program.cs
+++ b/src/Aquifer.Public.API/Program.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Aquifer.Common.Middleware;
 using Aquifer.Common.Services;
 using Aquifer.Data;
 using Aquifer.Public.API.Configuration;
@@ -34,5 +35,7 @@ app.UseHealthChecks("/_health")
     })
     .UseOpenApi()
     .UseReDoc(options => options.Path = "/docs");
+
+app.UseResponseCachingVaryByAllQueryKeys();
 
 app.Run();


### PR DESCRIPTION
There's really no cases where we want different query keys to return the same response for our ResponseCaches. Switching them all to wildcard will make things more future proof.