### PR TITLE
Add missing indices for greek alignment query

### DIFF
--- a/src/Aquifer.Data/Entities/BibleVersionWordGroupWordEntity.cs
+++ b/src/Aquifer.Data/Entities/BibleVersionWordGroupWordEntity.cs
@@ -2,7 +2,10 @@
 using Microsoft.EntityFrameworkCore;
 
 namespace Aquifer.Data.Entities;
+
 [PrimaryKey(nameof(BibleVersionWordGroupId), nameof(BibleVersionWordId))]
+[Index(nameof(BibleVersionWordId))]
+
 public class BibleVersionWordGroupWordEntity
 {
     public int BibleVersionWordGroupId { get; set; }

--- a/src/Aquifer.Data/Migrations/20241004145335_AddMissingIndicesForGreekAlignmentQuery.Designer.cs
+++ b/src/Aquifer.Data/Migrations/20241004145335_AddMissingIndicesForGreekAlignmentQuery.Designer.cs
@@ -4,6 +4,7 @@ using Aquifer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Aquifer.Data.Migrations
 {
     [DbContext(typeof(AquiferDbContext))]
-    partial class AquiferDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241004145335_AddMissingIndicesForGreekAlignmentQuery")]
+    partial class AddMissingIndicesForGreekAlignmentQuery
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Aquifer.Data/Migrations/20241004145335_AddMissingIndicesForGreekAlignmentQuery.cs
+++ b/src/Aquifer.Data/Migrations/20241004145335_AddMissingIndicesForGreekAlignmentQuery.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Aquifer.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMissingIndicesForGreekAlignmentQuery : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_BibleVersionWordGroupWords_BibleVersionWordId",
+                table: "BibleVersionWordGroupWords",
+                column: "BibleVersionWordId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_BibleVersionWordGroupWords_BibleVersionWordId",
+                table: "BibleVersionWordGroupWords");
+        }
+    }
+}

--- a/src/Aquifer.Public.API/Endpoints/Bibles/Alignments/Greek/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Bibles/Alignments/Greek/Endpoint.cs
@@ -248,9 +248,9 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
             FROM BibleVersionWords bvw
                 LEFT JOIN BibleVersionWordGroupWords bvwgw ON bvwgw.BibleVersionWordId = bvw.Id
                 LEFT JOIN BibleVersionWordGroups bvwg ON bvwg.Id = bvwgw.BibleVersionWordGroupId
-                LEFT JOIN NewTestamentAlignments nta ON nta.BibleVersionWordGroupId = BVWG.Id
+                LEFT JOIN NewTestamentAlignments nta ON nta.BibleVersionWordGroupId = bvwg.Id
                 LEFT JOIN GreekNewTestamentWordGroups gntwg ON gntwg.Id = nta.GreekNewTestamentWordGroupId
-                LEFT JOIN GreekNewTestamentWordGroupWords gntwgw ON gntwgw.GreekNewTestamentWordGroupId = GNTWG.Id
+                LEFT JOIN GreekNewTestamentWordGroupWords gntwgw ON gntwgw.GreekNewTestamentWordGroupId = gntwg.Id
                 LEFT JOIN GreekNewTestamentWords gntw ON gntw.Id = gntwgw.GreekNewTestamentWordId
                 LEFT JOIN GreekNewTestamentWordSenses gntws ON gntws.GreekNewTestamentWordId = gntw.Id
             WHERE


### PR DESCRIPTION
Add missing index needed for [this JOIN](https://github.com/BiblioNexusStudio/aquifer-server/blob/ef30f99f626ae0db2ccb389b1c8ee3fe96760b9f/src/Aquifer.Public.API/Endpoints/Bibles/Alignments/Greek/Endpoint.cs#L249).  It will also benefit the [older endpoint](https://github.com/BiblioNexusStudio/aquifer-server/blob/ef30f99f626ae0db2ccb389b1c8ee3fe96760b9f/src/Aquifer.API/Endpoints/Bibles/Alignments/Greek/Book/Chapter/Endpoint.cs#L23).