### PR TITLE
Improve performance of resources/content/get endpoint.

### DIFF
--- a/src/Aquifer.API/Endpoints/Projects/AssignedToSelf/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Projects/AssignedToSelf/List/Endpoint.cs
@@ -40,13 +40,13 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
                         : null,
                 Counts = new ProjectResourceStatusCounts
                 {
-                    NotStarted = x.ResourceContents.Count(rc => ProjectResourceStatusCounts.NotStartedStatuses.Contains(rc.Status)),
-                    InProgress = x.ResourceContents.Count(rc => ProjectResourceStatusCounts.InProgressStatuses.Contains(rc.Status)),
+                    NotStarted = x.ProjectResourceContents.Count(prc => ProjectResourceStatusCounts.NotStartedStatuses.Contains(prc.ResourceContent.Status)),
+                    InProgress = x.ProjectResourceContents.Count(prc => ProjectResourceStatusCounts.InProgressStatuses.Contains(prc.ResourceContent.Status)),
                     InManagerReview =
-                        x.ResourceContents.Count(rc => ProjectResourceStatusCounts.InManagerReviewStatuses.Contains(rc.Status)),
+                        x.ProjectResourceContents.Count(prc => ProjectResourceStatusCounts.InManagerReviewStatuses.Contains(prc.ResourceContent.Status)),
                     InPublisherReview =
-                        x.ResourceContents.Count(rc => ProjectResourceStatusCounts.InPublisherReviewStatuses.Contains(rc.Status)),
-                    Completed = x.ResourceContents.Count(rc => rc.Status == ResourceContentStatus.Complete)
+                        x.ProjectResourceContents.Count(prc => ProjectResourceStatusCounts.InPublisherReviewStatuses.Contains(prc.ResourceContent.Status)),
+                    Completed = x.ProjectResourceContents.Count(prc => prc.ResourceContent.Status == ResourceContentStatus.Complete)
                 }
             })
             .ToListAsync(ct);

--- a/src/Aquifer.API/Endpoints/Projects/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Projects/Get/Endpoint.cs
@@ -62,13 +62,13 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
                 ProjectedPublishDate = x.ProjectedPublishDate,
                 Counts = new ProjectResourceStatusCounts
                 {
-                    NotStarted = x.ResourceContents.Count(rc => ProjectResourceStatusCounts.NotStartedStatuses.Contains(rc.Status)),
-                    InProgress = x.ResourceContents.Count(rc => ProjectResourceStatusCounts.InProgressStatuses.Contains(rc.Status)),
+                    NotStarted = x.ProjectResourceContents.Count(prc => ProjectResourceStatusCounts.NotStartedStatuses.Contains(prc.ResourceContent.Status)),
+                    InProgress = x.ProjectResourceContents.Count(prc => ProjectResourceStatusCounts.InProgressStatuses.Contains(prc.ResourceContent.Status)),
                     InManagerReview =
-                        x.ResourceContents.Count(rc => ProjectResourceStatusCounts.InManagerReviewStatuses.Contains(rc.Status)),
+                        x.ProjectResourceContents.Count(prc => ProjectResourceStatusCounts.InManagerReviewStatuses.Contains(prc.ResourceContent.Status)),
                     InPublisherReview =
-                        x.ResourceContents.Count(rc => ProjectResourceStatusCounts.InPublisherReviewStatuses.Contains(rc.Status)),
-                    Completed = x.ResourceContents.Count(rc => rc.Status == ResourceContentStatus.Complete)
+                        x.ProjectResourceContents.Count(prc => ProjectResourceStatusCounts.InPublisherReviewStatuses.Contains(prc.ResourceContent.Status)),
+                    Completed = x.ProjectResourceContents.Count(prc => prc.ResourceContent.Status == ResourceContentStatus.Complete)
                 }
             })
             .SingleOrDefaultAsync(ct);

--- a/src/Aquifer.API/Endpoints/Projects/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Projects/List/Endpoint.cs
@@ -29,33 +29,33 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
             .Where(x => (x.ActualPublishDate == null || x.ActualPublishDate.Value > DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30)) &&
                 (userService.HasPermission(PermissionName.ReadProject) ||
                     (userService.HasPermission(PermissionName.ReadProjectsInCompany) && self.CompanyId == x.CompanyId)))
