### PR TITLE
Use manual swagger tagging in order to get more control over route groupings.

### DIFF
--- a/src/Aquifer.Public.API/Endpoints/Bibles/Alignments/Greek/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Bibles/Alignments/Greek/Endpoint.cs
@@ -15,10 +15,13 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
     {
         Get("/bibles/{BibleId}/alignments/greek");
         Options(EndpointHelpers.UnauthenticatedServerCacheInSeconds(EndpointHelpers.OneHourInSeconds));
-        Description(d => d.ProducesProblemFE());
+        Description(d => d
+            .WithTags("Bibles")
+            .ProducesProblemFE()
+            .ProducesProblemFE(404));
         Summary(s =>
         {
-            s.Summary = "Gets a Bible's Greek alignment information.";
+            s.Summary = "Get a Bible's Greek alignment information.";
             s.Description =
                 "For a given Bible and book of the Bible, returns the Bible's text along with associated Greek alignment information and Greek sense data for each verse, similar to a reverse interlinear Bible. Data is returned for all verses within the chapter and verse parameters.";
         });

--- a/src/Aquifer.Public.API/Endpoints/Bibles/Books/List/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Bibles/Books/List/Endpoint.cs
@@ -10,7 +10,7 @@ public class Endpoint : EndpointWithoutRequest<IEnumerable<Response>>
     {
         Get("/bibles/books");
         Options(EndpointHelpers.UnauthenticatedServerCacheInSeconds(EndpointHelpers.OneHourInSeconds));
-
+        Description(x => x.WithTags("Bibles"));
         Summary(s =>
         {
             s.Summary = "Get a list of Bible books.";

--- a/src/Aquifer.Public.API/Endpoints/Bibles/List/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Bibles/List/Endpoint.cs
@@ -9,7 +9,9 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IReadOnlyL
     public override void Configure()
     {
         Get("/bibles");
-        Description(d => d.ProducesProblemFE());
+        Description(d => d
+            .WithTags("Bibles")
+            .ProducesProblemFE());
         Summary(s =>
         {
             s.Summary = "Get a list of Bibles.";

--- a/src/Aquifer.Public.API/Endpoints/Bibles/Texts/Get/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Bibles/Texts/Get/Endpoint.cs
@@ -11,10 +11,13 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
     public override void Configure()
     {
         Get("/bibles/{BibleId}/texts");
-        Description(d => d.ProducesProblemFE());
+        Description(d => d
+            .WithTags("Bibles")
+            .ProducesProblemFE()
+            .ProducesProblemFE(404));
         Summary(s =>
         {
-            s.Summary = "Gets the Bible text contained within a book of the Bible.";
+            s.Summary = "Get the Bible text contained within a book of the Bible.";
             s.Description =
                 "For a given Bible and book of the Bible, returns the Bible text (and optional audio information if available) for all verses within the chapter and verse parameters.";
         });

--- a/src/Aquifer.Public.API/Endpoints/Languages/AvailableResources/List/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Languages/AvailableResources/List/Endpoint.cs
@@ -12,9 +12,12 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, List<Respo
     {
         Get("/languages/available-resources");
         Options(EndpointHelpers.UnauthenticatedServerCacheInSeconds(EndpointHelpers.TenMinutesInSeconds));
+        Description(d => d
+            .ProducesProblemFE()
+            .WithTags("Languages"));
         Summary(s =>
         {
-            s.Summary = "Get count of resource types per language";
+            s.Summary = "Get count of resource types per language.";
             s.Description =
                 "For a given range, get a count of resources available per language and type.";
         });

--- a/src/Aquifer.Public.API/Endpoints/Languages/List/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Languages/List/Endpoint.cs
@@ -11,9 +11,10 @@ public class Endpoint(AquiferDbContext dbContext) : EndpointWithoutRequest<List<
     {
         Get("/languages");
         Options(EndpointHelpers.UnauthenticatedServerCacheInSeconds(EndpointHelpers.OneHourInSeconds));
+        Description(d => d.WithTags("Languages"));
         Summary(s =>
         {
-            s.Summary = "Return language list";
+            s.Summary = "Return language list.";
             s.Description = "Return a list of languages that can have associated resources in the Aquifer.";
         });
     }

--- a/src/Aquifer.Public.API/Endpoints/Resources/Collections/Get/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Collections/Get/Endpoint.cs
@@ -16,9 +16,13 @@ public sealed class Endpoint(AquiferDbContext _dbContext, ICachingLanguageServic
     {
         Get("/resources/collections/{code}");
         Options(EndpointHelpers.UnauthenticatedServerCacheInSeconds(EndpointHelpers.OneHourInSeconds));
+        Description(d => d
+            .WithTags("Resources/Collections")
+            .ProducesProblemFE()
+            .ProducesProblemFE(404));
         Summary(s =>
         {
-            s.Summary = "Gets a resource collection with language localization data for the given collection code.";
+            s.Summary = "Get a resource collection with language localization data for the given collection code.";
             s.Description =
                 "Returns the resource collection matching the collection code including the count of resource items in each available language.";
         });

--- a/src/Aquifer.Public.API/Endpoints/Resources/Collections/List/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Collections/List/Endpoint.cs
@@ -13,9 +13,12 @@ public sealed class Endpoint(AquiferDbContext _dbContext)
     {
         Get("/resources/collections");
         Options(EndpointHelpers.UnauthenticatedServerCacheInSeconds(EndpointHelpers.OneHourInSeconds));
+        Description(d => d
+            .WithTags("Resources/Collections")
+            .ProducesProblemFE());
         Summary(s =>
         {
-            s.Summary = "Gets a list of resource collections.";
+            s.Summary = "Get a list of resource collections.";
             s.Description =
                 "Returns summary data for all resource collections, optionally filtering by resource type.  Note that additional collection information can be retrieved via the individual GET route.";
         });

--- a/src/Aquifer.Public.API/Endpoints/Resources/Get/AvailableLanguages/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Get/AvailableLanguages/Endpoint.cs
@@ -9,7 +9,9 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IEnumerabl
     public override void Configure()
     {
         Get("/resources/{ContentId}/available-languages");
-        Description(d => d.ProducesProblemFE(404));
+        Description(d => d
+            .WithTags("Resources")
+            .ProducesProblemFE(404));
         Summary(s =>
         {
             s.Summary = "For a given resource content id, see in what other languages it is available.";

--- a/src/Aquifer.Public.API/Endpoints/Resources/Get/ByLanguage/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Get/ByLanguage/Endpoint.cs
@@ -9,7 +9,10 @@ public class Endpoint(AquiferDbContext dbContext, IResourceContentRequestTrackin
     public override void Configure()
     {
         Get("/resources/{ContentId}/by-language/{LanguageCode}");
-        Description(d => d.ProducesProblemFE(404));
+        Description(d => d
+            .WithTags("Resources")
+            .ProducesProblemFE()
+            .ProducesProblemFE(404));
         Summary(s =>
         {
             s.Summary = "Get specific resource information by a different language.";

--- a/src/Aquifer.Public.API/Endpoints/Resources/Get/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Get/Endpoint.cs
@@ -9,7 +9,10 @@ public class Endpoint(AquiferDbContext dbContext, IResourceContentRequestTrackin
     public override void Configure()
     {
         Get("/resources/{ContentId}");
-        Description(d => d.ProducesProblemFE(404));
+        Description(d => d
+            .WithTags("Resources")
+            .ProducesProblemFE()
+            .ProducesProblemFE(404));
         Summary(s =>
         {
             s.Summary = "Get specific resource information.";

--- a/src/Aquifer.Public.API/Endpoints/Resources/Search/GetResources/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Search/GetResources/Endpoint.cs
@@ -14,6 +14,9 @@ public class Endpoint(AquiferDbContext _dbContext, ICachingLanguageService _cach
     {
         Get("/resources/search");
         Options(EndpointHelpers.UnauthenticatedServerCacheInSeconds(EndpointHelpers.TenMinutesInSeconds));
+        Description(d => d
+            .WithTags("Resources")
+            .ProducesProblemFE());
         Summary(s =>
         {
             s.Summary = "Search resources by keyword query, passage, resource type or collection code, or a combination of the above.";

--- a/src/Aquifer.Public.API/Endpoints/Resources/Types/List/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Types/List/Endpoint.cs
@@ -14,6 +14,7 @@ public class Endpoint(AquiferDbContext dbContext) : EndpointWithoutRequest<List<
     {
         Get("/resources/types");
         Options(EndpointHelpers.UnauthenticatedServerCacheInSeconds(EndpointHelpers.TenMinutesInSeconds));
+        Description(d => d.WithTags("Resources/Types"));
         Summary(s =>
         {
             s.Summary = "Get a list of available resource types and collections.";

--- a/src/Aquifer.Public.API/Endpoints/Resources/Updates/List/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Updates/List/Endpoint.cs
@@ -9,10 +9,12 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
     public override void Configure()
     {
         Get("/resources/updates");
-        Description(d => d.ProducesProblemFE());
+        Description(d => d
+            .WithTags("Resources")
+            .ProducesProblemFE());
         Summary(s =>
         {
-            s.Summary = "Get resource ids that are new or updated since the given UTC timestamp";
+            s.Summary = "Get resource ids that are new or updated since the given UTC timestamp.";
             s.Description =
                 "For a given UTC timestamp and optional language id, get a list of resource ids that are new or have been updated since the provided timestamp. This is intended for users who are storing Aquifer data locally and want to fetch new content.";
         });

--- a/src/Aquifer.Public.API/OpenApi/SwaggerDocumentSettings.cs
+++ b/src/Aquifer.Public.API/OpenApi/SwaggerDocumentSettings.cs
@@ -10,6 +10,9 @@ public static class SwaggerDocumentSettings
     {
         return service.SwaggerDocument(sd =>
         {
+            // turn off auto-grouping (but now must manually tag each endpoint using `WithTags()`)
+            sd.AutoTagPathSegmentIndex = 0;
+
             sd.ShortSchemaNames = true;
             sd.EnableJWTBearerAuth = false;
             sd.EndpointFilter = ep => ep.EndpointTags?.Contains(EndpointHelpers.EndpointTags.ExcludeFromSwaggerDocument) != true;
@@ -39,6 +42,8 @@ public static class SwaggerDocumentSettings
                                   title of the collection to which it belongs is "Bible Dictionary (Tyndale)", and the resource type
                                   is "Dictionary".
                                   """;
+                td["Resources/Collections"] = "Endpoints for retrieving collections of resources.";
+                td["Resources/Types"] = "Endpoints for retrieving the different types of resource collections and resources.";
                 td["Languages"] = "Endpoints for pulling data specific to languages.";
                 td["Bibles"] = "Endpoints for discovering available Bibles and pulling down Bible text and audio information.";
             };


### PR DESCRIPTION
The Resources/Collections and Resources/Types sub-groups are now grouped together using manual swagger tags.  I also addressed missing response status code documentation and made naming and punctuation consistent on the endpoint summaries.

Nested groups are [supported in Redocly](https://redocly.com/docs/developer-portal/configuration/sidebar-nav#groups) but [FastEndpoints doesn't support them](https://fast-endpoints.com/docs/swagger-support#swagger-operation-tags).  Swagger only supports hierarchical groups via a plugin but NSwag doesn't allow supplying that plugin (yet): https://github.com/RicoSuter/NSwag/issues/4921 is addressed.