### PR TITLE
Fix Aquifer BaseUri appsettings.json configuration.

### DIFF
--- a/src/Aquifer.Jobs/appsettings.example.json
+++ b/src/Aquifer.Jobs/appsettings.example.json
@@ -1,4 +1,7 @@
 {
+    "AquiferAdminBaseUri": "Base URL of Aquifer Admin website",
+    "AquiferApiBaseUri": "Base URL of the Aquifer Internal API",
+    "KeyVaultUri": "https://key-vault-name.vault.azure.net/",
     "Analytics": {
         "ApiManagementResourceId": "/subscriptions/dacfa945-984c-4708-9f2d-7d8358f223d5/resourceGroups/BiblioNexus-Global/providers/Microsoft.ApiManagement/service/aquifer-api-management",
         "ApiRequestStatsTableName": "ApiRequestStatsQa",
@@ -7,10 +10,6 @@
         "HoursBetweenRuns": 1,
         "PageViewsTableName": "PageViewsQa",
         "StorageAccountUri": "https://aquiferstoragedev.table.core.windows.net"
-    },
-    "Aquifer": {
-        "AdminBaseUri": "Base URL of Aquifer Admin website",
-        "ApiBaseUri": "Base URL of the Aquifer Internal API"
     },
     "ConnectionStrings": {
         "ApplicationInsights": "Application insights connection string. Get from Azure instance.",
@@ -41,6 +40,5 @@
         "Address": "Email address that the new content email is coming from",
         "Name": "Name that the new content email is under when email is sent",
         "ResourceLink": "Link to resources in new content email template"
-    },
-    "KeyVaultUri": "https://key-vault-name.vault.azure.net/"
+    }
 }

--- a/src/Aquifer.Jobs/appsettings.json
+++ b/src/Aquifer.Jobs/appsettings.json
@@ -1,4 +1,7 @@
 {
+    "AquiferAdminBaseUri": "",
+    "AquiferApiBaseUri": "",
+    "KeyVaultUri": "",
     "Analytics": {
         "ApiManagementResourceId": "",
         "ApiRequestStatsTableName": "",
@@ -7,10 +10,6 @@
         "HoursBetweenRuns": 1,
         "PageViewsTableName": "",
         "StorageAccountUri": ""
-    },
-    "Aquifer": {
-        "AdminBaseUri": "",
-        "ApiBaseUri": ""
     },
     "ConnectionStrings": {
         "ApplicationInsights": "",
@@ -46,6 +45,5 @@
         "Address": "",
         "Name": "",
         "ResourceLink": ""
-    },
-    "KeyVaultUri": ""
+    }
 }


### PR DESCRIPTION
`Aquifer*BaseUri` is not in a sub-class in the [ConfigurationOptions](https://github.com/BiblioNexusStudio/aquifer-server/blob/0fee44288d7c3aef7e233c569159769fe767ad3c/src/Aquifer.Jobs/Configuration/ConfigurationOptions.cs#L7-L8).