-            .Select(x => new Response
+            .Select(p => new Response
             {
-                Id = x.Id,
-                Name = x.Name,
-                Company = x.Company.Name,
-                Language = x.Language.EnglishDisplay,
-                ProjectPlatform = x.ProjectPlatform.Name,
-                ProjectLead = $"{x.ProjectManagerUser.FirstName} {x.ProjectManagerUser.LastName}",
-                Manager = x.CompanyLeadUser != null ? $"{x.CompanyLeadUser.FirstName} {x.CompanyLeadUser.LastName}" : null,
-                Resource = x.ResourceContents.First().Resource.ParentResource.DisplayName,
-                ItemCount = x.ResourceContents.Count,
-                WordCount = x.SourceWordCount,
-                IsStarted = x.Started != null,
-                IsCompleted = x.ActualPublishDate != null,
+                Id = p.Id,
+                Name = p.Name,
+                Company = p.Company.Name,
+                Language = p.Language.EnglishDisplay,
+                ProjectPlatform = p.ProjectPlatform.Name,
+                ProjectLead = $"{p.ProjectManagerUser.FirstName} {p.ProjectManagerUser.LastName}",
+                Manager = p.CompanyLeadUser != null ? $"{p.CompanyLeadUser.FirstName} {p.CompanyLeadUser.LastName}" : null,
+                Resource = p.ProjectResourceContents.First().ResourceContent.Resource.ParentResource.DisplayName,
+                ItemCount = p.ProjectResourceContents.Count,
+                WordCount = p.SourceWordCount,
+                IsStarted = p.Started != null,
+                IsCompleted = p.ActualPublishDate != null,
                 Days =
-                    x.ProjectedDeliveryDate.HasValue
-                        ? x.ProjectedDeliveryDate.Value.DayNumber - DateOnly.FromDateTime(DateTime.UtcNow).DayNumber
+                    p.ProjectedDeliveryDate.HasValue
+                        ? p.ProjectedDeliveryDate.Value.DayNumber - DateOnly.FromDateTime(DateTime.UtcNow).DayNumber
                         : null,
                 Counts = new ProjectResourceStatusCounts
                 {
-                    NotStarted = x.ResourceContents.Count(rc => ProjectResourceStatusCounts.NotStartedStatuses.Contains(rc.Status)),
-                    InProgress = x.ResourceContents.Count(rc => ProjectResourceStatusCounts.InProgressStatuses.Contains(rc.Status)),
+                    NotStarted = p.ProjectResourceContents.Count(prc => ProjectResourceStatusCounts.NotStartedStatuses.Contains(prc.ResourceContent.Status)),
+                    InProgress = p.ProjectResourceContents.Count(prc => ProjectResourceStatusCounts.InProgressStatuses.Contains(prc.ResourceContent.Status)),
                     InManagerReview =
-                        x.ResourceContents.Count(rc => ProjectResourceStatusCounts.InManagerReviewStatuses.Contains(rc.Status)),
+                        p.ProjectResourceContents.Count(prc => ProjectResourceStatusCounts.InManagerReviewStatuses.Contains(prc.ResourceContent.Status)),
                     InPublisherReview =
-                        x.ResourceContents.Count(rc => ProjectResourceStatusCounts.InPublisherReviewStatuses.Contains(rc.Status)),
-                    Completed = x.ResourceContents.Count(rc => rc.Status == ResourceContentStatus.Complete)
+                        p.ProjectResourceContents.Count(prc => ProjectResourceStatusCounts.InPublisherReviewStatuses.Contains(prc.ResourceContent.Status)),
+                    Completed = p.ProjectResourceContents.Count(prc => prc.ResourceContent.Status == ResourceContentStatus.Complete)
                 }
             })
             .ToListAsync(ct);

--- a/src/Aquifer.API/Endpoints/Projects/Start/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Projects/Start/Endpoint.cs
@@ -30,7 +30,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
         ValidateProject(project);
 
         var resourceContentVersions = await dbContext.ResourceContentVersions
-            .Where(rcv => rcv.ResourceContent.Projects.Contains(project) && rcv.IsDraft)
+            .Where(rcv => rcv.ResourceContent.ProjectResourceContents.Any(prc => prc.Project.Id == project.Id) && rcv.IsDraft)
             .Include(rcv => rcv.ResourceContent)
             .ThenInclude(rc => rc.Language).ToListAsync(ct);
 

--- a/src/Aquifer.API/Endpoints/Resources/Content/AssignEditor/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/AssignEditor/Endpoint.cs
@@ -121,7 +121,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
         }
 
         var isCompanyLead = await dbContext.Projects
