### PR TITLE
pin GitHub Action versions

### DIFF
--- a/.github/actions/deploy-to-env/action.yml
+++ b/.github/actions/deploy-to-env/action.yml
@@ -57,12 +57,12 @@ runs:
               SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
               GITHUB_TOKEN: ${{ inputs.github-token }}
               LINEAR_API_KEY: ${{ inputs.linear-api-key }}
-        - uses: actions/download-artifact@v4
+        - uses: actions/download-artifact@v4.1.8
           with:
               name: build
               path: build
         - name: Login to Azure
-          uses: azure/login@v1
+          uses: azure/login@v2.1.1
           with:
               client-id: ${{ inputs.azure-client-id }}
               tenant-id: ${{ inputs.azure-tenant-id }}
@@ -75,7 +75,7 @@ runs:
           shell: bash
         - name: Deploy to staging slot if not dev
           if: inputs.environment != 'dev'
-          uses: azure/webapps-deploy@v3
+          uses: azure/webapps-deploy@v3.0.1
           with:
               app-name: ${{ inputs.web-app-name }}
               slot-name: staging
@@ -86,7 +86,7 @@ runs:
           shell: bash
         - name: Deploy directly to production if dev
           if: inputs.environment == 'dev'
-          uses: azure/webapps-deploy@v3
+          uses: azure/webapps-deploy@v3.0.1
           with:
               app-name: ${{ inputs.web-app-name }}
               package: ./build/Build.zip

--- a/.github/workflows/post-merge-internal-api.yml
+++ b/.github/workflows/post-merge-internal-api.yml
@@ -38,9 +38,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v4.0.1
               with:
                   dotnet-version: '8.x'
             - name: Install NuGet packages (linux)
@@ -56,7 +56,7 @@ jobs:
             - name: Bundle migrations
               run: dotnet ef migrations bundle --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --output build/Migrate --self-contained
             - name: Publish artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v4.4.0
               with:
                   include-hidden-files: true
                   name: build
@@ -72,7 +72,7 @@ jobs:
             url: ${{ vars.URL_DEV }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
             - uses: ./.github/actions/deploy-to-env
               id: deploy
               with:
@@ -94,7 +94,7 @@ jobs:
             url: ${{ vars.URL_QA }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
             - uses: ./.github/actions/deploy-to-env
               id: deploy
               with:
@@ -121,7 +121,7 @@ jobs:
             url: ${{ vars.URL_PROD }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
             - uses: ./.github/actions/deploy-to-env

--- a/.github/workflows/post-merge-jobs.yml
+++ b/.github/workflows/post-merge-jobs.yml
@@ -20,9 +20,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v4.0.1
               with:
                   dotnet-version: '8.x'
             - name: Make build directory
@@ -33,7 +33,7 @@ jobs:
                 dotnet build --configuration Release --output ../../build --runtime win-x64
                 cd ../..
             - name: Publish artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v4.4.0
               with:
                   include-hidden-files: true
                   name: build
@@ -47,12 +47,12 @@ jobs:
         environment:
             name: dev-qa-jobs
         steps:
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v4.1.8
               with:
                   name: build
                   path: build
             - name: Deploy Jobs to dev/qa
-              uses: Azure/functions-action@v1
+              uses: Azure/functions-action@v1.5.2
               with:
                   app-name: ${{ vars.AZURE_FUNCTION_APP_NAME_DEV_QA }}
                   package: build
@@ -66,12 +66,12 @@ jobs:
         environment:
             name: prod-jobs
         steps:
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v4.1.8
               with:
                   name: build
                   path: build
             - name: Deploy Jobs to prod
-              uses: Azure/functions-action@v1
+              uses: Azure/functions-action@v1.5.2
               with:
                   app-name: ${{ vars.AZURE_FUNCTION_APP_NAME_PROD }}
                   package: build

--- a/.github/workflows/post-merge-public-api.yml
+++ b/.github/workflows/post-merge-public-api.yml
@@ -38,9 +38,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v4.0.1
               with:
                   dotnet-version: '8.x'
             - name: Install NuGet packages (linux)
@@ -56,7 +56,7 @@ jobs:
             - name: Bundle migrations
               run: dotnet ef migrations bundle --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --output build/Migrate --self-contained
             - name: Publish artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v4.4.0
               with:
                   include-hidden-files: true
                   name: build
@@ -72,7 +72,7 @@ jobs:
             url: ${{ vars.URL_DEV }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
             - uses: ./.github/actions/deploy-to-env
               id: deploy
               with:
@@ -94,7 +94,7 @@ jobs:
             url: ${{ vars.URL_QA }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
             - uses: ./.github/actions/deploy-to-env
               id: deploy
               with:
@@ -121,7 +121,7 @@ jobs:
             url: ${{ vars.URL_PROD }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
             - uses: ./.github/actions/deploy-to-env

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -11,11 +11,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.1.7
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v4.0.1
               with:
                   dotnet-version: '8.x'
             - name: Build


### PR DESCRIPTION
To make builds/deployments fully reproducible and avoid untimely failures this pins all GitHub Action versions.