### PR TITLE
Use Directory.Build.props files for solution wide project settings.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -258,9 +258,6 @@ resharper_csharp_continuous_indent_multiplier = 1
 resharper_csharp_max_invocation_arguments_on_line = 6
 resharper_csharp_wrap_list_pattern = chop_if_long
 
-[src/Aquifer.Data/Migrations/*.cs]
-generated_code = true
-
 [*.{cs,vb}]
 dotnet_style_coalesce_expression = true:error
 dotnet_style_null_propagation = true:error
@@ -272,4 +269,3 @@ dotnet_style_operator_placement_when_wrapping = beginning_of_line
 dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
 tab_width = 4
 indent_size = 4
-end_of_line = crlf

--- a/.editorconfig
+++ b/.editorconfig
@@ -102,12 +102,12 @@ csharp_style_var_when_type_is_apparent = true:suggestion
 
 # Expression-bodied members
 csharp_style_expression_bodied_accessors = true:suggestion
-csharp_style_expression_bodied_constructors = false
+csharp_style_expression_bodied_constructors = false:silent
 csharp_style_expression_bodied_indexers = true:suggestion
 csharp_style_expression_bodied_lambdas = true:suggestion
-csharp_style_expression_bodied_local_functions = false
-csharp_style_expression_bodied_methods = false
-csharp_style_expression_bodied_operators = false
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_operators = false:silent
 csharp_style_expression_bodied_properties = true:suggestion
 
 # Pattern matching preferences
@@ -128,8 +128,8 @@ csharp_style_prefer_readonly_struct = true
 csharp_style_prefer_readonly_struct_member = true
 
 # Code-block preferences
-csharp_prefer_braces = true
-csharp_prefer_simple_using_statement = true
+csharp_prefer_braces = true:silent
+csharp_prefer_simple_using_statement = true:suggestion
 csharp_style_namespace_declarations = file_scoped:error
 csharp_style_prefer_method_group_conversion = true:suggestion
 csharp_style_prefer_top_level_statements = true:error
@@ -260,3 +260,16 @@ resharper_csharp_wrap_list_pattern = chop_if_long
 
 [src/Aquifer.Data/Migrations/*.cs]
 generated_code = true
+
+[*.{cs,vb}]
+dotnet_style_coalesce_expression = true:error
+dotnet_style_null_propagation = true:error
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:silent
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -102,12 +102,12 @@ csharp_style_var_when_type_is_apparent = true:suggestion
 
 # Expression-bodied members
 csharp_style_expression_bodied_accessors = true:suggestion
-csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_constructors = false
 csharp_style_expression_bodied_indexers = true:suggestion
 csharp_style_expression_bodied_lambdas = true:suggestion
-csharp_style_expression_bodied_local_functions = false:silent
-csharp_style_expression_bodied_methods = false:silent
-csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_local_functions = false
+csharp_style_expression_bodied_methods = false
+csharp_style_expression_bodied_operators = false
 csharp_style_expression_bodied_properties = true:suggestion
 
 # Pattern matching preferences
@@ -128,7 +128,7 @@ csharp_style_prefer_readonly_struct = true
 csharp_style_prefer_readonly_struct_member = true
 
 # Code-block preferences
-csharp_prefer_braces = true:silent
+csharp_prefer_braces = true
 csharp_prefer_simple_using_statement = true:suggestion
 csharp_style_namespace_declarations = file_scoped:error
 csharp_style_prefer_method_group_conversion = true:suggestion
@@ -265,11 +265,11 @@ generated_code = true
 dotnet_style_coalesce_expression = true:error
 dotnet_style_null_propagation = true:error
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_auto_properties = true
 dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:silent
+dotnet_style_collection_initializer = true
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
 tab_width = 4
 indent_size = 4
 end_of_line = crlf
-dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion

--- a/Aquifer.sln
+++ b/Aquifer.sln
@@ -6,6 +6,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{795E7203-D40F-4962-837D-DD39BAF2C930}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{51DD9DE3-DA20-4C0B-82D6-029445F6BD42}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Directory.Build.props = tests\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aquifer.API", "src\Aquifer.API\Aquifer.API.csproj", "{831A381B-68CF-4ED8-A5FC-FD2A4D94F18B}"
 EndProject
@@ -19,9 +22,22 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aquifer.Common", "src\Aquif
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aquifer.Jobs", "src\Aquifer.Jobs\Aquifer.Jobs.csproj", "{CDDA72AF-C879-4CFC-9015-B0CB4979837F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aquifer.Public.API.UnitTests", "tests\Aquifer.Public.API.UnitTests\Aquifer.Public.API.UnitTests.csproj", "{54472F2B-2D3F-4985-BE86-550B4C584CB3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aquifer.Public.API.UnitTests", "tests\Aquifer.Public.API.UnitTests\Aquifer.Public.API.UnitTests.csproj", "{54472F2B-2D3F-4985-BE86-550B4C584CB3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aquifer.Common.UnitTests", "tests\Aquifer.Common.UnitTests\Aquifer.Common.UnitTests.csproj", "{8ECBEB0B-4575-486E-9B9F-4CAC0A1EE2D5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{180F25DB-77E1-47DA-B532-B40736EBFD15}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitignore = .gitignore
+		Directory.Build.props = Directory.Build.props
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{A58E5204-2BD0-4AE8-936B-70F707A66F21}"
+	ProjectSection(SolutionItems) = preProject
+		docs\infrastructure.md = docs\infrastructure.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -74,6 +90,7 @@ Global
 		{CDDA72AF-C879-4CFC-9015-B0CB4979837F} = {795E7203-D40F-4962-837D-DD39BAF2C930}
 		{54472F2B-2D3F-4985-BE86-550B4C584CB3} = {51DD9DE3-DA20-4C0B-82D6-029445F6BD42}
 		{8ECBEB0B-4575-486E-9B9F-4CAC0A1EE2D5} = {51DD9DE3-DA20-4C0B-82D6-029445F6BD42}
+		{A58E5204-2BD0-4AE8-936B-70F707A66F21} = {180F25DB-77E1-47DA-B532-B40736EBFD15}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8E32492B-EA66-40E4-A7A8-67E4ABA14A53}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,20 @@
+<Project>
+
+    <PropertyGroup>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <GitHubOrganization>BiblioNexusStudio</GitHubOrganization>
+        <RepositoryName>aquifer-server</RepositoryName>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <RepositoryUrl>https://github.com/$(GitHubOrganization)/$(RepositoryName).git</RepositoryUrl>
+        <Authors>BiblioNexus</Authors>
+        <Copyright>Copyright $(Authors)</Copyright>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>false</IsTestProject>
+    </PropertyGroup>
+
+</Project>

--- a/src/Aquifer.API/Aquifer.API.csproj
+++ b/src/Aquifer.API/Aquifer.API.csproj
@@ -2,11 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-        <WarningsAsErrors>true</WarningsAsErrors>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Aquifer.API/Endpoints/Resources/Content/GeneralReportingSummary/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/GeneralReportingSummary/Endpoint.cs
@@ -94,7 +94,9 @@ public class Endpoint(AquiferDbContext dbContext) : EndpointWithoutRequest<Respo
         // Must iterate twice with current setup (i.e. don't call ToList)
         var parentResourcesByGroup = resourcesByParentResource.GroupBy(x => x.ParentResourceName);
 
+#pragma warning disable CA1851 // Possible multiple enumerations of IEnumerable collection
         foreach (var resourceGroup in parentResourcesByGroup)
+#pragma warning restore CA1851
         {
             foreach (var date in lastFiveMonths)
             {
@@ -114,7 +116,9 @@ public class Endpoint(AquiferDbContext dbContext) : EndpointWithoutRequest<Respo
         // exits the foreach. So moving this into the one above does not work.
         // I'm sure there's some way to get it done in one loop, but not
         // worrying about it right now.
+#pragma warning disable CA1851 // Possible multiple enumerations of IEnumerable collection
         foreach (var resourceGroup in parentResourcesByGroup)
+#pragma warning restore CA1851
         {
             var orderedGroup = resourceGroup.OrderBy(x => x.Date).ToList();
             for (var i = 1; i < orderedGroup.Count; i++)
@@ -159,7 +163,9 @@ public class Endpoint(AquiferDbContext dbContext) : EndpointWithoutRequest<Respo
             }
         }
 
+#pragma warning disable CA1851 // Possible multiple enumerations of IEnumerable collection
         foreach (var resourceGroup in resourceLanguagesByGroup)
+#pragma warning restore CA1851
         {
             foreach (var date in lastFiveMonths)
             {
@@ -176,7 +182,9 @@ public class Endpoint(AquiferDbContext dbContext) : EndpointWithoutRequest<Respo
             }
         }
 
+#pragma warning disable CA1851 // Possible multiple enumerations of IEnumerable collection
         foreach (var resourceGroup in resourceLanguagesByGroup)
+#pragma warning restore CA1851
         {
             var orderedGroup = resourceGroup.OrderBy(x => x.Date).ToList();
             for (var i = 1; i < orderedGroup.Count; i++)

--- a/src/Aquifer.Common/Aquifer.Common.csproj
+++ b/src/Aquifer.Common/Aquifer.Common.csproj
@@ -2,8 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Aquifer.Common/Middleware/ResponseCachingVaryByAllQueryKeys.cs
+++ b/src/Aquifer.Common/Middleware/ResponseCachingVaryByAllQueryKeys.cs
@@ -12,15 +12,8 @@ public static class ResponseCachingVaryByAllQueryKeysExtensions
     }
 }
 
-public class ResponseCachingVaryByAllQueryKeysMiddleware
+public class ResponseCachingVaryByAllQueryKeysMiddleware(RequestDelegate _next)
 {
-    private readonly RequestDelegate _next;
-
-    public ResponseCachingVaryByAllQueryKeysMiddleware(RequestDelegate next)
-    {
-        _next = next;
-    }
-
     public async Task InvokeAsync(HttpContext context)
     {
         context.Features.Set<IResponseCachingFeature>(new ResponseCachingFeature

--- a/src/Aquifer.Data/Aquifer.Data.csproj
+++ b/src/Aquifer.Data/Aquifer.Data.csproj
@@ -2,8 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Aquifer.Data/Entities/BibleVersionWordEntity.cs
+++ b/src/Aquifer.Data/Entities/BibleVersionWordEntity.cs
@@ -22,5 +22,5 @@ public class BibleVersionWordEntity : IHasUpdatedTimestamp
 
     public BibleEntity Bible { get; set; } = null!;
 
-    public ICollection<BibleVersionWordGroupWordEntity> BibleVersionWordGroupWords { get; set; } = new List<BibleVersionWordGroupWordEntity>();
+    public ICollection<BibleVersionWordGroupWordEntity> BibleVersionWordGroupWords { get; set; } = [];
 }

--- a/src/Aquifer.Data/Entities/BibleVersionWordGroupEntity.cs
+++ b/src/Aquifer.Data/Entities/BibleVersionWordGroupEntity.cs
@@ -7,6 +7,6 @@ public class BibleVersionWordGroupEntity
     [SqlDefaultValue("getutcdate()")]
     public DateTime Created { get; set; } = DateTime.UtcNow;
 
-    public ICollection<NewTestamentAlignmentEntity> NewTestamentAlignments { get; set; } = new List<NewTestamentAlignmentEntity>();
-    public ICollection<BibleVersionWordGroupWordEntity> BibleVersionWordGroupWords { get; set; } = new List<BibleVersionWordGroupWordEntity>();
+    public ICollection<NewTestamentAlignmentEntity> NewTestamentAlignments { get; set; } = [];
+    public ICollection<BibleVersionWordGroupWordEntity> BibleVersionWordGroupWords { get; set; } = [];
 }

--- a/src/Aquifer.Data/Entities/GreekLemmaEntity.cs
+++ b/src/Aquifer.Data/Entities/GreekLemmaEntity.cs
@@ -13,6 +13,6 @@ public class GreekLemmaEntity : IHasUpdatedTimestamp
     [SqlDefaultValue("getutcdate()")]
     public DateTime Updated { get; set; } = DateTime.UtcNow;
 
-    public ICollection<GreekWordEntity> GreekWords { get; set; } = new List<GreekWordEntity>();
+    public ICollection<GreekWordEntity> GreekWords { get; set; } = [];
     public StrongNumberEntity StrongNumber { get; set; } = null!;
 }

--- a/src/Aquifer.Data/Entities/GreekNewTestamentEntity.cs
+++ b/src/Aquifer.Data/Entities/GreekNewTestamentEntity.cs
@@ -13,5 +13,5 @@ public class GreekNewTestamentEntity : IHasUpdatedTimestamp
     [SqlDefaultValue("getutcdate()")]
     public DateTime Updated { get; set; } = DateTime.UtcNow;
 
-    public ICollection<GreekNewTestamentWordEntity> GreekNewTestamentWords { get; set; } = new List<GreekNewTestamentWordEntity>();
+    public ICollection<GreekNewTestamentWordEntity> GreekNewTestamentWords { get; set; } = [];
 }

--- a/src/Aquifer.Data/Entities/GreekNewTestamentWordEntity.cs
+++ b/src/Aquifer.Data/Entities/GreekNewTestamentWordEntity.cs
@@ -22,9 +22,7 @@ public class GreekNewTestamentWordEntity : IHasUpdatedTimestamp
     public GreekWordEntity GreekWord { get; set; } = null!;
     public GreekNewTestamentEntity GreekNewTestament { get; set; } = null!;
 
-    public ICollection<GreekNewTestamentWordGroupWordEntity> GreekNewTestamentWordGroupWords { get; set; } =
-        new List<GreekNewTestamentWordGroupWordEntity>();
+    public ICollection<GreekNewTestamentWordGroupWordEntity> GreekNewTestamentWordGroupWords { get; set; } = [];
 
-    public ICollection<GreekNewTestamentWordSenseEntity> GreekNewTestamentWordSenses { get; set; } =
-        new List<GreekNewTestamentWordSenseEntity>();
+    public ICollection<GreekNewTestamentWordSenseEntity> GreekNewTestamentWordSenses { get; set; } = [];
 }

--- a/src/Aquifer.Data/Entities/GreekNewTestamentWordGroupEntity.cs
+++ b/src/Aquifer.Data/Entities/GreekNewTestamentWordGroupEntity.cs
@@ -7,7 +7,7 @@ public class GreekNewTestamentWordGroupEntity
     [SqlDefaultValue("getutcdate()")]
     public DateTime Created { get; set; } = DateTime.UtcNow;
 
-    public ICollection<NewTestamentAlignmentEntity> NewTestamentAlignments { get; set; } = new List<NewTestamentAlignmentEntity>();
-    public ICollection<GreekNewTestamentWordGroupWordEntity> GreekNewTestamentWordGroupWords { get; set; } = new List<GreekNewTestamentWordGroupWordEntity>();
+    public ICollection<NewTestamentAlignmentEntity> NewTestamentAlignments { get; set; } = [];
+    public ICollection<GreekNewTestamentWordGroupWordEntity> GreekNewTestamentWordGroupWords { get; set; } = [];
 
 }

--- a/src/Aquifer.Data/Entities/GreekSenseEntity.cs
+++ b/src/Aquifer.Data/Entities/GreekSenseEntity.cs
@@ -21,8 +21,7 @@ public class GreekSenseEntity : IHasUpdatedTimestamp
     public StrongNumberEntity StrongNumber { get; set; } = null!;
     public ICollection<GreekSenseGlossEntity> GreekSenseGlosses { get; set; } = [];
 
-    public ICollection<GreekNewTestamentWordSenseEntity> GreekNewTestamentWordSenses { get; set; } =
-        new List<GreekNewTestamentWordSenseEntity>();
+    public ICollection<GreekNewTestamentWordSenseEntity> GreekNewTestamentWordSenses { get; set; } = [];
 
     [SqlDefaultValue("getutcdate()")]
     public DateTime Updated { get; set; } = DateTime.UtcNow;

--- a/src/Aquifer.Data/Entities/GreekWordEntity.cs
+++ b/src/Aquifer.Data/Entities/GreekWordEntity.cs
@@ -15,6 +15,6 @@ public class GreekWordEntity : IHasUpdatedTimestamp
     [SqlDefaultValue("getutcdate()")]
     public DateTime Updated { get; set; } = DateTime.UtcNow;
 
-    public ICollection<GreekNewTestamentWordEntity> GreekNewTestamentWords { get; set; } = new List<GreekNewTestamentWordEntity>();
+    public ICollection<GreekNewTestamentWordEntity> GreekNewTestamentWords { get; set; } = [];
     public GreekLemmaEntity GreekLemma { get; set; } = null!;
 }

--- a/src/Aquifer.Data/Entities/PassageEntity.cs
+++ b/src/Aquifer.Data/Entities/PassageEntity.cs
@@ -16,7 +16,7 @@ public class PassageEntity : IHasUpdatedTimestamp
 
     public VerseEntity StartVerse { get; set; } = null!;
     public VerseEntity EndVerse { get; set; } = null!;
-    public ICollection<PassageResourceEntity> PassageResources { get; set; } = new List<PassageResourceEntity>();
+    public ICollection<PassageResourceEntity> PassageResources { get; set; } = [];
 
     [SqlDefaultValue("getutcdate()")]
     public DateTime Updated { get; set; }

--- a/src/Aquifer.Data/Entities/ProjectEntity.cs
+++ b/src/Aquifer.Data/Entities/ProjectEntity.cs
@@ -30,7 +30,7 @@ public class ProjectEntity : IHasUpdatedTimestamp
     public DateOnly? ProjectedPublishDate { get; set; }
     public DateOnly? ActualPublishDate { get; set; }
 
-    public ICollection<ProjectResourceContentEntity> ProjectResourceContents { get; set; } = new List<ProjectResourceContentEntity>();
+    public ICollection<ProjectResourceContentEntity> ProjectResourceContents { get; set; } = [];
 
     [SqlDefaultValue("getutcdate()")]
     public DateTime Created { get; set; } = DateTime.UtcNow;

--- a/src/Aquifer.Data/Entities/ResourceContentEntity.cs
+++ b/src/Aquifer.Data/Entities/ResourceContentEntity.cs
@@ -17,8 +17,7 @@ public class ResourceContentEntity : IHasUpdatedTimestamp
     public bool Trusted { get; set; }
     public ResourceContentMediaType MediaType { get; set; }
 
-    public ICollection<ResourceContentVersionEntity> Versions { get; set; } =
-        new List<ResourceContentVersionEntity>();
+    public ICollection<ResourceContentVersionEntity> Versions { get; set; } = [];
 
     [SqlDefaultValue("getutcdate()")]
     public DateTime Created { get; set; } = DateTime.UtcNow;
@@ -26,7 +25,7 @@ public class ResourceContentEntity : IHasUpdatedTimestamp
     public LanguageEntity Language { get; set; } = null!;
     public ResourceEntity Resource { get; set; } = null!;
 
-    public ICollection<ProjectResourceContentEntity> ProjectResourceContents { get; set; } = new List<ProjectResourceContentEntity>();
+    public ICollection<ProjectResourceContentEntity> ProjectResourceContents { get; set; } = [];
     public int Id { get; set; }
     public ResourceContentStatus Status { get; set; }
 

--- a/src/Aquifer.Data/Entities/ResourceContentVersionEntity.cs
+++ b/src/Aquifer.Data/Entities/ResourceContentVersionEntity.cs
@@ -32,14 +32,11 @@ public class ResourceContentVersionEntity : IHasUpdatedTimestamp
 
     public ICollection<ResourceContentVersionMachineTranslationEntity> MachineTranslations { get; set; } = [];
 
-    public IEnumerable<ResourceContentVersionStatusHistoryEntity> ResourceContentVersionStatusHistories { get; set; } =
-        new List<ResourceContentVersionStatusHistoryEntity>();
+    public IEnumerable<ResourceContentVersionStatusHistoryEntity> ResourceContentVersionStatusHistories { get; set; } = [];
 
-    public IEnumerable<ResourceContentVersionAssignedUserHistoryEntity> ResourceContentVersionAssignedUserHistories { get; set; } =
-        new List<ResourceContentVersionAssignedUserHistoryEntity>();
+    public IEnumerable<ResourceContentVersionAssignedUserHistoryEntity> ResourceContentVersionAssignedUserHistories { get; set; } = [];
 
-    public ICollection<ResourceContentVersionSnapshotEntity> ResourceContentVersionSnapshots { get; set; } =
-        new List<ResourceContentVersionSnapshotEntity>();
+    public ICollection<ResourceContentVersionSnapshotEntity> ResourceContentVersionSnapshots { get; set; } = [];
 
     public ICollection<ResourceContentVersionCommentThreadEntity> CommentThreads { get; set; } = [];
 

--- a/src/Aquifer.Data/Entities/ResourceEntity.cs
+++ b/src/Aquifer.Data/Entities/ResourceEntity.cs
@@ -19,17 +19,13 @@ public class ResourceEntity : IHasUpdatedTimestamp
     [SqlDefaultValue("getutcdate()")]
     public DateTime Created { get; set; } = DateTime.UtcNow;
 
-    public ICollection<VerseResourceEntity> VerseResources { get; set; } =
-        new List<VerseResourceEntity>();
+    public ICollection<VerseResourceEntity> VerseResources { get; set; } = [];
 
-    public ICollection<PassageResourceEntity> PassageResources { get; set; } =
-        new List<PassageResourceEntity>();
+    public ICollection<PassageResourceEntity> PassageResources { get; set; } = [];
 
-    public ICollection<ResourceContentEntity> ResourceContents { get; set; } =
-        new List<ResourceContentEntity>();
+    public ICollection<ResourceContentEntity> ResourceContents { get; set; } = [];
 
-    public ICollection<AssociatedResourceEntity> AssociatedResources { get; set; } =
-        new List<AssociatedResourceEntity>();
+    public ICollection<AssociatedResourceEntity> AssociatedResources { get; set; } = [];
 
     [SqlDefaultValue("getutcdate()")]
     public DateTime Updated { get; set; } = DateTime.UtcNow;

--- a/src/Aquifer.Data/Entities/StrongNumberEntity.cs
+++ b/src/Aquifer.Data/Entities/StrongNumberEntity.cs
@@ -12,5 +12,5 @@ public class StrongNumberEntity : IHasUpdatedTimestamp
     [SqlDefaultValue("getutcdate()")]
     public DateTime Updated { get; set; } = DateTime.UtcNow;
 
-    public ICollection<GreekLemmaEntity> GreekLemmas { get; set; } = new List<GreekLemmaEntity>();
+    public ICollection<GreekLemmaEntity> GreekLemmas { get; set; } = [];
 }

--- a/src/Aquifer.Data/Entities/VerseEntity.cs
+++ b/src/Aquifer.Data/Entities/VerseEntity.cs
@@ -7,6 +7,5 @@ public class VerseEntity
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public int Id { get; set; }
 
-    public ICollection<VerseResourceEntity> VerseResources { get; set; } =
-        new List<VerseResourceEntity>();
+    public ICollection<VerseResourceEntity> VerseResources { get; set; } = [];
 }

--- a/src/Aquifer.Data/EventHandlers/ResourceStatusChangeHandler.cs
+++ b/src/Aquifer.Data/EventHandlers/ResourceStatusChangeHandler.cs
@@ -22,6 +22,7 @@ public static class ResourceStatusChangeHandler
             .ToList()
             .ForEach(x =>
             {
+#pragma warning disable IDE0010 // Add missing cases to switch statement
                 switch (x?.Status)
                 {
                     case ResourceContentStatus.Complete:
@@ -35,6 +36,7 @@ public static class ResourceStatusChangeHandler
                         inProgressIds.Add(x.Id);
                         break;
                 }
+#pragma warning restore IDE0010
             });
 
         if (completedContentIds.Count + inReviewContentIds.Count + inProgressIds.Count == 0)

--- a/src/Aquifer.Data/Migrations/.editorconfig
+++ b/src/Aquifer.Data/Migrations/.editorconfig
@@ -1,0 +1,6 @@
+# This folder is all generated code so ignore analyzer warnings
+root = true
+
+[*.cs]
+generated_code = true
+dotnet_analyzer_diagnostic.severity = none

--- a/src/Aquifer.Jobs/Aquifer.Jobs.csproj
+++ b/src/Aquifer.Jobs/Aquifer.Jobs.csproj
@@ -3,8 +3,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <AzureFunctionsVersion>v4</AzureFunctionsVersion>
         <OutputType>Exe</OutputType>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Azure.Data.Tables" Version="12.9.0"/>

--- a/src/Aquifer.Jobs/SendNewContentEmails.cs
+++ b/src/Aquifer.Jobs/SendNewContentEmails.cs
@@ -20,7 +20,7 @@ public class SendNewContentEmails(
     TelemetryClient telemetryClient)
 {
     [Function(nameof(SendNewContentEmails))]
-    public async Task Run([TimerTrigger("%MarketingEmail:CronSchedule:NewContent%")] TimerInfo timerInfo, CancellationToken ct)
+    public async Task Run([TimerTrigger("%MarketingEmail:CronSchedule:NewContent%")] TimerInfo _, CancellationToken ct)
     {
         var subscribers = await GetSubscribersAsync(ct);
         var allNewItems = await GetAllNewItemsAsync(subscribers, ct);

--- a/src/Aquifer.Jobs/SyncApiRequestStatsToStorageTable.cs
+++ b/src/Aquifer.Jobs/SyncApiRequestStatsToStorageTable.cs
@@ -15,7 +15,7 @@ public class SyncApiRequestStatsToStorageTable(
     IOptions<ConfigurationOptions> _options)
 {
     [Function(nameof(SyncApiRequestStatsToStorageTable))]
-    public async Task Run([TimerTrigger("%Analytics:CronSchedule%")] TimerInfo timerInfo, CancellationToken ct)
+    public async Task Run([TimerTrigger("%Analytics:CronSchedule%")] TimerInfo _, CancellationToken ct)
     {
         const string partitionKey = "ApiRequestStats";
         var tableClient = new AquiferTableClient(_options.Value.Analytics.ApiRequestStatsTableName, partitionKey, _azureClientService,

--- a/src/Aquifer.Jobs/SyncCustomEventsToStorageTable.cs
+++ b/src/Aquifer.Jobs/SyncCustomEventsToStorageTable.cs
@@ -16,7 +16,7 @@ public class SyncCustomEventsToStorageTable(
     IOptions<ConfigurationOptions> _options)
 {
     [Function(nameof(SyncCustomEventsToStorageTable))]
-    public async Task Run([TimerTrigger("%Analytics:CronSchedule%")] TimerInfo timerInfo, CancellationToken ct)
+    public async Task Run([TimerTrigger("%Analytics:CronSchedule%")] TimerInfo _, CancellationToken ct)
     {
         await SyncSourceToPartitionKey("content-manager-web", "AquiferAdminCustomEvents", ct);
         await SyncSourceToPartitionKey("well-web", "BibleWellCustomEvents", ct);

--- a/src/Aquifer.Jobs/SyncPageViewsToStorageTable.cs
+++ b/src/Aquifer.Jobs/SyncPageViewsToStorageTable.cs
@@ -16,7 +16,7 @@ public class SyncPageViewsToStorageTable(
     IOptions<ConfigurationOptions> _options)
 {
     [Function(nameof(SyncPageViewsToStorageTable))]
-    public async Task Run([TimerTrigger("%Analytics:CronSchedule%")] TimerInfo timerInfo, CancellationToken ct)
+    public async Task Run([TimerTrigger("%Analytics:CronSchedule%")] TimerInfo _, CancellationToken ct)
     {
         await SyncSourceToPartitionKey("content-manager-web", "AquiferAdminPageViews", ct);
         await SyncSourceToPartitionKey("well-web", "BibleWellPageViews", ct);

--- a/src/Aquifer.Migrations/Aquifer.Migrations.csproj
+++ b/src/Aquifer.Migrations/Aquifer.Migrations.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aquifer.Public.API/Aquifer.Public.API.csproj
+++ b/src/Aquifer.Public.API/Aquifer.Public.API.csproj
@@ -2,11 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-        <WarningsAsErrors>true</WarningsAsErrors>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 

--- a/tests/Aquifer.Common.UnitTests/Aquifer.Common.UnitTests.csproj
+++ b/tests/Aquifer.Common.UnitTests/Aquifer.Common.UnitTests.csproj
@@ -2,25 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Aquifer.Common\Aquifer.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aquifer.Public.API.UnitTests/Aquifer.Public.API.UnitTests.csproj
+++ b/tests/Aquifer.Public.API.UnitTests/Aquifer.Public.API.UnitTests.csproj
@@ -2,25 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Aquifer.Public.API\Aquifer.Public.API.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
   </ItemGroup>
 
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,21 @@
+<Project>
+
+    <!-- Import the root Directory.Build.Props and override/add settings that only apply to tests -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+    <PropertyGroup>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Some projects in the solution were running style analysis on build but others weren't.  Some were treating warnings as errors but others weren't.  This caused me to miss [a build error](https://github.com/BiblioNexusStudio/aquifer-server/actions/runs/11481872205/job/31953579431) caught by CI but that Visual Studio didn't notice locally when building.

This PR implements solution-wide settings across projects where possible and moves the settings from the project files into the solution-wide `Directory.Build.props` file(s).

This change required fixing or disabling warnings and style errors that were previously undetected in certain projects.  Note also that I added the `.editorconfig` file to the solution which caused some settings to be added automatically via VS.