-            .Where(p => p.ResourceContents.Any(rc => rc.Id == version.ResourceContentId))
+            .Where(p => p.ProjectResourceContents.Any(prc => prc.ResourceContent.Id == version.ResourceContentId))
             .Select(p => p.CompanyLeadUserId == userId)
             .FirstOrDefaultAsync(ct);
 

--- a/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
@@ -64,7 +64,9 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
                     ParentResourceName = ar.ParentResource.DisplayName,
                     MediaTypes = ar.ResourceContents.Select(arrc => arrc.MediaType)
                 }),
-                ProjectEntity = rc.Projects.FirstOrDefault(),
+                ProjectEntity = rc.ProjectResourceContents.FirstOrDefault(prc => prc.ResourceContentId == request.Id) == null
+                    ? null
+                    : rc.ProjectResourceContents.First(prc => prc.ResourceContentId == request.Id).Project,
                 HasPublishedVersion = rc.Versions.Any(rcv => rcv.IsPublished)
             })
             .AsSplitQuery()

--- a/src/Aquifer.API/Endpoints/Resources/Content/SendForManagerReview/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/SendForManagerReview/Endpoint.cs
@@ -27,7 +27,8 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
         var draftVersions = await dbContext.ResourceContentVersions
             .Where(x => contentIds.Contains(x.ResourceContentId) && allowedStatuses.Contains(x.ResourceContent.Status) && x.IsDraft)
             .Include(x => x.ResourceContent)
-            .ThenInclude(x => x.Projects)
+            .ThenInclude(x => x.ProjectResourceContents)
+            .ThenInclude(x => x.Project)
             .ToListAsync(ct);
 
         if (draftVersions.Count != contentIds.Count)
@@ -55,7 +56,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
 
             draftVersion.ResourceContent.Status = reviewPendingStatus;
             await SetAssignedUserId(user,
-                draftVersion.ResourceContent.Projects.FirstOrDefault(x => x.ActualPublishDate == null),
+                draftVersion.ResourceContent.ProjectResourceContents.FirstOrDefault(x => x.Project.ActualPublishDate == null)?.Project,
                 managerIds,
                 draftVersion);
 

--- a/src/Aquifer.Data/AquiferDbContext.cs
+++ b/src/Aquifer.Data/AquiferDbContext.cs
@@ -56,6 +56,7 @@ public class AquiferDbContext : DbContext
     public DbSet<PassageResourceEntity> PassageResources { get; set; }
     public DbSet<ProjectEntity> Projects { get; set; }
     public DbSet<ProjectPlatformEntity> ProjectPlatforms { get; set; }
+    public DbSet<ProjectResourceContentEntity> ProjectResourceContents { get; set; }
     public DbSet<ReportEntity> Reports { get; set; }
     public DbSet<ResourceContentEntity> ResourceContents { get; set; }
     public DbSet<ResourceContentRequestEntity> ResourceContentRequests { get; set; }

--- a/src/Aquifer.Data/Entities/ProjectEntity.cs
+++ b/src/Aquifer.Data/Entities/ProjectEntity.cs
@@ -1,10 +1,8 @@
 using Aquifer.Data.EventHandlers;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Aquifer.Data.Entities;
 
