### PR TITLE
Turn off EF Tracking for all read-only queries.

### DIFF
--- a/src/Aquifer.API/Endpoints/Comments/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Comments/Create/Endpoint.cs
@@ -16,7 +16,10 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
 
     public override async Task HandleAsync(Request req, CancellationToken ct)
     {
-        var thread = await dbContext.CommentThreads.SingleOrDefaultAsync(x => x.Id == req.ThreadId && !x.Resolved, ct);
+        var thread = await dbContext.CommentThreads
+            .AsTracking()
+            .SingleOrDefaultAsync(x => x.Id == req.ThreadId && !x.Resolved, ct);
+
         EndpointHelpers.ThrowErrorIfNull<Request>(thread, x => x.ThreadId, "No open thread found for id", 404);
 
         var user = await userService.GetUserFromJwtAsync(ct);

--- a/src/Aquifer.API/Endpoints/Comments/Threads/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Comments/Threads/Create/Endpoint.cs
@@ -30,7 +30,9 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
     private async Task<Response> CreateResourceContentVersionCommentThreadAsync(Request req, CancellationToken ct)
     {
         var resourceContentVersion = await dbContext.ResourceContentVersions
-            .Include(x => x.CommentThreads).SingleOrDefaultAsync(x => x.Id == req.TypeId, ct);
+            .AsTracking()
+            .Include(x => x.CommentThreads)
+            .SingleOrDefaultAsync(x => x.Id == req.TypeId, ct);
 
         EndpointHelpers.ThrowErrorIfNull<Request>(resourceContentVersion, x => x.TypeId, "No type found for given id.", 404);
 

--- a/src/Aquifer.API/Endpoints/Comments/Threads/Resolve/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Comments/Threads/Resolve/Endpoint.cs
@@ -15,7 +15,10 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
 
     public override async Task HandleAsync(Request req, CancellationToken ct)
     {
-        var thread = await dbContext.CommentThreads.SingleOrDefaultAsync(x => x.Id == req.ThreadId && !x.Resolved, ct);
+        var thread = await dbContext.CommentThreads
+            .AsTracking()
+            .SingleOrDefaultAsync(x => x.Id == req.ThreadId && !x.Resolved, ct);
+
         EndpointHelpers.ThrowErrorIfNull<Request>(thread, x => x.ThreadId, "No unresolved thread found for given id.", 404);
 
         var user = await userService.GetUserFromJwtAsync(ct);

--- a/src/Aquifer.API/Endpoints/Comments/Update/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Comments/Update/Endpoint.cs
@@ -17,6 +17,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
     {
         var user = await userService.GetUserFromJwtAsync(ct);
         var comment = await dbContext.Comments
+            .AsTracking()
             .SingleOrDefaultAsync(x => x.Id == req.CommentId && x.UserId == user.Id && !x.Thread.Resolved, ct);
 
         EndpointHelpers.ThrowErrorIfNull<Request>(comment, x => x.CommentId, "No owned, unresolved comment found", 404);

--- a/src/Aquifer.API/Endpoints/Feedback/Resources/Content/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Feedback/Resources/Content/Create/Endpoint.cs
@@ -15,7 +15,9 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
 
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
-        var resourceContentVersion = await dbContext.ResourceContentVersions.Where(rcv =>
+        var resourceContentVersion = await dbContext.ResourceContentVersions
+            .AsTracking()
+            .Where(rcv =>
                 rcv.ResourceContentId == request.ContentId &&
                 (rcv.Version == request.Version || (request.Version == null && rcv.IsPublished)))
             .FirstOrDefaultAsync(ct);

--- a/src/Aquifer.API/Endpoints/Marketing/Subscribers/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Marketing/Subscribers/Endpoint.cs
@@ -18,7 +18,9 @@ public class Endpoint(AquiferDbContext dbContext, ILogger<Endpoint> logger) : En
     {
         try
         {
-            var subscriber = await dbContext.ContentSubscribers.Where(x => x.Email == req.Email)
+            var subscriber = await dbContext.ContentSubscribers
+                .AsTracking()
+                .Where(x => x.Email == req.Email)
                 .Include(x => x.ContentSubscriberLanguages)
                 .Include(x => x.ContentSubscriberParentResources)
                 .SingleOrDefaultAsync(ct);

--- a/src/Aquifer.API/Endpoints/Projects/Update/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Projects/Update/Endpoint.cs
@@ -17,7 +17,11 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
 
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
-        var project = await dbContext.Projects.Include(p => p.ProjectPlatform).SingleOrDefaultAsync(p => p.Id == request.Id, ct);
+        var project = await dbContext.Projects
+            .AsTracking()
+            .Include(p => p.ProjectPlatform)
+            .SingleOrDefaultAsync(p => p.Id == request.Id, ct);
+
         if (project is null)
         {
             await SendNotFoundAsync(ct);

--- a/src/Aquifer.API/Endpoints/Resources/BibleReferences/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/BibleReferences/Create/Endpoint.cs
@@ -17,6 +17,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
         var resourceContent = await dbContext.ResourceContents
+            .AsTracking()
             .Include(rc => rc.Resource)
             .ThenInclude(r => r.VerseResources)
             .Include(rc => rc.Resource)
@@ -50,9 +51,9 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
                     pr.Passage.StartVerseId == request.StartVerseId && pr.Passage.EndVerseId == request.EndVerseId))
             {
                 var passage = await dbContext.Passages
-                                  .SingleOrDefaultAsync(p => p.StartVerseId == request.StartVerseId && p.EndVerseId == request.EndVerseId,
-                                      ct) ??
-                              new PassageEntity { StartVerseId = request.StartVerseId, EndVerseId = request.EndVerseId };
+                    .AsTracking()
+                    .SingleOrDefaultAsync(p => p.StartVerseId == request.StartVerseId && p.EndVerseId == request.EndVerseId, ct)
+                    ?? new PassageEntity { StartVerseId = request.StartVerseId, EndVerseId = request.EndVerseId };
                 ;
 
                 await dbContext.PassageResources.AddAsync(

--- a/src/Aquifer.API/Endpoints/Resources/BibleReferences/Delete/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/BibleReferences/Delete/Endpoint.cs
@@ -16,6 +16,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
         var resourceContent = await dbContext.ResourceContents
+            .AsTracking()
             .Include(rc => rc.Resource)
             .ThenInclude(r => r.VerseResources)
             .Include(rc => rc.Resource)

--- a/src/Aquifer.API/Endpoints/Resources/Content/AssignPublisherReview/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/AssignPublisherReview/Endpoint.cs
@@ -27,6 +27,7 @@ public class Endpoint(AquiferDbContext dbContext, IResourceHistoryService histor
         var contentIds = request.ContentId is not null ? [(int)request.ContentId] : request.ContentIds!;
 
         var draftVersions = await dbContext.ResourceContentVersions
+            .AsTracking()
             .Where(x => contentIds.Contains(x.ResourceContentId) &&
                         x.IsDraft &&
                         (x.ResourceContent.Status == ResourceContentStatus.AquiferizeReviewPending ||
@@ -71,7 +72,9 @@ public class Endpoint(AquiferDbContext dbContext, IResourceHistoryService histor
 
     private async Task ValidateAssignedUser(Request request, CancellationToken ct)
     {
-        var assignedUser = await dbContext.Users.SingleOrDefaultAsync(u => u.Id == request.AssignedUserId && u.Enabled, ct);
+        var assignedUser = await dbContext.Users
+            .AsTracking()
+            .SingleOrDefaultAsync(u => u.Id == request.AssignedUserId && u.Enabled, ct);
         if (assignedUser is null)
         {
             ThrowEntityNotFoundError<Request>(r => r.AssignedUserId);

--- a/src/Aquifer.API/Endpoints/Resources/Content/CreateTranslation/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/CreateTranslation/Endpoint.cs
@@ -23,6 +23,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
 
         if (isCommunityUser) {
             var isUserAssigned = await dbContext.ResourceContentVersions
+                .AsTracking()
                 .AnyAsync(x => x.AssignedUserId == user.Id, ct);
 
             if (isUserAssigned) {
@@ -30,7 +31,9 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
             }
         }
 
-        var baseContent = await dbContext.ResourceContents.Where(x => x.Id == request.BaseContentId)
+        var baseContent = await dbContext.ResourceContents
+            .AsTracking()
+            .Where(x => x.Id == request.BaseContentId)
             .Include(x => x.Versions)
             .SingleOrDefaultAsync(ct);
         if (baseContent is null ||
@@ -40,8 +43,9 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
             ThrowError("Base version not found");
         }
 
-        var isExistingTranslation = await dbContext.ResourceContents.AnyAsync(x =>
-                x.LanguageId == request.LanguageId && x.ResourceId == baseContent.ResourceId,
+        var isExistingTranslation = await dbContext.ResourceContents
+            .AsTracking()
+            .AnyAsync(x => x.LanguageId == request.LanguageId && x.ResourceId == baseContent.ResourceId,
             ct);
         if (isExistingTranslation)
         {

--- a/src/Aquifer.API/Endpoints/Resources/Content/Helpers.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Helpers.cs
@@ -22,7 +22,9 @@ public static class Helpers
         Task<(ResourceContentVersionEntity? latestVersion, ResourceContentVersionEntity? publishedVersion, ResourceContentVersionEntity?
             draftVersion)> GetResourceContentVersions(int contentId, AquiferDbContext dbContext, CancellationToken cancellationToken)
     {
-        var resourceContentVersions = await dbContext.ResourceContentVersions.Where(x => x.ResourceContentId == contentId)
+        var resourceContentVersions = await dbContext.ResourceContentVersions
+            .AsTracking()
+            .Where(x => x.ResourceContentId == contentId)
             .Include(x => x.ResourceContent)
             .ToListAsync(cancellationToken);
 
@@ -94,6 +96,7 @@ public static class Helpers
         CancellationToken ct)
     {
         var assignmentHistory = await dbContext.ResourceContentVersionAssignedUserHistory
+            .AsTracking()
             .Where(x => resourceContentVersionIds.Contains(x.ResourceContentVersionId))
             .OrderByDescending(x => x.Id)
             .Include(x => x.AssignedUser)

--- a/src/Aquifer.API/Endpoints/Resources/Content/MachineTranslation/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/MachineTranslation/Create/Endpoint.cs
@@ -17,9 +17,9 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
 
     public override async Task HandleAsync(Request req, CancellationToken ct)
     {
-        var existingMt =
-            await dbContext.ResourceContentVersionMachineTranslations
-                .FirstOrDefaultAsync(x => x.ResourceContentVersionId == req.ResourceContentVersionId && x.ContentIndex == req.ContentIndex, ct);
+        var existingMt = await dbContext.ResourceContentVersionMachineTranslations
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.ResourceContentVersionId == req.ResourceContentVersionId && x.ContentIndex == req.ContentIndex, ct);
 
         if (existingMt is not null)
         {

--- a/src/Aquifer.API/Endpoints/Resources/Content/MachineTranslation/Update/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/MachineTranslation/Update/Endpoint.cs
@@ -17,7 +17,9 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
     public override async Task HandleAsync(Request req, CancellationToken ct)
     {
         var user = await userService.GetUserFromJwtAsync(ct);
-        var existingMt = await dbContext.ResourceContentVersionMachineTranslations.FirstOrDefaultAsync(x => x.Id == req.Id, ct);
+        var existingMt = await dbContext.ResourceContentVersionMachineTranslations
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.Id == req.Id, ct);
 
         if (existingMt is null || existingMt.UserId != user.Id)
         {

--- a/src/Aquifer.API/Endpoints/Resources/Content/Publish/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Publish/Endpoint.cs
@@ -75,8 +75,10 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
             }
             else
             {
-                var resourceContent = await dbContext.ResourceContents.FirstOrDefaultAsync(x => x.Id == contentId, ct) ??
-                                      throw new ArgumentNullException();
+                var resourceContent = await dbContext.ResourceContents
+                    .AsTracking()
+                    .FirstOrDefaultAsync(x => x.Id == contentId, ct)
+                    ?? throw new ArgumentNullException();
                 resourceContent.Status = ResourceContentStatus.Complete;
 
                 await historyService.AddStatusHistoryAsync(mostRecentContentVersion, ResourceContentStatus.Complete, user.Id, ct);

--- a/src/Aquifer.API/Endpoints/Resources/Content/SendForManagerReview/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/SendForManagerReview/Endpoint.cs
@@ -25,6 +25,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
         ];
 
         var draftVersions = await dbContext.ResourceContentVersions
+            .AsTracking()
             .Where(x => contentIds.Contains(x.ResourceContentId) && allowedStatuses.Contains(x.ResourceContent.Status) && x.IsDraft)
             .Include(x => x.ResourceContent)
             .ThenInclude(x => x.ProjectResourceContents)
@@ -98,6 +99,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
         else
         {
             var lastAssignmentHistory = await dbContext.ResourceContentVersionAssignedUserHistory
+                .AsTracking()
                 .Where(x => x.ResourceContentVersionId == draftVersion.Id && managers.Contains(x.ChangedByUserId))
                 .OrderByDescending(x => x.Id)
                 .FirstOrDefaultAsync();

--- a/src/Aquifer.API/Endpoints/Resources/Content/SendForPublisherReview/Community/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/SendForPublisherReview/Community/Endpoint.cs
@@ -20,6 +20,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
     {
         var user = await userService.GetUserFromJwtAsync(ct);
         var contentVersion = await dbContext.ResourceContentVersions
+            .AsTracking()
             .Where(x => x.ResourceContentId == request.ContentId && x.AssignedUserId == user.Id && x.IsDraft)
             .Include(x => x.ResourceContent)
             .SingleOrDefaultAsync(ct);

--- a/src/Aquifer.API/Endpoints/Resources/Content/SendForPublisherReview/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/SendForPublisherReview/Endpoint.cs
@@ -25,6 +25,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
         ];
 
         var draftVersions = await dbContext.ResourceContentVersions
+            .AsTracking()
             .Where(x => contentIds.Contains(x.ResourceContentId) && allowedStatuses.Contains(x.ResourceContent.Status) && x.IsDraft)
             .Include(x => x.ResourceContent).ToListAsync(ct);
 

--- a/src/Aquifer.API/Endpoints/Resources/Content/Update/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Update/Endpoint.cs
@@ -20,8 +20,9 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
 
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
-        var entity = await dbContext.ResourceContentVersions.Where(x => x.IsDraft)
-            .Where(x => x.ResourceContentId == request.ContentId)
+        var entity = await dbContext.ResourceContentVersions
+            .AsTracking()
+            .Where(x => x.IsDraft && x.ResourceContentId == request.ContentId)
             .Include(x => x.ResourceContent)
             .SingleOrDefaultAsync(ct);
 

--- a/src/Aquifer.API/Endpoints/Resources/ResourceReferences/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/ResourceReferences/Create/Endpoint.cs
@@ -17,6 +17,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
         var resourceContent = await dbContext.ResourceContents
+            .AsTracking()
             .Include(rc => rc.Resource)
             .ThenInclude(r => r.AssociatedResources)
             .SingleOrDefaultAsync(rc => rc.Id == request.ResourceContentId, ct);

--- a/src/Aquifer.API/Endpoints/Resources/ResourceReferences/Delete/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/ResourceReferences/Delete/Endpoint.cs
@@ -16,6 +16,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
         var resourceContent = await dbContext.ResourceContents
+            .AsTracking()
             .Include(rc => rc.Resource)
             .ThenInclude(r => r.AssociatedResources)
             .SingleOrDefaultAsync(rc => rc.Id == request.ResourceContentId, ct);

--- a/src/Aquifer.API/Endpoints/Users/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Users/Create/Endpoint.cs
@@ -38,7 +38,9 @@ public class Endpoint(AquiferDbContext dbContext, IAuth0HttpClient authProviderS
 
     private async Task ValidateCompanyIdAsync(int companyId, CancellationToken ct)
     {
-        var newUserCompany = await dbContext.Companies.SingleOrDefaultAsync(x => x.Id == companyId, ct);
+        var newUserCompany = await dbContext.Companies
+            .AsTracking()
+            .SingleOrDefaultAsync(x => x.Id == companyId, ct);
         if (newUserCompany is null)
         {
             ThrowError(x => x.CompanyId, "Invalid company id");

--- a/src/Aquifer.API/Endpoints/Users/Disable/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Users/Disable/Endpoint.cs
@@ -5,6 +5,7 @@ using Aquifer.Common.Utilities;
 using Aquifer.Data;
 using Aquifer.Data.Entities;
 using FastEndpoints;
+using Microsoft.EntityFrameworkCore;
 
 namespace Aquifer.API.Endpoints.Users.Disable;
 
@@ -24,7 +25,9 @@ public class Endpoint(
     {
         var currentUser = await userService.GetUserFromJwtAsync(ct);
         var currentUserPermissions = userService.GetAllJwtPermissions();
-        var userToDisable = dbContext.Users.SingleOrDefault(x => x.Id == req.UserId && x.Enabled);
+        var userToDisable = dbContext.Users
+            .AsTracking()
+            .SingleOrDefault(x => x.Id == req.UserId && x.Enabled);
         if (userToDisable is null ||
             (!currentUserPermissions.Contains(PermissionName.DisableUser) && currentUser.CompanyId != userToDisable.CompanyId))
         {

--- a/src/Aquifer.API/Endpoints/Users/VerifyEmail/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Users/VerifyEmail/Endpoint.cs
@@ -25,7 +25,9 @@ public class Endpoint(AquiferDbContext dbContext, ILogger<Endpoint> logger) : En
             return;
         }
 
-        var user = await dbContext.Users.SingleOrDefaultAsync(x => x.ProviderId == req.ProviderId && x.Enabled, ct);
+        var user = await dbContext.Users
+            .AsTracking()
+            .SingleOrDefaultAsync(x => x.ProviderId == req.ProviderId && x.Enabled, ct);
         if (user is null || user.EmailVerified)
         {
             logger.LogWarning("Tried to log update email verification but no user found or already set: {providerId}", req.ProviderId);

--- a/src/Aquifer.API/Program.cs
+++ b/src/Aquifer.API/Program.cs
@@ -25,7 +25,8 @@ builder.Services.AddAuth(configuration?.JwtSettings)
     .AddSingleton<ITelemetryInitializer, RequestTelemetryInitializer>()
     .AddDbContext<AquiferDbContext>(options => options
         .UseSqlServer(configuration?.ConnectionStrings.BiblioNexusDb, providerOptions => providerOptions.EnableRetryOnFailure(3))
-        .EnableSensitiveDataLogging(sensitiveDataLoggingEnabled: builder.Environment.IsDevelopment()))
+        .EnableSensitiveDataLogging(sensitiveDataLoggingEnabled: builder.Environment.IsDevelopment())
+        .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking))
     .RegisterModules()
     .Configure<JsonOptions>(options => options.SerializerOptions.Converters.Add(new JsonStringEnumConverter()))
     .AddHttpLogging(logging =>

--- a/src/Aquifer.API/Services/ResourceHistoryService.cs
+++ b/src/Aquifer.API/Services/ResourceHistoryService.cs
@@ -67,6 +67,7 @@ public class ResourceHistoryService(AquiferDbContext _dbContext) : IResourceHist
         if (!isNew)
         {
             snapshotEntity = await _dbContext.ResourceContentVersionSnapshots
+                .AsTracking()
                 .Where(rcvn => rcvn.ResourceContentVersionId == contentVersionEntity.Id)
                 .OrderByDescending(x => x.Created).FirstOrDefaultAsync(ct);
         }

--- a/src/Aquifer.Jobs/TrackResourceContentRequestJob.cs
+++ b/src/Aquifer.Jobs/TrackResourceContentRequestJob.cs
@@ -30,7 +30,8 @@ public class TrackResourceContentRequestJob(
             }
 
             await LookupIpAddressAsync(trackingMetadata, ct);
-            await dbContext.ResourceContentRequests.AddRangeAsync(trackingMetadata.ResourceContentIds.Select(x =>
+            await dbContext.ResourceContentRequests
+                .AddRangeAsync(trackingMetadata.ResourceContentIds.Select(x =>
                     new ResourceContentRequestEntity
                     {
                         ResourceContentId = x,
@@ -61,7 +62,9 @@ public class TrackResourceContentRequestJob(
                 return;
             }
 
-            var ipDataRecord = await dbContext.IpAddressData.SingleOrDefaultAsync(x => x.IpAddress == trackingMetadata.IpAddress, ct);
+            var ipDataRecord = await dbContext.IpAddressData
+                .AsTracking()
+                .SingleOrDefaultAsync(x => x.IpAddress == trackingMetadata.IpAddress, ct);
             if (ipDataRecord is null)
             {
                 var ipData = await ipAddressClient.LookupIpAddressAsync(trackingMetadata.IpAddress, ct);

--- a/src/Aquifer.Public.API/Program.cs
+++ b/src/Aquifer.Public.API/Program.cs
@@ -12,7 +12,8 @@ var configuration = builder.Configuration.Get<ConfigurationOptions>();
 
 builder.Services.AddDbContext<AquiferDbContext>(options => options
     .UseSqlServer(configuration?.ConnectionStrings.BiblioNexusDb, providerOptions => providerOptions.EnableRetryOnFailure(3))
-    .EnableSensitiveDataLogging(sensitiveDataLoggingEnabled: builder.Environment.IsDevelopment()));
+    .EnableSensitiveDataLogging(sensitiveDataLoggingEnabled: builder.Environment.IsDevelopment())
+    .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking));
 
 builder.Services.AddFastEndpoints()
     .AddSingleton<IResourceContentRequestTrackingService, ResourceContentRequestTrackingService>()


### PR DESCRIPTION
EF tracking is on by default.  After fetching an entity from the DB, tracking incurs a performance cost in order to track updates to that entity so that the changes can be saved back to the DB when `await dbContext.SaveChangesAsync(ct)` is called.  If no save back to the DB is necessary (for read-only routes) then it is advisable to turn off tracking for that query.  See https://learn.microsoft.com/en-us/ef/core/querying/tracking and https://medium.com/@anyanwuraphaelc/benefits-of-asnotracking-in-entity-framework-core-a-guide-to-improved-performance-186ed44a5eb7.

Changes:
Public API:
* Turn off tracking globally for all EF commands; the Public API is read-only.
* 
Internal API:
* Turn off tracking globally for all EF commands.
* Add `.AsTracking()` to all write routes (Post/Put/Patch/Delete/etc.).  In some cases this required whitespace/alignment changes.

Consequences:
* If anyone tries to save changes to the `DbContext` on the Public API in future routes it will not work by default.  They can, however, use `AsTracking()` to enable it for that one query.
* Anyone working on any update route in the Internal API will need to explicitly use `AsTracking()` for any new queries.