### PR TITLE
Pass in same DbConnection.

### DIFF
--- a/src/Aquifer.Public.API/Endpoints/Bibles/Alignments/Greek/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Bibles/Alignments/Greek/Endpoint.cs
@@ -36,8 +36,10 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
             return;
         }
 
+        var dbConnection = dbContext.Database.GetDbConnection();
+
         var greekAlignmentNewTestamentName = await GetAssociatedGreekAlignmentNewTestamentNameForBibleAsync(
-            dbContext.Database.GetDbConnection(),
+            dbConnection,
             request.BibleId,
             ct);
 
@@ -48,20 +50,20 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
         }
 
         var bibleText = await GetBibleTextAsync(
-            dbContext.Database.GetDbConnection(),
+            dbConnection,
             request.BibleId,
             textLowerBounds: new BibleWordIdentifier(bookId, request.StartChapter, request.StartVerse, request.StartWord),
             textUpperBounds: BibleWordIdentifier.GetUpperBoundOfWord(bookId, request.EndChapter, request.EndVerse, request.EndWord),
             ct);
 
         var greekWordResultByIdMap = await GetGreekWordResultByGreekWordIdMapAsync(
-            dbContext.Database.GetDbConnection(),
+            dbConnection,
             bibleText.Where(bt => bt.GreekWordId is not null).Select(r => r.GreekWordId!.Value),
             ct);
 
         var greekSenseResultsByIdMap = request.ShouldReturnSenseData
             ? await GetGreekSenseResultsByGreekSenseIdMapAsync(
-                dbContext.Database.GetDbConnection(),
+                dbConnection,
                 bibleText.Where(bt => bt.GreekSenseId is not null).Select(r => r.GreekSenseId!.Value),
                 ct)
             : null;


### PR DESCRIPTION
I don't think this will change functionality because EF should have only a single open `DbConnection` per instantiation of a `DbContext`.  That said, this is more clear, it avoids a method call into the EF stack, and it enables an easier future refactor to open connections manually outside of EF.