### PR TITLE
Improve public API resource search route performance.

### DIFF
--- a/src/Aquifer.Common/Services/Caching/CachingLanguageService.cs
+++ b/src/Aquifer.Common/Services/Caching/CachingLanguageService.cs
@@ -1,0 +1,67 @@
+﻿using Aquifer.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Aquifer.Common.Services.Caching;
+
+public interface ICachingLanguageService
+{
+    Task<string?> GetLanguageCodeAsync(int languageId, CancellationToken ct);
+    Task<IReadOnlyDictionary<int, string>> GetLanguageCodeByIdMapAsync(CancellationToken ct);
+    Task<int?> GetLanguageIdAsync(string languageCode, CancellationToken ct);
+    Task<IReadOnlyDictionary<string, int>> GetLanguageIdByCodeMapAsync(CancellationToken ct);
+}
+
+public sealed class CachingLanguageService(AquiferDbContext _dbContext, IMemoryCache _memoryCache) : ICachingLanguageService
+{
+    private const string LanguageDictionariesCacheKey = $"{nameof(CachingLanguageService)}:LanguageDictionaries";
+    private static readonly TimeSpan s_cacheLifetime = TimeSpan.FromMinutes(30);
+
+    public async Task<string?> GetLanguageCodeAsync(int languageId, CancellationToken ct)
+    {
+        return (await GetLanguageCodeByIdMapAsync(ct))
+            .TryGetValue(languageId, out var languageCode)
+                ? languageCode
+                : null;
+    }
+
+    public async Task<IReadOnlyDictionary<int, string>> GetLanguageCodeByIdMapAsync(CancellationToken ct)
+    {
+        return (await GetDictionariesFromCacheAsync(ct))
+            .LanguageCodeByIdMap;
+    }
+
+    public async Task<int?> GetLanguageIdAsync(string languageCode, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(languageCode);
+
+        return (await GetLanguageIdByCodeMapAsync(ct))
+            .TryGetValue(languageCode, out var languageId)
+                ? languageId
+                : null;
+    }
+
+    public async Task<IReadOnlyDictionary<string, int>> GetLanguageIdByCodeMapAsync(CancellationToken ct)
+    {
+        return (await GetDictionariesFromCacheAsync(ct))
+            .LanguageIdByCodeMap;
+    }
+
+    private async Task<(IReadOnlyDictionary<int, string> LanguageCodeByIdMap, IReadOnlyDictionary<string, int> LanguageIdByCodeMap)>
+        GetDictionariesFromCacheAsync(CancellationToken ct)
+    {
+        return await _memoryCache.GetOrCreateAsync(
+            LanguageDictionariesCacheKey,
+            async cacheEntry =>
+            {
+                cacheEntry.SlidingExpiration = s_cacheLifetime;
+
+                var LanguageCodeById = await _dbContext.Languages
+                    .ToDictionaryAsync(li => li.Id, li => li.ISO6393Code, ct);
+
+                return
+                    (LanguageCodeById,
+                    LanguageIdByCode: LanguageCodeById.ToDictionary(li => li.Value, li => li.Key));
+            });
+    }
+}

--- a/src/Aquifer.Public.API/Endpoints/Resources/Search/GetResources/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Search/GetResources/Endpoint.cs
@@ -98,7 +98,8 @@ public class Endpoint(AquiferDbContext _dbContext, ICachingLanguageService _cach
     {
         var languageCodeByIdMap = await _cachingLanguageService.GetLanguageCodeByIdMapAsync(ct);
 
-        var resources = await query.OrderBy(x => x.ResourceContent.Resource.EnglishLabel)
+        var resources = await query
+            .OrderBy(x => x.ResourceContent.Resource.Id)
             .Skip(req.Offset)
             .Take(req.Limit)
             .Select(x => new ResponseContent

--- a/src/Aquifer.Public.API/Program.cs
+++ b/src/Aquifer.Public.API/Program.cs
@@ -4,6 +4,7 @@ using Aquifer.Common.Services;
 using Aquifer.Data;
 using Aquifer.Public.API.Configuration;
 using Aquifer.Public.API.OpenApi;
+using Aquifer.Public.API.Services;
 using FastEndpoints;
 using Microsoft.EntityFrameworkCore;
 
@@ -16,6 +17,8 @@ builder.Services.AddDbContext<AquiferDbContext>(options => options
     .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking));
 
 builder.Services.AddFastEndpoints()
+    .AddMemoryCache()
+    .AddCachingServices()
     .AddSingleton<IResourceContentRequestTrackingService, ResourceContentRequestTrackingService>()
     .AddAzureClient(builder.Environment.IsDevelopment())
     .AddSwaggerDocumentSettings()

--- a/src/Aquifer.Public.API/Services/ServiceRegistry.cs
+++ b/src/Aquifer.Public.API/Services/ServiceRegistry.cs
@@ -1,0 +1,13 @@
+﻿using Aquifer.Common.Services.Caching;
+
+namespace Aquifer.Public.API.Services;
+
+public static class ServiceRegistry
+{
+    public static IServiceCollection AddCachingServices(this IServiceCollection services)
+    {
+        services.AddScoped<ICachingLanguageService, CachingLanguageService>();
+
+        return services;
+    }
+}


### PR DESCRIPTION
This improves performance of basic query searching by a factor of 2-3.  Most of the improvement is from changing the ordering but removing the language JOIN also shaved off some time.  See comments for details on both of those.  See also https://biblionexusworkspace.slack.com/archives/C05D8BE3KUY/p1728062517872939 for some additional ideas for future improvements.

Some data from QA DB profiling.  Searching for "Christ" (https://qa.api.aquifer.bible/resources/search?languageCode=eng&query=christ&offset=0&limit=100&api-key={apiKey}) takes the following duration:
* Getting the total: 1.012 seconds
* Getting the first 100 results (there are only 31): 3.782 seconds

With these changes applied:
* Getting the total: 0.426 seconds
* Getting the first 100 results (there are only 31): 1.700 seconds