### PR TITLE
Add Dapper retry overloads.

### DIFF
--- a/Aquifer.sln
+++ b/Aquifer.sln
@@ -19,7 +19,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aquifer.Common", "src\Aquif
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aquifer.Jobs", "src\Aquifer.Jobs\Aquifer.Jobs.csproj", "{CDDA72AF-C879-4CFC-9015-B0CB4979837F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aquifer.Common.UnitTests", "Aquifer.Common.UnitTests\Aquifer.Common.UnitTests.csproj", "{93508A60-45FD-4A2E-9EFC-8D7C18259B20}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aquifer.Common.UnitTests", "Aquifer.Common.UnitTests\Aquifer.Common.UnitTests.csproj", "{93508A60-45FD-4A2E-9EFC-8D7C18259B20}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Aquifer.API/Program.cs
+++ b/src/Aquifer.API/Program.cs
@@ -55,6 +55,8 @@ builder.Services.AddOptions<ConfigurationOptions>().Bind(builder.Configuration);
 
 var app = builder.Build();
 
+StaticLoggerFactory.LoggerFactory = app.Services.GetRequiredService<ILoggerFactory>();
+
 app.UseCors(b => b.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod());
 app.UseHealthChecks("/_health");
 if (builder.Environment.IsDevelopment())

--- a/src/Aquifer.Common/Aquifer.Common.csproj
+++ b/src/Aquifer.Common/Aquifer.Common.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0"/>
         <PackageReference Include="Azure.Storage.Queues" Version="12.19.1"/>
         <PackageReference Include="FastEndpoints" Version="5.28.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"/>
         <PackageReference Include="ReverseMarkdown" Version="4.6.0"/>
         <PackageReference Include="SendGrid" Version="9.29.3"/>
         <PackageReference Include="SendGrid.Extensions.DependencyInjection" Version="1.0.1"/>

--- a/src/Aquifer.Data/Aquifer.Data.csproj
+++ b/src/Aquifer.Data/Aquifer.Data.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -7,12 +7,15 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Dapper" Version="2.1.35" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
+        <PackageReference Include="Polly" Version="8.4.2" />
+        <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     </ItemGroup>
-
 
 </Project>

--- a/src/Aquifer.Data/DapperExtensions.cs
+++ b/src/Aquifer.Data/DapperExtensions.cs
@@ -1,0 +1,252 @@
+﻿using System.ComponentModel;
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Contrib.WaitAndRetry;
+using Polly.Retry;
+
+namespace Aquifer.Data;
+
+/// <summary>
+/// Recreates Dapper extension methods with a built-in retry policy for transient errors and also
+/// provides a simplified interface for using cancellation tokens without <see cref="CommandDefinition"/>.
+/// Methods are ordered according to the original source: https://github.com/DapperLib/Dapper/blob/main/Dapper/SqlMapper.Async.cs
+/// Note that some less common Dapper extension methods are not yet reimplemented here.
+/// </summary>
+public static class DapperExtensions
+{
+    private static readonly ILogger s_logger = StaticLoggerFactory.CreateLogger(typeof(DapperExtensions));
+
+    /// <summary>
+    /// Retry up to two times but only for transient failures with logging on retry.
+    /// </summary>
+    private static readonly AsyncRetryPolicy s_retryPolicy = Policy
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        .Handle<SqlException>(SqlServerTransientExceptionDetector.ShouldRetryOn) // use the transient exception detector from EF Core
+        .Or<TimeoutException>()
+        .OrInner<Win32Exception>(SqlServerTransientExceptionDetector.ShouldRetryOn)
+#pragma warning restore EF1001 // Internal EF Core API usage.
+        .WaitAndRetryAsync(
+            Backoff.DecorrelatedJitterBackoffV2(medianFirstRetryDelay: TimeSpan.FromMilliseconds(50), retryCount: 3),
+            LogRetry);
+
+    /// <summary>
+    /// Execute a query asynchronously using Task.
+    /// </summary>
+    /// <typeparam name="T">The type of results to return.</typeparam>
+    /// <param name="cnn">The connection to query on.</param>
+    /// <param name="sql">The SQL to execute for the query.</param>
+    /// <param name="param">The parameters to pass, if any.</param>
+    /// <param name="transaction">The transaction to use, if any.</param>
+    /// <param name="commandTimeout">The command timeout (in seconds).</param>
+    /// <param name="commandType">The type of command to execute.</param>
+    /// <param name="flags">The behavior flags for this command (defaults to <see cref="CommandFlags.Buffered"/>.</param>
+    /// <param name="cancellationToken">The cancellation token, if any.</param>
+    /// <returns>
+    /// A sequence of data of <typeparamref name="T"/>; if a basic type (int, string, etc) is queried then the data from the first column is assumed, otherwise an instance is
+    /// created per row, and a direct column-name===member-name mapping is assumed (case insensitive).
+    /// </returns>
+    public static async Task<IEnumerable<T>> QueryWithRetriesAsync<T>(
+        this IDbConnection cnn,
+        string sql,
+        object? param = null,
+        IDbTransaction? transaction = null,
+        int? commandTimeout = null,
+        CommandType? commandType = null,
+        CommandFlags flags = CommandFlags.Buffered,
+        CancellationToken cancellationToken = default)
+    {
+        return await s_retryPolicy.ExecuteAsync(async () => await cnn.QueryAsync<T>(
+            new CommandDefinition(sql, param, transaction, commandTimeout, commandType, flags, cancellationToken)));
+    }
+
+    /// <summary>
+    /// Execute a single-row query asynchronously using Task.
+    /// </summary>
+    /// <typeparam name="T">The type of result to return.</typeparam>
+    /// <param name="cnn">The connection to query on.</param>
+    /// <param name="sql">The SQL to execute for the query.</param>
+    /// <param name="param">The parameters to pass, if any.</param>
+    /// <param name="transaction">The transaction to use, if any.</param>
+    /// <param name="commandTimeout">The command timeout (in seconds).</param>
+    /// <param name="commandType">The type of command to execute.</param>
+    /// <param name="flags">The behavior flags for this command (defaults to <see cref="CommandFlags.None"/>.</param>
+    /// <param name="cancellationToken">The cancellation token, if any.</param>
+    public static async Task<T> QueryFirstWithRetriesAsync<T>(
+        this IDbConnection cnn,
+        string sql,
+        object? param = null,
+        IDbTransaction? transaction = null,
+        int? commandTimeout = null,
+        CommandType? commandType = null,
+        CommandFlags flags = CommandFlags.None,
+        CancellationToken cancellationToken = default)
+    {
+        return await s_retryPolicy.ExecuteAsync(async () => await cnn.QueryFirstAsync<T>(
+            new CommandDefinition(sql, param, transaction, commandTimeout, commandType, flags, cancellationToken)));
+    }
+
+    /// <summary>
+    /// Execute a single-row query asynchronously using Task.
+    /// </summary>
+    /// <typeparam name="T">The type of result to return.</typeparam>
+    /// <param name="cnn">The connection to query on.</param>
+    /// <param name="sql">The SQL to execute for the query.</param>
+    /// <param name="param">The parameters to pass, if any.</param>
+    /// <param name="transaction">The transaction to use, if any.</param>
+    /// <param name="commandTimeout">The command timeout (in seconds).</param>
+    /// <param name="commandType">The type of command to execute.</param>
+    /// <param name="flags">The behavior flags for this command (defaults to <see cref="CommandFlags.None"/>.</param>
+    /// <param name="cancellationToken">The cancellation token, if any.</param>
+    public static async Task<T?> QueryFirstOrDefaultWithRetriesAsync<T>(
+        this IDbConnection cnn,
+        string sql,
+        object? param = null,
+        IDbTransaction? transaction = null,
+        int? commandTimeout = null,
+        CommandType? commandType = null,
+        CommandFlags flags = CommandFlags.None,
+        CancellationToken cancellationToken = default)
+    {
+        return await s_retryPolicy.ExecuteAsync(async () => await cnn.QueryFirstOrDefaultAsync<T>(
+            new CommandDefinition(sql, param, transaction, commandTimeout, commandType, flags, cancellationToken)));
+    }
+
+    /// <summary>
+    /// Execute a single-row query asynchronously using Task.
+    /// </summary>
+    /// <typeparam name="T">The type of result to return.</typeparam>
+    /// <param name="cnn">The connection to query on.</param>
+    /// <param name="sql">The SQL to execute for the query.</param>
+    /// <param name="param">The parameters to pass, if any.</param>
+    /// <param name="transaction">The transaction to use, if any.</param>
+    /// <param name="commandTimeout">The command timeout (in seconds).</param>
+    /// <param name="commandType">The type of command to execute.</param>
+    /// <param name="flags">The behavior flags for this command (defaults to <see cref="CommandFlags.None"/>.</param>
+    /// <param name="cancellationToken">The cancellation token, if any.</param>
+    public static async Task<T> QuerySingleWithRetriesAsync<T>(
+        this IDbConnection cnn,
+        string sql,
+        object? param = null,
+        IDbTransaction? transaction = null,
+        int? commandTimeout = null,
+        CommandType? commandType = null,
+        CommandFlags flags = CommandFlags.None,
+        CancellationToken cancellationToken = default)
+    {
+        return await s_retryPolicy.ExecuteAsync(async () => await cnn.QuerySingleAsync<T>(
+            new CommandDefinition(sql, param, transaction, commandTimeout, commandType, flags, cancellationToken)));
+    }
+
+    /// <summary>
+    /// Execute a single-row query asynchronously using Task.
+    /// </summary>
+    /// <typeparam name="T">The type to return.</typeparam>
+    /// <param name="cnn">The connection to query on.</param>
+    /// <param name="sql">The SQL to execute for the query.</param>
+    /// <param name="param">The parameters to pass, if any.</param>
+    /// <param name="transaction">The transaction to use, if any.</param>
+    /// <param name="commandTimeout">The command timeout (in seconds).</param>
+    /// <param name="commandType">The type of command to execute.</param>
+    /// <param name="flags">The behavior flags for this command (defaults to <see cref="CommandFlags.None"/>.</param>
+    /// <param name="cancellationToken">The cancellation token, if any.</param>
+    public static async Task<T?> QuerySingleOrDefaultWithRetriesAsync<T>(
+        this IDbConnection cnn,
+        string sql,
+        object? param = null,
+        IDbTransaction? transaction = null,
+        int? commandTimeout = null,
+        CommandType? commandType = null,
+        CommandFlags flags = CommandFlags.None,
+        CancellationToken cancellationToken = default)
+    {
+        return await s_retryPolicy.ExecuteAsync(async () => await cnn.QuerySingleOrDefaultAsync<T?>(
+            new CommandDefinition(sql, param, transaction, commandTimeout, commandType, flags, cancellationToken)));
+    }
+
+    /// <summary>
+    /// Execute a command asynchronously using Task.
+    /// </summary>
+    /// <param name="cnn">The connection to query on.</param>
+    /// <param name="sql">The SQL to execute for this query.</param>
+    /// <param name="param">The parameters to use for this query.</param>
+    /// <param name="transaction">The transaction to use for this query.</param>
+    /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
+    /// <param name="commandType">Is it a stored proc or a batch?</param>
+    /// <param name="flags">The behavior flags for this command (defaults to <see cref="CommandFlags.Buffered"/>.</param>
+    /// <param name="cancellationToken">The cancellation token, if any.</param>
+    /// <returns>The number of rows affected.</returns>
+    public static async Task<int> ExecuteWithRetriesAsync(
+        this IDbConnection cnn,
+        string sql,
+        object? param = null,
+        IDbTransaction? transaction = null,
+        int? commandTimeout = null,
+        CommandType? commandType = null,
+        CommandFlags flags = CommandFlags.Buffered,
+        CancellationToken cancellationToken = default)
+    {
+        return await s_retryPolicy.ExecuteAsync(async () => await cnn.ExecuteAsync(
+            new CommandDefinition(sql, param, transaction, commandTimeout, commandType, flags, cancellationToken)));
+    }
+
+    /// <summary>
+    /// Execute a command that returns multiple result sets, and access each in turn.
+    /// </summary>
+    /// <param name="cnn">The connection to query on.</param>
+    /// <param name="sql">The SQL to execute for this query.</param>
+    /// <param name="param">The parameters to use for this query.</param>
+    /// <param name="transaction">The transaction to use for this query.</param>
+    /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
+    /// <param name="commandType">Is it a stored proc or a batch?</param>
+    /// <param name="flags">The behavior flags for this command (defaults to <see cref="CommandFlags.Buffered"/>.</param>
+    /// <param name="cancellationToken">The cancellation token, if any.</param>
+    public static async Task<SqlMapper.GridReader> QueryMultipleWithRetriesAsync(
+        this IDbConnection cnn,
+        string sql,
+        object? param = null,
+        IDbTransaction? transaction = null,
+        int? commandTimeout = null,
+        CommandType? commandType = null,
+        CommandFlags flags = CommandFlags.Buffered,
+        CancellationToken cancellationToken = default)
+    {
+        return await s_retryPolicy.ExecuteAsync(async () => await cnn.QueryMultipleAsync(
+            new CommandDefinition(sql, param, transaction, commandTimeout, commandType, flags, cancellationToken)));
+    }
+
+    /// <summary>
+    /// Execute parameterized SQL that selects a single value.
+    /// </summary>
+    /// <typeparam name="T">The type to return.</typeparam>
+    /// <param name="cnn">The connection to execute on.</param>
+    /// <param name="sql">The SQL to execute.</param>
+    /// <param name="param">The parameters to use for this command.</param>
+    /// <param name="transaction">The transaction to use for this command.</param>
+    /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
+    /// <param name="commandType">Is it a stored proc or a batch?</param>
+    /// <param name="flags">The behavior flags for this command (defaults to <see cref="CommandFlags.Buffered"/>.</param>
+    /// <param name="cancellationToken">The cancellation token, if any.</param>
+    /// <returns>The first cell returned, as <typeparamref name="T"/>.</returns>
+    public static async Task<T?> ExecuteScalarWithRetriesAsync<T>(
+        this IDbConnection cnn,
+        string sql,
+        object? param = null,
+        IDbTransaction? transaction = null,
+        int? commandTimeout = null,
+        CommandType? commandType = null,
+        CommandFlags flags = CommandFlags.Buffered,
+        CancellationToken cancellationToken = default)
+    {
+        return await s_retryPolicy.ExecuteAsync(async () => await cnn.ExecuteScalarAsync<T>(
+            new CommandDefinition(sql, param, transaction, commandTimeout, commandType, flags, cancellationToken)));
+    }
+
+    private static void LogRetry(Exception exception, TimeSpan retryAfter, int retryCount, Context context)
+    {
+        s_logger.LogWarning(exception, "Gracefully handled a transient error during a Dapper DB operation. Retry after: {retryAfter}. Retry attempt: {retryCount}.", retryAfter, retryCount);
+    }
+}

--- a/src/Aquifer.Data/StaticLoggerFactory.cs
+++ b/src/Aquifer.Data/StaticLoggerFactory.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Aquifer.Data;
+
+/// <summary>
+/// Use only for logging in a static context where Dependency Injection is not possible.
+/// For non-static inject an <see cref="ILogger"/>.
+/// </summary>
+/// <example>
+/// public static class ExampleClass
+/// {
+///     private static readonly ILogger s_logger = StaticLoggerFactory.CreateLogger(typeof(ExampleClass));
+/// }
+/// </example>
+public static class StaticLoggerFactory
+{
+    private static ILoggerFactory? s_loggerFactory;
+
+    public static ILoggerFactory LoggerFactory
+    {
+        private get => s_loggerFactory ?? throw new InvalidOperationException($"{nameof(LoggerFactory)} must be initialized on app startup before accessing.");
+        set => s_loggerFactory = value;
+    }
+
+    public static ILogger CreateLogger<T>()
+    {
+        return LoggerFactory.CreateLogger<T>();
+    }
+
+    public static ILogger CreateLogger(string categoryName)
+    {
+        return LoggerFactory.CreateLogger(categoryName);
+    }
+
+    public static ILogger CreateLogger(Type type)
+    {
+        return LoggerFactory.CreateLogger(type);
+    }
+}

--- a/src/Aquifer.Public.API/Aquifer.Public.API.csproj
+++ b/src/Aquifer.Public.API/Aquifer.Public.API.csproj
@@ -12,7 +12,6 @@
 
     <ItemGroup>
         <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
-        <PackageReference Include="Dapper" Version="2.1.35" />
         <PackageReference Include="FastEndpoints" Version="5.28.0" />
         <PackageReference Include="FastEndpoints.Swagger" Version="5.28.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />

--- a/src/Aquifer.Public.API/Endpoints/Bibles/Alignments/Greek/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Bibles/Alignments/Greek/Endpoint.cs
@@ -266,16 +266,15 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
                 gntws.GreekSenseId
             """;
 
-        return (await dbConnection.QueryAsync<BibleTextWithGreekAlignmentForeignKeysResult>(
-                new CommandDefinition(
-                    bibleTextWithGreekAlignmentForeignKeysQuery,
-                    new
-                    {
-                        bibleId,
-                        lowerBounds = textLowerBounds.WordIdentifier,
-                        upperBounds = textUpperBounds.WordIdentifier,
-                    },
-                    cancellationToken: ct)))
+        return (await dbConnection.QueryWithRetriesAsync<BibleTextWithGreekAlignmentForeignKeysResult>(
+                bibleTextWithGreekAlignmentForeignKeysQuery,
+                new
+                {
+                    bibleId,
+                    lowerBounds = textLowerBounds.WordIdentifier,
+                    upperBounds = textUpperBounds.WordIdentifier,
+                },
+                cancellationToken: ct))
             .ToList();
     }
 
@@ -316,14 +315,13 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
         foreach (var batch in greekWordIds.Distinct().Order().Chunk(size: SqlParameterBatchSize))
         {
             greekWordResults.AddRange(
-                await dbConnection.QueryAsync<GreekWordResult>(
-                    new CommandDefinition(
-                        greekWordsQuery,
-                        new
-                        {
-                            greekWordIds = batch
-                        },
-                        cancellationToken: ct)));
+                await dbConnection.QueryWithRetriesAsync<GreekWordResult>(
+                    greekWordsQuery,
+                    new
+                    {
+                        greekWordIds = batch
+                    },
+                    cancellationToken: ct));
         }
 
         return greekWordResults
@@ -360,14 +358,13 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
         foreach (var batch in greekSenseIds.Distinct().Order().Chunk(size: SqlParameterBatchSize))
         {
             greekSenseResults.AddRange(
-                await dbConnection.QueryAsync<GreekSenseResult>(
-                    new CommandDefinition(
-                        greekSensesQuery,
-                        new
-                        {
-                            greekSenseIds = batch
-                        },
-                        cancellationToken: ct)));
+                await dbConnection.QueryWithRetriesAsync<GreekSenseResult>(
+                    greekSensesQuery,
+                    new
+                    {
+                        greekSenseIds = batch
+                    },
+                    cancellationToken: ct));
         }
 
         return new Dictionary<int, IReadOnlyList<GreekSenseResult>>(

--- a/src/Aquifer.Public.API/Program.cs
+++ b/src/Aquifer.Public.API/Program.cs
@@ -30,6 +30,9 @@ builder.Services.AddFastEndpoints()
 builder.Services.AddOptions<ConfigurationOptions>().Bind(builder.Configuration);
 
 var app = builder.Build();
+
+StaticLoggerFactory.LoggerFactory = app.Services.GetRequiredService<ILoggerFactory>();
+
 app.UseHealthChecks("/_health")
     .UseResponseCaching()
     .UseOutputCache()


### PR DESCRIPTION
Dapper doesn't build in automatic retries.  This PR adds new "WithRetries" extension methods that we should use instead of the primary Dapper extension methods.  The new methods use the EF Core transient SQL Exception detection and Polly to trigger retries.