-[EntityTypeConfiguration(typeof(ProjectEntityConfiguration))]
 [Index(nameof(Name), IsUnique = true)]
 public class ProjectEntity : IHasUpdatedTimestamp
 {
@@ -32,32 +30,11 @@ public class ProjectEntity : IHasUpdatedTimestamp
     public DateOnly? ProjectedPublishDate { get; set; }
     public DateOnly? ActualPublishDate { get; set; }
 
-    public ICollection<ResourceContentEntity> ResourceContents { get; set; } = new List<ResourceContentEntity>();
+    public ICollection<ProjectResourceContentEntity> ProjectResourceContents { get; set; } = new List<ProjectResourceContentEntity>();
 
     [SqlDefaultValue("getutcdate()")]
     public DateTime Created { get; set; } = DateTime.UtcNow;
 
     [SqlDefaultValue("getutcdate()")]
     public DateTime Updated { get; set; } = DateTime.UtcNow;
-}
-
-public class ProjectEntityConfiguration : IEntityTypeConfiguration<ProjectEntity>
-{
-    public void Configure(EntityTypeBuilder<ProjectEntity> builder)
-    {
-        builder
-            .HasMany(x => x.ResourceContents)
-            .WithMany(y => y.Projects)
-            .UsingEntity(
-                "ProjectResourceContents",
-                l => l.HasOne(typeof(ResourceContentEntity)).WithMany().HasForeignKey("ResourceContentId")
-                    .HasPrincipalKey(nameof(ResourceContentEntity.Id)).OnDelete(DeleteBehavior.Restrict),
-                r => r.HasOne(typeof(ProjectEntity)).WithMany().HasForeignKey("ProjectId").HasPrincipalKey(nameof(ProjectEntity.Id))
-                    .OnDelete(DeleteBehavior.Restrict),
-                j =>
-                {
-                    j.HasKey("ProjectId", "ResourceContentId");
-                    j.HasIndex("ResourceContentId").IsUnique();
-                });
-    }
 }

