### PR TITLE
Fix Projects load time

### DIFF
--- a/src/Aquifer.API/Endpoints/Projects/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Projects/List/Endpoint.cs
@@ -1,6 +1,7 @@
 ﻿using Aquifer.API.Common;
 using Aquifer.API.Services;
 using Aquifer.Data;
+using Aquifer.Data.Entities;
 using FastEndpoints;
 using Microsoft.EntityFrameworkCore;
 
@@ -25,28 +26,37 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
         var self = await userService.GetUserFromJwtAsync(ct);
 
         return await dbContext.Projects
-            .Where(x =>
-                (x.ActualPublishDate == null || x.ActualPublishDate.Value > DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30)) &&
+            .Where(x => (x.ActualPublishDate == null || x.ActualPublishDate.Value > DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30)) &&
                 (userService.HasPermission(PermissionName.ReadProject) ||
-                    (userService.HasPermission(PermissionName.ReadProjectsInCompany) && self.CompanyId == x.CompanyId))).Select(x =>
-                new Response
+                    (userService.HasPermission(PermissionName.ReadProjectsInCompany) && self.CompanyId == x.CompanyId)))
+            .Select(x => new Response
+            {
+                Id = x.Id,
+                Name = x.Name,
+                Company = x.Company.Name,
+                Language = x.Language.EnglishDisplay,
+                ProjectPlatform = x.ProjectPlatform.Name,
+                ProjectLead = $"{x.ProjectManagerUser.FirstName} {x.ProjectManagerUser.LastName}",
+                Manager = x.CompanyLeadUser != null ? $"{x.CompanyLeadUser.FirstName} {x.CompanyLeadUser.LastName}" : null,
+                Resource = x.ResourceContents.First().Resource.ParentResource.DisplayName,
+                ItemCount = x.ResourceContents.Count,
+                WordCount = x.SourceWordCount,
+                IsStarted = x.Started != null,
+                Days =
+                    x.ProjectedDeliveryDate.HasValue
+                        ? x.ProjectedDeliveryDate.Value.DayNumber - DateOnly.FromDateTime(DateTime.UtcNow).DayNumber
+                        : null,
+                Counts = new ProjectResourceStatusCounts
                 {
-                    Id = x.Id,
-                    Name = x.Name,
-                    Company = x.Company.Name,
-                    Language = x.Language.EnglishDisplay,
-                    ProjectPlatform = x.ProjectPlatform.Name,
-                    ProjectLead = $"{x.ProjectManagerUser.FirstName} {x.ProjectManagerUser.LastName}",
-                    Manager = x.CompanyLeadUser != null ? $"{x.CompanyLeadUser.FirstName} {x.CompanyLeadUser.LastName}" : null,
-                    Resource = x.ResourceContents.First().Resource.ParentResource.DisplayName,
-                    ItemCount = x.ResourceContents.Count,
-                    WordCount = x.SourceWordCount,
-                    IsStarted = x.Started != null,
-                    Days =
-                        x.ProjectedDeliveryDate.HasValue
-                            ? x.ProjectedDeliveryDate.Value.DayNumber - DateOnly.FromDateTime(DateTime.UtcNow).DayNumber
-                            : null,
-                    Counts = new ProjectResourceStatusCounts(x.ResourceContents)
-                }).ToListAsync(ct);
+                    NotStarted = x.ResourceContents.Count(rc => ProjectResourceStatusCounts.NotStartedStatuses.Contains(rc.Status)),
+                    InProgress = x.ResourceContents.Count(rc => ProjectResourceStatusCounts.InProgressStatuses.Contains(rc.Status)),
+                    InManagerReview =
+                        x.ResourceContents.Count(rc => ProjectResourceStatusCounts.InManagerReviewStatuses.Contains(rc.Status)),
+                    InPublisherReview =
+                        x.ResourceContents.Count(rc => ProjectResourceStatusCounts.InPublisherReviewStatuses.Contains(rc.Status)),
+                    Completed = x.ResourceContents.Count(rc => rc.Status == ResourceContentStatus.Complete)
+                }
+            })
+            .ToListAsync(ct);
     }
 }

--- a/src/Aquifer.API/Endpoints/Projects/ProjectResourceStatusCounts.cs
+++ b/src/Aquifer.API/Endpoints/Projects/ProjectResourceStatusCounts.cs
@@ -4,19 +4,19 @@ namespace Aquifer.API.Endpoints.Projects;
 
 public class ProjectResourceStatusCounts
 {
-    private readonly List<ResourceContentStatus> _inManagerReviewStatuses =
+    internal static readonly List<ResourceContentStatus> InManagerReviewStatuses =
     [
         ResourceContentStatus.AquiferizeManagerReview,
         ResourceContentStatus.TranslationManagerReview
     ];
 
-    private readonly List<ResourceContentStatus> _inProgressStatuses =
+    internal static readonly List<ResourceContentStatus> InProgressStatuses =
     [
         ResourceContentStatus.AquiferizeInProgress,
         ResourceContentStatus.TranslationInProgress
     ];
 
-    private readonly List<ResourceContentStatus> _inPublisherReviewStatuses =
+    internal static readonly List<ResourceContentStatus> InPublisherReviewStatuses =
     [
         ResourceContentStatus.AquiferizePublisherReview,
         ResourceContentStatus.AquiferizeReviewPending,
@@ -24,24 +24,15 @@ public class ProjectResourceStatusCounts
         ResourceContentStatus.TranslationReviewPending
     ];
 
-    private readonly List<ResourceContentStatus> _notStartedStatuses =
+    internal static readonly List<ResourceContentStatus> NotStartedStatuses =
     [
         ResourceContentStatus.New,
         ResourceContentStatus.TranslationNotStarted
     ];
 
-    public ProjectResourceStatusCounts(ICollection<ResourceContentEntity> resourceContents)
-    {
-        NotStarted = resourceContents.Count(rc => _notStartedStatuses.Contains(rc.Status));
-        InProgress = resourceContents.Count(rc => _inProgressStatuses.Contains(rc.Status));
-        InManagerReview = resourceContents.Count(rc => _inManagerReviewStatuses.Contains(rc.Status));
-        InPublisherReview = resourceContents.Count(rc => _inPublisherReviewStatuses.Contains(rc.Status));
-        Completed = resourceContents.Count(rc => rc.Status == ResourceContentStatus.Complete);
-    }
-
-    public int NotStarted { get; private init; }
-    public int InProgress { get; private init; }
-    public int InManagerReview { get; private init; }
-    public int InPublisherReview { get; private init; }
-    public int Completed { get; private init; }
+    public int NotStarted { get; init; }
+    public int InProgress { get; init; }
+    public int InManagerReview { get; init; }
+    public int InPublisherReview { get; init; }
+    public int Completed { get; init; }
 }


### PR DESCRIPTION
This fixes the Projects page load times because it won't pull many thousands of resources for the count. However, it slows down the other two pages generally because they have far fewer resources to pull, so counting in memory was then faster.

I think the broader solution is that the progress bar should lazy load on the page, because that part of the query is what's slowing everything down.