### PR TITLE
split AssociatedResources into its own entity and add suggested indexes

### DIFF
--- a/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
@@ -52,17 +52,17 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
                         HasPublished = orc.Versions.Any(x => x.IsPublished),
                         ResourceContentStatus = orc.Status
                     }),
-                AssociatedResources = rc.Resource.AssociatedResourceChildren.Select(ar => new AssociatedContentResponse
+                AssociatedResources = rc.Resource.AssociatedResources.Select(ar => new AssociatedContentResponse
                 {
                     // Get the associated resource content for the current content's language or fallback to English
                     ResourceContent =
-                        ar.ResourceContents.Where(rci => rci.MediaType == ResourceContentMediaType.Text)
+                        ar.AssociatedResource.ResourceContents.Where(rci => rci.MediaType == ResourceContentMediaType.Text)
                             .OrderByDescending(rci =>
                                 rci.LanguageId == rc.LanguageId ? 2 : rci.LanguageId == Constants.EnglishLanguageId ? 1 : 0)
                             .FirstOrDefault(),
-                    EnglishLabel = ar.EnglishLabel,
-                    ParentResourceName = ar.ParentResource.DisplayName,
-                    MediaTypes = ar.ResourceContents.Select(arrc => arrc.MediaType)
+                    EnglishLabel = ar.AssociatedResource.EnglishLabel,
+                    ParentResourceName = ar.AssociatedResource.ParentResource.DisplayName,
+                    MediaTypes = ar.AssociatedResource.ResourceContents.Select(arrc => arrc.MediaType)
                 }),
                 ProjectEntity = rc.ProjectResourceContents.FirstOrDefault(prc => prc.ResourceContentId == request.Id) == null
                     ? null

--- a/src/Aquifer.API/Endpoints/Resources/ResourceReferences/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/ResourceReferences/Create/Endpoint.cs
@@ -1,5 +1,6 @@
 using Aquifer.API.Common;
 using Aquifer.Data;
+using Aquifer.Data.Entities;
 using FastEndpoints;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,7 +18,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
     {
         var resourceContent = await dbContext.ResourceContents
             .Include(rc => rc.Resource)
-            .ThenInclude(r => r.AssociatedResourceChildren)
+            .ThenInclude(r => r.AssociatedResources)
             .SingleOrDefaultAsync(rc => rc.Id == request.ResourceContentId, ct);
 
         if (resourceContent == null)
@@ -26,7 +27,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
             return;
         }
 
-        if (!resourceContent.Resource.AssociatedResourceChildren.Any(r => r.Id == request.ReferenceResourceId))
+        if (!resourceContent.Resource.AssociatedResources.Any(r => r.AssociatedResourceId == request.ReferenceResourceId))
         {
             var referenceResource = await dbContext.Resources.FindAsync([request.ReferenceResourceId], ct);
 
@@ -36,7 +37,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
                 return;
             }
 
-            resourceContent.Resource.AssociatedResourceChildren.Add(referenceResource);
+            resourceContent.Resource.AssociatedResources.Add(new AssociatedResourceEntity { AssociatedResource = referenceResource });
             await dbContext.SaveChangesAsync(ct);
         }
 

--- a/src/Aquifer.API/Endpoints/Resources/ResourceReferences/Delete/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/ResourceReferences/Delete/Endpoint.cs
@@ -17,7 +17,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
     {
         var resourceContent = await dbContext.ResourceContents
             .Include(rc => rc.Resource)
-            .ThenInclude(r => r.AssociatedResourceChildren)
+            .ThenInclude(r => r.AssociatedResources)
             .SingleOrDefaultAsync(rc => rc.Id == request.ResourceContentId, ct);
 
         if (resourceContent == null)
@@ -26,8 +26,8 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
             return;
         }
 