--- a/src/Aquifer.Data/Entities/ProjectResourceContentEntity.cs
+++ b/src/Aquifer.Data/Entities/ProjectResourceContentEntity.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Aquifer.Data.Entities;
+
+[PrimaryKey(nameof(ProjectId), nameof(ResourceContentId))]
+[Index(nameof(ResourceContentId), IsUnique = true)]
+public class ProjectResourceContentEntity
+{
+    public int ProjectId { get; set; }
+    public ProjectEntity Project { get; set; } = null!;
+    public int ResourceContentId { get; set; }
+    public ResourceContentEntity ResourceContent { get; set; } = null!;
+}
+
+public class ProjectResourceContentEntityConfiguration
+    : IEntityTypeConfiguration<ProjectResourceContentEntity>
+{
+    public void Configure(EntityTypeBuilder<ProjectResourceContentEntity> builder)
+    {
+        builder
+            .HasOne(x => x.Project)
+            .WithMany()
+            .HasForeignKey(nameof(ProjectResourceContentEntity.ProjectId))
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder
+            .HasOne(x => x.ResourceContent)
+            .WithMany()
+            .HasForeignKey(nameof(ProjectResourceContentEntity.ResourceContentId))
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Aquifer.Data/Entities/ProjectResourceContentEntity.cs
+++ b/src/Aquifer.Data/Entities/ProjectResourceContentEntity.cs
@@ -5,6 +5,7 @@ namespace Aquifer.Data.Entities;
 
 [PrimaryKey(nameof(ProjectId), nameof(ResourceContentId))]
 [Index(nameof(ResourceContentId), IsUnique = true)]
+[EntityTypeConfiguration(typeof(ProjectResourceContentEntityConfiguration))]
 public class ProjectResourceContentEntity
 {
     public int ProjectId { get; set; }
@@ -20,13 +21,13 @@ public class ProjectResourceContentEntityConfiguration
     {
         builder
             .HasOne(x => x.Project)
-            .WithMany()
+            .WithMany(x => x.ProjectResourceContents)
             .HasForeignKey(nameof(ProjectResourceContentEntity.ProjectId))
             .OnDelete(DeleteBehavior.Restrict);
 
         builder
             .HasOne(x => x.ResourceContent)
-            .WithMany()
+            .WithMany(x => x.ProjectResourceContents)
             .HasForeignKey(nameof(ProjectResourceContentEntity.ResourceContentId))
             .OnDelete(DeleteBehavior.Restrict);
     }

--- a/src/Aquifer.Data/Entities/ResourceContentEntity.cs
+++ b/src/Aquifer.Data/Entities/ResourceContentEntity.cs
@@ -26,7 +26,7 @@ public class ResourceContentEntity : IHasUpdatedTimestamp
     public LanguageEntity Language { get; set; } = null!;
     public ResourceEntity Resource { get; set; } = null!;
 
-    public ICollection<ProjectEntity> Projects { get; set; } = new List<ProjectEntity>();
+    public ICollection<ProjectResourceContentEntity> ProjectResourceContents { get; set; } = new List<ProjectResourceContentEntity>();
     public int Id { get; set; }
     public ResourceContentStatus Status { get; set; }
 

--- a/src/Aquifer.Data/EventHandlers/ResourceStatusChangeHandler.cs
+++ b/src/Aquifer.Data/EventHandlers/ResourceStatusChangeHandler.cs
@@ -71,8 +71,8 @@ public static class ResourceStatusChangeHandler
             await dbContext.Projects.Where(x =>
                     x.ActualDeliveryDate != null &&
                     x.ActualPublishDate == null &&
-                    x.ResourceContents.Any(rc => inProgressIds.Contains(rc.Id)) &&
-                    x.ResourceContents.Where(rc => !inProgressIds.Contains(rc.Id)).All(rc => InReviewOrGreaterStatuses.Contains(rc.Status)))
+                    x.ProjectResourceContents.Any(prc => inProgressIds.Contains(prc.ResourceContent.Id)) &&
+                    x.ProjectResourceContents.Where(prc => !inProgressIds.Contains(prc.ResourceContent.Id)).All(prc => InReviewOrGreaterStatuses.Contains(prc.ResourceContent.Status)))
                 .ExecuteUpdateAsync(x => x
                     .SetProperty(p => p.ActualDeliveryDate, null as DateOnly?)
                     .SetProperty(p => p.Updated, DateTime.UtcNow));

--- a/src/Aquifer.Data/EventHandlers/ResourceStatusChangeHandler.cs
+++ b/src/Aquifer.Data/EventHandlers/ResourceStatusChangeHandler.cs
@@ -47,9 +47,9 @@ public static class ResourceStatusChangeHandler
         if (completedContentIds.Count > 0)
         {
             await dbContext.Projects.Where(x =>
-                    x.ResourceContents.Any(rc => completedContentIds.Contains(rc.Id)) &&
-                    x.ResourceContents.Where(rc => !completedContentIds.Contains(rc.Id))
-                        .All(rc => rc.Status == ResourceContentStatus.Complete))
+                    x.ProjectResourceContents.Any(prc => completedContentIds.Contains(prc.ResourceContent.Id)) &&
+                    x.ProjectResourceContents.Where(prc => !completedContentIds.Contains(prc.ResourceContent.Id))
+                        .All(prc => prc.ResourceContent.Status == ResourceContentStatus.Complete))
                 .ExecuteUpdateAsync(x => x
                     .SetProperty(p => p.ActualPublishDate, DateOnly.FromDateTime(DateTime.UtcNow))
                     .SetProperty(p => p.Updated, DateTime.UtcNow));
@@ -58,9 +58,9 @@ public static class ResourceStatusChangeHandler
         if (inReviewContentIds.Count > 0)
         {
             await dbContext.Projects.Where(x =>
-                    x.ResourceContents.Any(rc => inReviewContentIds.Contains(rc.Id)) &&
-                    x.ResourceContents.Where(rc => !inReviewContentIds.Contains(rc.Id))
-                        .All(rc => InReviewOrGreaterStatuses.Contains(rc.Status)))
+                    x.ProjectResourceContents.Any(prc => inReviewContentIds.Contains(prc.ResourceContent.Id)) &&
+                    x.ProjectResourceContents.Where(prc => !inReviewContentIds.Contains(prc.ResourceContent.Id))
+                        .All(prc => InReviewOrGreaterStatuses.Contains(prc.ResourceContent.Status)))
                 .ExecuteUpdateAsync(x => x
                     .SetProperty(p => p.ActualDeliveryDate, DateOnly.FromDateTime(DateTime.UtcNow))
                     .SetProperty(p => p.Updated, DateTime.UtcNow));

--- a/src/Aquifer.Data/Migrations/AquiferDbContextModelSnapshot.cs
+++ b/src/Aquifer.Data/Migrations/AquiferDbContextModelSnapshot.cs
@@ -1074,6 +1074,22 @@ namespace Aquifer.Data.Migrations
                     b.ToTable("ProjectPlatforms");
                 });
 
