### PR TITLE
drop TextUrl column from BibleBookContents table

### DIFF
--- a/src/Aquifer.Data/Migrations/20240909211746_DropTextUrlColumnFromBibleBookContents.Designer.cs
+++ b/src/Aquifer.Data/Migrations/20240909211746_DropTextUrlColumnFromBibleBookContents.Designer.cs
@@ -4,6 +4,7 @@ using Aquifer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Aquifer.Data.Migrations
 {
     [DbContext(typeof(AquiferDbContext))]
-    partial class AquiferDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240909211746_DropTextUrlColumnFromBibleBookContents")]
+    partial class DropTextUrlColumnFromBibleBookContents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Aquifer.Data/Migrations/20240909211746_DropTextUrlColumnFromBibleBookContents.cs
+++ b/src/Aquifer.Data/Migrations/20240909211746_DropTextUrlColumnFromBibleBookContents.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Aquifer.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropTextUrlColumnFromBibleBookContents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TextUrl",
+                table: "BibleBookContents");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TextUrl",
+                table: "BibleBookContents",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}


### PR DESCRIPTION
Usages of this column have been removed and the code deployed in all envs.