### PR TITLE
fix line ending settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,7 +28,6 @@ tab_width = 4
 max_line_length = 140
 
 # New line preferences
-end_of_line = crlf
 insert_final_newline = false
 
 #### .NET Coding Conventions ####

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
-* text eol=crlf
+* text=auto
+*.cs diff=csharp
+*.sh eol=lf
+*.sln eol=crlf


### PR DESCRIPTION
Turns out we weren't using the suggested settings for line endings. This updates our .gitattributes and .editorconfig to the same settings that the EFCore repo uses.

Doesn't change what's in the repo but the advantage is non-Windows diffing tools won't detect false positive changes from line endings.