### PR TITLE
Fix resource assignment.

### DIFF
--- a/src/Aquifer.Data/Entities/ResourceContentVersionEntity.cs
+++ b/src/Aquifer.Data/Entities/ResourceContentVersionEntity.cs
@@ -32,9 +32,9 @@ public class ResourceContentVersionEntity : IHasUpdatedTimestamp
 
     public ICollection<ResourceContentVersionMachineTranslationEntity> MachineTranslations { get; set; } = [];
 
-    public IEnumerable<ResourceContentVersionStatusHistoryEntity> ResourceContentVersionStatusHistories { get; set; } = [];
+    public ICollection<ResourceContentVersionStatusHistoryEntity> ResourceContentVersionStatusHistories { get; set; } = [];
 
-    public IEnumerable<ResourceContentVersionAssignedUserHistoryEntity> ResourceContentVersionAssignedUserHistories { get; set; } = [];
+    public ICollection<ResourceContentVersionAssignedUserHistoryEntity> ResourceContentVersionAssignedUserHistories { get; set; } = [];
 
     public ICollection<ResourceContentVersionSnapshotEntity> ResourceContentVersionSnapshots { get; set; } = [];
 


### PR DESCRIPTION
See https://biblionexusworkspace.slack.com/archives/C0662HZ7RKM/p1729797051412399 for details on why this was breaking.  tl;dr: Don't use `IEnumerable<T>` for EF one-to-many or many-to-many relationships with an assignment of `[]` because that will assign `Array.Empty<T>` under the hood which doesn't support `Add`.

I confirmed this fixes resource assignment and these are the only `IEnumerable<T>` usages like this in the Aquifer.Data project.