### PR TITLE
Fix related Content dropdown can link to audio file

### DIFF
--- a/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
@@ -4,6 +4,7 @@ using Aquifer.API.Services;
 using Aquifer.Common.Extensions;
 using Aquifer.Common.Utilities;
 using Aquifer.Data;
+using Aquifer.Data.Entities;
 using FastEndpoints;
 using Microsoft.EntityFrameworkCore;
 
@@ -51,21 +52,21 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
                         HasPublished = orc.Versions.Any(x => x.IsPublished),
                         ResourceContentStatus = orc.Status
                     }),
-                AssociatedResources =
-                    rc.Resource.AssociatedResourceChildren.Select(ar =>
-                        new AssociatedContentResponse
-                        {
-                            // Get the associated resource content for the current content's language or fallback to English
-                            ResourceContent =
-                                ar.ResourceContents.OrderByDescending(rci =>
-                                    rci.LanguageId == rc.LanguageId ? 2 : rci.LanguageId == englishLanguageId ? 1 : 0).FirstOrDefault(),
-                            EnglishLabel = ar.EnglishLabel,
-                            ParentResourceName = ar.ParentResource.DisplayName,
-                            MediaTypes = ar.ResourceContents.Select(arrc => arrc.MediaType)
-                        }),
+                AssociatedResources = rc.Resource.AssociatedResourceChildren.Select(ar => new AssociatedContentResponse
+                {
+                    // Get the associated resource content for the current content's language or fallback to English
+                    ResourceContent =
+                        ar.ResourceContents.Where(rci => rci.MediaType == ResourceContentMediaType.Text)
+                            .OrderByDescending(rci => rci.LanguageId == rc.LanguageId ? 2 : rci.LanguageId == englishLanguageId ? 1 : 0)
+                            .FirstOrDefault(),
+                    EnglishLabel = ar.EnglishLabel,
+                    ParentResourceName = ar.ParentResource.DisplayName,
+                    MediaTypes = ar.ResourceContents.Select(arrc => arrc.MediaType)
+                }),
                 ProjectEntity = rc.Projects.FirstOrDefault(),
                 HasPublishedVersion = rc.Versions.Any(rcv => rcv.IsPublished)
-            }).FirstOrDefaultAsync(ct);
+            })
+            .FirstOrDefaultAsync(ct);
 
         if (resourceContent is null)
         {
@@ -75,21 +76,28 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
 
         resourceContent.AssociatedResources = resourceContent.AssociatedResources.OrderBy(x => x.EnglishLabel);
 
-        resourceContent.VerseReferences = await dbContext.VerseResources
-            .Where(x => x.ResourceId == resourceContent.ResourceId)
-            .Select(vr => new VerseReferenceResponse { VerseId = vr.VerseId }).ToListAsync(ct);
+        resourceContent.VerseReferences = await dbContext.VerseResources.Where(x => x.ResourceId == resourceContent.ResourceId)
+            .Select(vr => new VerseReferenceResponse { VerseId = vr.VerseId })
+            .ToListAsync(ct);
 
-        resourceContent.PassageReferences = await dbContext.PassageResources
-            .Where(x => x.ResourceId == resourceContent.ResourceId)
-            .Select(pr => new PassageReferenceResponse { StartVerseId = pr.Passage.StartVerseId, EndVerseId = pr.Passage.EndVerseId })
+        resourceContent.PassageReferences = await dbContext.PassageResources.Where(x => x.ResourceId == resourceContent.ResourceId)
+            .Select(pr => new PassageReferenceResponse
+            {
+                StartVerseId = pr.Passage.StartVerseId,
+                EndVerseId = pr.Passage.EndVerseId
+            })
             .ToListAsync(ct);
 
         var relevantContentVersion = await dbContext.ResourceContentVersions.Where(rcv => rcv.ResourceContentId == request.Id)
-            .Include(rcv => rcv.CommentThreads).ThenInclude(cth => cth.CommentThread.Comments).ThenInclude(c => c.User)
-            .Include(rcv => rcv.CommentThreads).ThenInclude(cth => cth.CommentThread.ResolvedByUser)
+            .Include(rcv => rcv.CommentThreads)
+            .ThenInclude(cth => cth.CommentThread.Comments)
+            .ThenInclude(c => c.User)
+            .Include(rcv => rcv.CommentThreads)
+            .ThenInclude(cth => cth.CommentThread.ResolvedByUser)
             .Include(rcv => rcv.AssignedUser)
             .Include(rcv => rcv.MachineTranslations)
-            .OrderBy(rcv => rcv.IsDraft ? 0 : rcv.IsPublished ? 1 : 2).ThenByDescending(rcv => rcv.Version)
+            .OrderBy(rcv => rcv.IsDraft ? 0 : rcv.IsPublished ? 1 : 2)
+            .ThenByDescending(rcv => rcv.Version)
             .FirstOrDefaultAsync(ct);
 
         if (relevantContentVersion is null)
@@ -97,44 +105,53 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
             ThrowError("Data integrity issue, no resource content version found.");
         }
 
