### PR TITLE
force the resources content endpoint main query to be split

### DIFF
--- a/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
@@ -66,6 +66,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
                 ProjectEntity = rc.Projects.FirstOrDefault(),
                 HasPublishedVersion = rc.Versions.Any(rcv => rcv.IsPublished)
             })
+            .AsSplitQuery()
             .FirstOrDefaultAsync(ct);
 
         if (resourceContent is null)
@@ -143,14 +144,14 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
             .ToListAsync(ct);
 
         resourceContent.MachineTranslation = relevantContentVersion.MachineTranslations.Select(mt => new MachineTranslationResponse
-            {
-                Id = mt.Id,
-                UserId = mt.UserId,
-                UserRating = mt.UserRating,
-                ImproveClarity = mt.ImproveClarity,
-                ImproveConsistency = mt.ImproveConsistency,
-                ImproveTone = mt.ImproveTone
-            })
+        {
+            Id = mt.Id,
+            UserId = mt.UserId,
+            UserRating = mt.UserRating,
+            ImproveClarity = mt.ImproveClarity,
+            ImproveConsistency = mt.ImproveConsistency,
+            ImproveTone = mt.ImproveTone
+        })
             .FirstOrDefault();
 
         resourceContent.IsDraft = relevantContentVersion.IsDraft;
@@ -168,18 +169,18 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
             {
                 ThreadTypeId = relevantContentVersion.Id,
                 Threads = relevantContentVersion.CommentThreads.Select(x => new ThreadResponse
+                {
+                    Id = x.CommentThreadId,
+                    Resolved = x.CommentThread.Resolved,
+                    Comments = x.CommentThread.Comments.Select(c => new CommentResponse
                     {
-                        Id = x.CommentThreadId,
-                        Resolved = x.CommentThread.Resolved,
-                        Comments = x.CommentThread.Comments.Select(c => new CommentResponse
-                            {
-                                Id = c.Id,
-                                Comment = c.Comment,
-                                User = UserDto.FromUserEntity(c.User)!,
-                                DateTime = c.Updated
-                            })
-                            .ToList()
+                        Id = c.Id,
+                        Comment = c.Comment,
+                        User = UserDto.FromUserEntity(c.User)!,
+                        DateTime = c.Updated
                     })
+                            .ToList()
+                })
                     .ToList()
             };
 


### PR DESCRIPTION
Tested locally and in dev. Almost doubles the speed of the endpoint.
Before: 700-1200ms
After: 300-800ms