-        var associatedResource = resourceContent.Resource.AssociatedResourceChildren
-            .FirstOrDefault(r => r.Id == request.ReferenceResourceId);
+        var associatedResource = resourceContent.Resource.AssociatedResources
+            .FirstOrDefault(ar => ar.AssociatedResourceId == request.ReferenceResourceId);
 
         if (associatedResource == null)
         {
@@ -35,7 +35,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
             return;
         }
 
-        resourceContent.Resource.AssociatedResourceChildren.Remove(associatedResource);
+        dbContext.AssociatedResources.Remove(associatedResource);
 
         await dbContext.SaveChangesAsync(ct);
         await SendNoContentAsync(ct);

--- a/src/Aquifer.Data/AquiferDbContext.cs
+++ b/src/Aquifer.Data/AquiferDbContext.cs
@@ -21,6 +21,7 @@ public class AquiferDbContext : DbContext
         SavedChanges += async (s, e) => await OnSavingChanges(s, e);
     }
 
+    public DbSet<AssociatedResourceEntity> AssociatedResources { get; set; }
     public DbSet<BibleBookChapterEntity> BibleBookChapters { get; set; }
     public DbSet<BibleBookChapterVerseEntity> BibleBookChapterVerses { get; set; }
     public DbSet<BibleBookContentEntity> BibleBookContents { get; set; }

--- a/src/Aquifer.Data/Entities/AssociatedResourceEntity.cs
+++ b/src/Aquifer.Data/Entities/AssociatedResourceEntity.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Aquifer.Data.Entities;
+
+[Index(nameof(ResourceId))]
+[PrimaryKey(nameof(AssociatedResourceId), nameof(ResourceId))]
+[EntityTypeConfiguration(typeof(AssociatedResourceEntityConfiguration))]
+public class AssociatedResourceEntity
+{
+    public int ResourceId { get; set; }
+    public ResourceEntity Resource { get; set; } = null!;
+
+    public int AssociatedResourceId { get; set; }
+    public ResourceEntity AssociatedResource { get; set; } = null!;
+}
+
+public class AssociatedResourceEntityConfiguration : IEntityTypeConfiguration<AssociatedResourceEntity>
+{
+    public void Configure(EntityTypeBuilder<AssociatedResourceEntity> builder)
+    {
+        builder.HasOne(ar => ar.Resource)
+            .WithMany()
+            .HasForeignKey(ar => ar.ResourceId)
+            .OnDelete(DeleteBehavior.NoAction);
+    }
+}

--- a/src/Aquifer.Data/Migrations/20241003205330_AddSuggestedIndexesForAssociatedResourcesAndResources.Designer.cs
+++ b/src/Aquifer.Data/Migrations/20241003205330_AddSuggestedIndexesForAssociatedResourcesAndResources.Designer.cs
@@ -4,6 +4,7 @@ using Aquifer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Aquifer.Data.Migrations
 {
     [DbContext(typeof(AquiferDbContext))]
-    partial class AquiferDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241003205330_AddSuggestedIndexesForAssociatedResourcesAndResources")]
+    partial class AddSuggestedIndexesForAssociatedResourcesAndResources
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Aquifer.Data/Migrations/20241003205330_AddSuggestedIndexesForAssociatedResourcesAndResources.cs
+++ b/src/Aquifer.Data/Migrations/20241003205330_AddSuggestedIndexesForAssociatedResourcesAndResources.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Aquifer.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSuggestedIndexesForAssociatedResourcesAndResources : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Resources_ExternalId",
+                table: "Resources",
+                column: "ExternalId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AssociatedResources_ResourceId",
+                table: "AssociatedResources",
+                column: "ResourceId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Resources_ExternalId",
+                table: "Resources");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AssociatedResources_ResourceId",
+                table: "AssociatedResources");
+        }
+    }
+}


### PR DESCRIPTION
This adds an entity for associated resources as an actual entity class for more control over the `AssociatedResources` table. It does so mainly to allow Azure-suggested indexes to be added. It could potentially help improve performance as well, as we saw with EF-generated `ProjectResourceContents` queries.