-        if (relevantContentVersion.IsDraft && relevantContentVersion.AssignedUserId != self.Id &&
-            userService.HasPermission(PermissionName.SendReviewContent) && Constants.ReviewPendingStatuses.Contains(resourceContent.Status))
+        if (relevantContentVersion.IsDraft &&
+            relevantContentVersion.AssignedUserId != self.Id &&
+            userService.HasPermission(PermissionName.SendReviewContent) &&
+            Constants.ReviewPendingStatuses.Contains(resourceContent.Status))
         {
-            resourceContent.CanPullBackToManagerReview = resourceContent.ProjectEntity?.CompanyLeadUserId == self.Id
-                                                         || await dbContext.ResourceContentVersionAssignedUserHistory
-                                                             .Where(h => h.ResourceContentVersionId == relevantContentVersion.Id &&
-                                                                         h.AssignedUserId != null)
-                                                             .OrderByDescending(h => h.Created)
-                                                             .Select(h => h.AssignedUserId == self.Id)
-                                                             .FirstOrDefaultAsync(ct);
+            resourceContent.CanPullBackToManagerReview = resourceContent.ProjectEntity?.CompanyLeadUserId == self.Id ||
+                await dbContext.ResourceContentVersionAssignedUserHistory
+                    .Where(h => h.ResourceContentVersionId == relevantContentVersion.Id && h.AssignedUserId != null)
+                    .OrderByDescending(h => h.Created)
+                    .Select(h => h.AssignedUserId == self.Id)
+                    .FirstOrDefaultAsync(ct);
         }
 
         var snapshots = await dbContext.ResourceContentVersionSnapshots
-            .Where(rcvs => rcvs.ResourceContentVersionId == relevantContentVersion.Id).OrderByDescending(rcvs => rcvs.Created).Select(
-                rcvs =>
-                    new SnapshotResponse
-                    {
-                        Id = rcvs.Id,
-                        Created = rcvs.Created,
-                        AssignedUserName = rcvs.User == null ? null : $"{rcvs.User.FirstName} {rcvs.User.LastName}",
-                        Status = rcvs.Status.GetDisplayName()
-                    }).ToListAsync(ct);
+            .Where(rcvs => rcvs.ResourceContentVersionId == relevantContentVersion.Id)
+            .OrderByDescending(rcvs => rcvs.Created)
+            .Select(rcvs => new SnapshotResponse
+            {
+                Id = rcvs.Id,
+                Created = rcvs.Created,
+                AssignedUserName = rcvs.User == null ? null : $"{rcvs.User.FirstName} {rcvs.User.LastName}",
+                Status = rcvs.Status.GetDisplayName()
+            })
+            .ToListAsync(ct);
 
         var versions = await dbContext.ResourceContentVersions
             .Where(rcv => rcv.Id != relevantContentVersion.Id && rcv.ResourceContentId == relevantContentVersion.ResourceContentId)
-            .OrderByDescending(rcv => rcv.Created).Select(rcv =>
-                new VersionResponse { Id = rcv.Id, Created = rcv.Created, Version = rcv.Version, IsPublished = rcv.IsPublished })
+            .OrderByDescending(rcv => rcv.Created)
+            .Select(rcv => new VersionResponse
+            {
+                Id = rcv.Id,
+                Created = rcv.Created,
+                Version = rcv.Version,
+                IsPublished = rcv.IsPublished
+            })
             .ToListAsync(ct);
 
         resourceContent.MachineTranslation = relevantContentVersion.MachineTranslations.Select(mt => new MachineTranslationResponse
-        {
-            Id = mt.Id,
-            UserId = mt.UserId,
-            UserRating = mt.UserRating,
-            ImproveClarity = mt.ImproveClarity,
-            ImproveConsistency = mt.ImproveConsistency,
-            ImproveTone = mt.ImproveTone
-        }).FirstOrDefault();
+            {
+                Id = mt.Id,
+                UserId = mt.UserId,
+                UserRating = mt.UserRating,
+                ImproveClarity = mt.ImproveClarity,
+                ImproveConsistency = mt.ImproveConsistency,
+                ImproveTone = mt.ImproveTone
+            })
+            .FirstOrDefault();
 
         resourceContent.IsDraft = relevantContentVersion.IsDraft;
         resourceContent.ResourceContentVersionId = relevantContentVersion.Id;
@@ -151,17 +168,19 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
             {
                 ThreadTypeId = relevantContentVersion.Id,
                 Threads = relevantContentVersion.CommentThreads.Select(x => new ThreadResponse
-                {
-                    Id = x.CommentThreadId,
-                    Resolved = x.CommentThread.Resolved,
-                    Comments = x.CommentThread.Comments.Select(c => new CommentResponse
                     {
-                        Id = c.Id,
-                        Comment = c.Comment,
-                        User = UserDto.FromUserEntity(c.User)!,
-                        DateTime = c.Updated
-                    }).ToList()
-                }).ToList()
+                        Id = x.CommentThreadId,
+                        Resolved = x.CommentThread.Resolved,
+                        Comments = x.CommentThread.Comments.Select(c => new CommentResponse
+                            {
+                                Id = c.Id,
+                                Comment = c.Comment,
+                                User = UserDto.FromUserEntity(c.User)!,
+                                DateTime = c.Updated
+                            })
+                            .ToList()
+                    })
+                    .ToList()
             };
 
             if (relevantContentVersion.AssignedUser is not null)


### PR DESCRIPTION
Fixes situation where the audio file resource content id can be what's linked in Related Content dropdown (which then would load a blank page). This makes sure we load the text resoruce content instead.