### PR TITLE
Fix TimerInfo parameter Azure Trigger Function bindings.

### DIFF
--- a/src/Aquifer.Jobs/SendNewContentEmails.cs
+++ b/src/Aquifer.Jobs/SendNewContentEmails.cs
@@ -20,7 +20,9 @@ public class SendNewContentEmails(
     TelemetryClient telemetryClient)
 {
     [Function(nameof(SendNewContentEmails))]
-    public async Task Run([TimerTrigger("%MarketingEmail:CronSchedule:NewContent%")] TimerInfo _, CancellationToken ct)
+#pragma warning disable IDE0060 // Remove unused parameter: A (non-discard) TimerInfo parameter is required for correct Azure bindings
+    public async Task Run([TimerTrigger("%MarketingEmail:CronSchedule:NewContent%")] TimerInfo timerInfo, CancellationToken ct)
+#pragma warning restore IDE0060 // Remove unused parameter
     {
         var subscribers = await GetSubscribersAsync(ct);
         var allNewItems = await GetAllNewItemsAsync(subscribers, ct);

--- a/src/Aquifer.Jobs/SyncApiRequestStatsToStorageTable.cs
+++ b/src/Aquifer.Jobs/SyncApiRequestStatsToStorageTable.cs
@@ -15,7 +15,9 @@ public class SyncApiRequestStatsToStorageTable(
     IOptions<ConfigurationOptions> _options)
 {
     [Function(nameof(SyncApiRequestStatsToStorageTable))]
-    public async Task Run([TimerTrigger("%Analytics:CronSchedule%")] TimerInfo _, CancellationToken ct)
+#pragma warning disable IDE0060 // Remove unused parameter: A (non-discard) TimerInfo parameter is required for correct Azure bindings
+    public async Task Run([TimerTrigger("%Analytics:CronSchedule%")] TimerInfo timerInfo, CancellationToken ct)
+#pragma warning restore IDE0060 // Remove unused parameter
     {
         const string partitionKey = "ApiRequestStats";
         var tableClient = new AquiferTableClient(_options.Value.Analytics.ApiRequestStatsTableName, partitionKey, _azureClientService,

--- a/src/Aquifer.Jobs/SyncCustomEventsToStorageTable.cs
+++ b/src/Aquifer.Jobs/SyncCustomEventsToStorageTable.cs
@@ -16,7 +16,9 @@ public class SyncCustomEventsToStorageTable(
     IOptions<ConfigurationOptions> _options)
 {
     [Function(nameof(SyncCustomEventsToStorageTable))]
-    public async Task Run([TimerTrigger("%Analytics:CronSchedule%")] TimerInfo _, CancellationToken ct)
+#pragma warning disable IDE0060 // Remove unused parameter: A (non-discard) TimerInfo parameter is required for correct Azure bindings
+    public async Task Run([TimerTrigger("%Analytics:CronSchedule%")] TimerInfo timerInfo, CancellationToken ct)
+#pragma warning restore IDE0060 // Remove unused parameter
     {
         await SyncSourceToPartitionKey("content-manager-web", "AquiferAdminCustomEvents", ct);
         await SyncSourceToPartitionKey("well-web", "BibleWellCustomEvents", ct);

--- a/src/Aquifer.Jobs/SyncPageViewsToStorageTable.cs
+++ b/src/Aquifer.Jobs/SyncPageViewsToStorageTable.cs
@@ -16,7 +16,9 @@ public class SyncPageViewsToStorageTable(
     IOptions<ConfigurationOptions> _options)
 {
     [Function(nameof(SyncPageViewsToStorageTable))]
-    public async Task Run([TimerTrigger("%Analytics:CronSchedule%")] TimerInfo _, CancellationToken ct)
+#pragma warning disable IDE0060 // Remove unused parameter: A (non-discard) TimerInfo parameter is required for correct Azure bindings
+    public async Task Run([TimerTrigger("%Analytics:CronSchedule%")] TimerInfo timerInfo, CancellationToken ct)
+#pragma warning restore IDE0060 // Remove unused parameter
     {
         await SyncSourceToPartitionKey("content-manager-web", "AquiferAdminPageViews", ct);
         await SyncSourceToPartitionKey("well-web", "BibleWellPageViews", ct);


### PR DESCRIPTION
Azure is dumb and can't bind `_` (the discard parameter) as a parameter name for a `TimerTrigger` parameter.  But it doesn't let you know this until it blows up at runtime and I missed it amongst the other Job logging when testing my previous PR.  See also https://github.com/Azure/azure-functions-dotnet-worker/issues/323.

Logs:
```
[2024-10-23T20:16:27.939Z] The 'SyncApiRequestStatsToStorageTable' function is in error: The binding name _ is invalid. Please assign a valid name to the binding.
[2024-10-23T20:16:27.940Z] The 'SendNewContentEmails' function is in error: The binding name _ is invalid. Please assign a valid name to the binding.
[2024-10-23T20:16:27.940Z] The 'SyncCustomEventsToStorageTable' function is in error: The binding name _ is invalid. Please assign a valid name to the binding.
[2024-10-23T20:16:27.941Z] The 'SyncPageViewsToStorageTable' function is in error: The binding name _ is invalid. Please assign a valid name to the binding.
```