+            modelBuilder.Entity("Aquifer.Data.Entities.ProjectResourceContentEntity", b =>
+                {
+                    b.Property<int>("ProjectId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("ResourceContentId")
+                        .HasColumnType("int");
+
+                    b.HasKey("ProjectId", "ResourceContentId");
+
+                    b.HasIndex("ResourceContentId")
+                        .IsUnique();
+
+                    b.ToTable("ProjectResourceContents");
+                });
+
             modelBuilder.Entity("Aquifer.Data.Entities.ReportEntity", b =>
                 {
                     b.Property<int>("Id")
@@ -1699,22 +1715,6 @@ namespace Aquifer.Data.Migrations
                     b.ToTable("AssociatedResources");
                 });
 
-            modelBuilder.Entity("ProjectResourceContents", b =>
-                {
-                    b.Property<int>("ProjectId")
-                        .HasColumnType("int");
-
-                    b.Property<int>("ResourceContentId")
-                        .HasColumnType("int");
-
-                    b.HasKey("ProjectId", "ResourceContentId");
-
-                    b.HasIndex("ResourceContentId")
-                        .IsUnique();
-
-                    b.ToTable("ProjectResourceContents");
-                });
-
             modelBuilder.Entity("Aquifer.Data.Entities.BibleBookChapterEntity", b =>
                 {
                     b.HasOne("Aquifer.Data.Entities.BibleBookEntity", "BibleBook")
@@ -2126,6 +2126,25 @@ namespace Aquifer.Data.Migrations
                     b.Navigation("ProjectPlatform");
                 });
 
+            modelBuilder.Entity("Aquifer.Data.Entities.ProjectResourceContentEntity", b =>
+                {
+                    b.HasOne("Aquifer.Data.Entities.ProjectEntity", "Project")
+                        .WithMany("ProjectResourceContents")
+                        .HasForeignKey("ProjectId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.HasOne("Aquifer.Data.Entities.ResourceContentEntity", "ResourceContent")
+                        .WithMany("ProjectResourceContents")
+                        .HasForeignKey("ResourceContentId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("Project");
+
+                    b.Navigation("ResourceContent");
+                });
+
             modelBuilder.Entity("Aquifer.Data.Entities.ResourceContentEntity", b =>
                 {
                     b.HasOne("Aquifer.Data.Entities.LanguageEntity", "Language")
@@ -2354,21 +2373,6 @@ namespace Aquifer.Data.Migrations
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("ProjectResourceContents", b =>
-                {
-                    b.HasOne("Aquifer.Data.Entities.ProjectEntity", null)
-                        .WithMany()
-                        .HasForeignKey("ProjectId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.HasOne("Aquifer.Data.Entities.ResourceContentEntity", null)
-                        .WithMany()
-                        .HasForeignKey("ResourceContentId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-                });
-
             modelBuilder.Entity("Aquifer.Data.Entities.BibleBookChapterEntity", b =>
                 {
                     b.Navigation("Verses");
@@ -2465,8 +2469,15 @@ namespace Aquifer.Data.Migrations
                     b.Navigation("PassageResources");
                 });
 
+            modelBuilder.Entity("Aquifer.Data.Entities.ProjectEntity", b =>
+                {
+                    b.Navigation("ProjectResourceContents");
+                });
+
             modelBuilder.Entity("Aquifer.Data.Entities.ResourceContentEntity", b =>
                 {
+                    b.Navigation("ProjectResourceContents");
+
                     b.Navigation("Versions");
                 });
 


### PR DESCRIPTION
This is a larger change that only impacts the admin site's routes, not the Bible well.  It was large in scope because it adds a true `ProjectResourceContent` entity instead of bypassing it in the ORM with configuration.  This addition allows filtering a sub-query on the resources/content/get endpoint to only the resource content ID specified in the request instead of doing large join. 

This change significantly reduces DB execution time of this part of the split query from an original 200-300 ms to < 100 ms for resource content ID `6779` in production.

Loading https://qa.admin.aquifer.bible/resources/4949 and looking at the network tab vs local changes goes from 1 second to 500 ms for fetching resource content data with this change.