### PR TITLE
allow hotfix deploys to happen from regular hotfix Post-merge workflow

### DIFF
--- a/.github/workflows/post-merge-internal-api.yml
+++ b/.github/workflows/post-merge-internal-api.yml
@@ -63,10 +63,12 @@ jobs:
                   path: build
 
     deploy_internal_api_to_dev:
-        if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+        if: needs.check_should_deploy.outputs.should_deploy == 'true'
         name: Deploy Internal API to dev
         runs-on: ubuntu-latest
-        needs: build
+        needs:
+            - build
+            - check_should_deploy
         environment:
             name: dev-internal
             url: ${{ vars.URL_DEV }}
@@ -85,10 +87,12 @@ jobs:
                   azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     deploy_internal_api_to_qa:
-        if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+        if: needs.check_should_deploy.outputs.should_deploy == 'true'
         name: Deploy Internal API to qa
         runs-on: ubuntu-latest
-        needs: build
+        needs:
+            - build
+            - check_should_deploy
         environment:
             name: qa-internal
             url: ${{ vars.URL_QA }}
@@ -112,10 +116,12 @@ jobs:
                   service-name: Internal API
 
     deploy_internal_api_to_prod:
-        if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+        if: needs.check_should_deploy.outputs.should_deploy == 'true'
         name: Deploy Internal API to prod
         runs-on: ubuntu-latest
-        needs: build
+        needs:
+            - build
+            - check_should_deploy
         environment:
             name: prod-internal
             url: ${{ vars.URL_PROD }}

--- a/.github/workflows/post-merge-public-api.yml
+++ b/.github/workflows/post-merge-public-api.yml
@@ -63,10 +63,12 @@ jobs:
                   path: build
 
     deploy_public_api_to_dev:
-        if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+        if: needs.check_should_deploy.outputs.should_deploy == 'true'
         name: Deploy Public API to dev
         runs-on: ubuntu-latest
-        needs: build
+        needs:
+            - build
+            - check_should_deploy
         environment:
             name: dev-public
             url: ${{ vars.URL_DEV }}
@@ -85,10 +87,12 @@ jobs:
                   azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     deploy_public_api_to_qa:
-        if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+        if: needs.check_should_deploy.outputs.should_deploy == 'true'
         name: Deploy Public API to qa
         runs-on: ubuntu-latest
-        needs: build
+        needs:
+            - build
+            - check_should_deploy
         environment:
             name: qa-public
             url: ${{ vars.URL_QA }}
@@ -112,10 +116,12 @@ jobs:
                   service-name: Public API
 
     deploy_public_api_to_prod:
-        if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+        if: needs.check_should_deploy.outputs.should_deploy == 'true'
         name: Deploy Public API to prod
         runs-on: ubuntu-latest
-        needs: build
+        needs:
+            - build
+            - check_should_deploy
         environment:
             name: prod-public
             url: ${{ vars.URL_PROD }}


### PR DESCRIPTION
When a hotfix PR merges it triggers a Post-merge workflow which should allow deploying to a given
env. This was not working because the conditional logic in the deploy jobs wasn't handling the
check_should_deploy job.
