### PR TITLE
make TotalVerses more accurate

### DIFF
--- a/src/Aquifer.API/Endpoints/Bibles/Book/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Bibles/Book/List/Endpoint.cs
@@ -26,7 +26,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, List<Respo
             Chapters = x.Chapters.OrderBy(c => c.Number).Select(c => new ResponseChapter
             {
                 Number = c.Number,
-                TotalVerses = c.Verses.Count
+                TotalVerses = c.Verses.Max(v => v.Number)
             })
         }).ToListAsync(ct);
 


### PR DESCRIPTION
Total verses was looking at the verse count, which will be inaccurate on more dynamic translations
where verses are combined. Instead we should look at the max verse number to know what the total
verses is for that translation+book+chapter.
