### PR TITLE
Refactor notification emails to use unique personalizations and one email per To address.

### DIFF
--- a/src/Aquifer.Common/Messages/Models/SendEmailMessage.cs
+++ b/src/Aquifer.Common/Messages/Models/SendEmailMessage.cs
@@ -5,5 +5,4 @@ public sealed record SendEmailMessage(
     string Subject,
     string HtmlContent,
     IReadOnlyList<EmailAddress> Tos,
-    IReadOnlyList<EmailAddress>? Ccs = null,
-    IReadOnlyList<EmailAddress>? Bccs = null);
+    IReadOnlyList<EmailAddress>? ReplyTos = null);

--- a/src/Aquifer.Common/Messages/Models/SendTemplatedEmailMessage.cs
+++ b/src/Aquifer.Common/Messages/Models/SendTemplatedEmailMessage.cs
@@ -12,7 +12,7 @@ namespace Aquifer.Common.Messages.Models;
 public sealed record SendTemplatedEmailMessage(
     EmailAddress From,
     string TemplateId,
-    IDictionary<string, object> DynamicTemplateData,
     IReadOnlyList<EmailAddress> Tos,
-    IReadOnlyList<EmailAddress>? Ccs = null,
-    IReadOnlyList<EmailAddress>? Bccs = null);
+    Dictionary<string, object> DynamicTemplateData,
+    Dictionary<string, Dictionary<string, object>>? EmailSpecificDynamicTemplateDataByToEmailAddressMap = null,
+    IReadOnlyList<EmailAddress>? ReplyTos = null);

--- a/src/Aquifer.Jobs/Common/NotificationsHelper.cs
+++ b/src/Aquifer.Jobs/Common/NotificationsHelper.cs
@@ -6,7 +6,7 @@ namespace Aquifer.Jobs.Common;
 public static class NotificationsHelper
 {
     public static readonly EmailAddress NotificationSenderEmailAddress = new("notifications@aquifer.bible", "Aquifer Notifications");
-    public static readonly EmailAddress NotificationToEmailAddress = new("no-reply@aquifer.bible", "Aquifer");
+    public static readonly EmailAddress NotificationNoReplyEmailAddress = new("no-reply@aquifer.bible", "Aquifer");
 
     public static EmailAddress GetEmailAddress(UserEntity userEntity)
     {

--- a/src/Aquifer.Jobs/Managers/SendResourceAssignmentNotificationsManager.cs
+++ b/src/Aquifer.Jobs/Managers/SendResourceAssignmentNotificationsManager.cs
@@ -98,7 +98,7 @@ public class SendResourceAssignmentNotificationsManager(
             })
             .ToList();
 
-            // Note: If execution fails during this loop then it's possible that we will send multiple emails to a single user;
+        // Note: If execution fails during this loop then it's possible that we will send multiple emails to a single user;
         // first during the initial failed run and again when the job retries (possibly with new data).
         foreach (var sendTemplatedEmailMessage in sendTemplatedEmailMessages)
         {

--- a/src/Aquifer.Jobs/Managers/SendResourceAssignmentNotificationsManager.cs
+++ b/src/Aquifer.Jobs/Managers/SendResourceAssignmentNotificationsManager.cs
@@ -56,38 +56,49 @@ public class SendResourceAssignmentNotificationsManager(
 
         var sendTemplatedEmailMessages = userHistories
             .GroupBy(uh => uh.AssignedUser.Id)
-            .Select(userGrouping => new SendTemplatedEmailMessage(
-                From: NotificationsHelper.NotificationSenderEmailAddress,
-                // Template Designer: https://mc.sendgrid.com/dynamic-templates/d-d85f76c6b4d344f5bc8b90b27cc40cc3/version/b6955fec-6f2e-41f7-a9f5-fb695a5b8ed7/editor
-                TemplateId: _configurationOptions.Value.Notifications.SendResourceAssignmentNotificationTemplateId,
-                DynamicTemplateData: new Dictionary<string, object>
-                {
-                    [EmailMessagePublisher.DynamicTemplateDataSubjectPropertyName] = "Aquifer Notification: Resources Assigned",
-                    ["aquiferAdminBaseUri"] = _configurationOptions.Value.AquiferAdminBaseUri,
-                    ["resourceCount"] = userGrouping.Count(),
-                    ["parentResources"] = userGrouping
-                        .GroupBy(uh => uh.ParentResourceName)
-                        .OrderBy(parentResourceGrouping => parentResourceGrouping.Key)
-                        .Select(parentResourceGrouping => new
+            .Select(userGrouping =>
+            {
+                var user = usersByIdMap[userGrouping.Key];
+
+                return new SendTemplatedEmailMessage(
+                    From: NotificationsHelper.NotificationSenderEmailAddress,
+                    TemplateId: _configurationOptions.Value.Notifications.SendResourceAssignmentNotificationTemplateId,
+                    Tos: [NotificationsHelper.GetEmailAddress(user)],
+                    DynamicTemplateData: new Dictionary<string, object>
+                    {
+                        [EmailMessagePublisher.DynamicTemplateDataSubjectPropertyName] = "Aquifer Notification: Resources Assigned",
+                        ["aquiferAdminBaseUri"] = _configurationOptions.Value.AquiferAdminBaseUri,
+                        ["resourceCount"] = userGrouping.Count(),
+                        ["parentResources"] = userGrouping
+                            .GroupBy(uh => uh.ParentResourceName)
+                            .OrderBy(parentResourceGrouping => parentResourceGrouping.Key)
+                            .Select(parentResourceGrouping => new
+                            {
+                                ParentResourceName = parentResourceGrouping.Key,
+                                Resources = parentResourceGrouping
+                                    .DistinctBy(uh => uh.ResourceContentId)
+                                    .OrderBy(uh => uh.ResourceName)
+                                    .Select(uh => new
+                                    {
+                                        uh.ResourceContentId,
+                                        uh.ResourceName,
+                                    })
+                                    .ToArray(),
+                            })
+                            .ToArray(),
+                    },
+                    EmailSpecificDynamicTemplateDataByToEmailAddressMap: new Dictionary<string, Dictionary<string, object>>
+                    {
+                        [user.Email] = new()
                         {
-                            ParentResourceName = parentResourceGrouping.Key,
-                            Resources = parentResourceGrouping
-                                .DistinctBy(uh => uh.ResourceContentId)
-                                .OrderBy(uh => uh.ResourceName)
-                                .Select(uh => new
-                                {
-                                    uh.ResourceContentId,
-                                    uh.ResourceName,
-                                })
-                                .ToArray(),
-                        })
-                        .ToArray(),
-                },
-                Tos: [NotificationsHelper.NotificationToEmailAddress],
-                Bccs: [NotificationsHelper.GetEmailAddress(usersByIdMap[userGrouping.Key])]))
+                            ["recipientName"] = NotificationsHelper.GetUserFullName(user),
+                        },
+                    },
+                    ReplyTos: [NotificationsHelper.NotificationNoReplyEmailAddress]);
+            })
             .ToList();
 
-        // Note: If execution fails during this loop then it's possible that we will send multiple emails to a single user;
+            // Note: If execution fails during this loop then it's possible that we will send multiple emails to a single user;
         // first during the initial failed run and again when the job retries (possibly with new data).
         foreach (var sendTemplatedEmailMessage in sendTemplatedEmailMessages)
         {

--- a/src/Aquifer.Jobs/Services/SendGridEmailService.cs
+++ b/src/Aquifer.Jobs/Services/SendGridEmailService.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Aquifer.Common.Clients;
 using SendGrid;
 using SendGrid.Helpers.Mail;
@@ -33,6 +34,7 @@ public class SendGridEmailService : IEmailService
 {
     // the SendGrid API limit is 1,000
     private const int _maximumNumberOfTosPerApiCall = 1_000;
+    private static readonly Regex s_removePlusAddressing = new("\\+.*@", RegexOptions.Compiled);
 
     private readonly SendGridClient _sendGridClient;
 
@@ -81,10 +83,7 @@ public class SendGridEmailService : IEmailService
 
     private static IReadOnlyList<SendGridMessage> MapToSendGridMessages(Email email)
     {
-        return email
-            .Tos
-            .DistinctBy(to => to.Email)
-            .Chunk(_maximumNumberOfTosPerApiCall)
+        return GetToEmailAddressBatches(email.Tos)
             .Select(tos => new SendGridMessage
             {
                 From = MapToSendGridEmailAddress(email.From),
@@ -104,10 +103,7 @@ public class SendGridEmailService : IEmailService
 
     private static IReadOnlyList<SendGridMessage> MapToSendGridMessages(TemplatedEmail email)
     {
-        return email
-            .Tos
-            .DistinctBy(to => to.Email)
-            .Chunk(_maximumNumberOfTosPerApiCall)
+        return GetToEmailAddressBatches(email.Tos)
             .Select(tos => new SendGridMessage
             {
                 From = MapToSendGridEmailAddress(email.From),
@@ -140,6 +136,43 @@ public class SendGridEmailService : IEmailService
             .Where(d => d is not null)
             .SelectMany(d => d!)
             .ToDictionary();
+    }
+
+    // Email providers (like Gmail) will not deliver all simultaneously sent emails from SendGrid
+    // if those emails are in the same batch with the same "Message-ID" (see https://mtsknn.fi/blog/tricky-email-aliases/).
+    // Thus, we need to send plus-aliased emails (e.g. "john.doe+testing@example.com") in separate batches
+    // when there is more than one plus-aliased email for the same email address in order for the provider to actually deliver them.
+    // This method will send most emails in the first batch but any duplicate email base email addresses will be sent in subsequent
+    // batches in order to force a different "Message-ID" for those plus-aliased email addresses.
+    private static IEnumerable<EmailAddress[]> GetToEmailAddressBatches(IEnumerable<EmailAddress> toEmailAddresses)
+    {
+        var plusAliasGroups = toEmailAddresses
+            .DistinctBy(to => to.Email)
+            .GroupBy(to => s_removePlusAddressing.Replace(to.Email, "@"))
+            .Select(grp => grp.ToList())
+            .ToList();
+
+        return RecursivelyChunkAndZipGroupedItems(plusAliasGroups);
+
+        // This method takes multiple lists and returns batches of items, each batch containing all items at index N in the lists.
+        // It then also batches the output batch if there are too many in a single batch.
+        static IEnumerable<EmailAddress[]> RecursivelyChunkAndZipGroupedItems(List<List<EmailAddress>> groups)
+        {
+            if (groups.Count == 0)
+            {
+                return [];
+            }
+
+            return groups
+                .Select(grp => grp.First())
+                .Chunk(_maximumNumberOfTosPerApiCall)
+                .Concat(
+                    RecursivelyChunkAndZipGroupedItems(
+                        groups
+                            .Select(grp => grp.Skip(1).ToList())
+                            .Where(grp => grp.Count > 0)
+                            .ToList()));
+        }
     }
 
     private static SendGrid.Helpers.Mail.EmailAddress MapToSendGridEmailAddress(EmailAddress emailAddress)

--- a/src/Aquifer.Jobs/Subscribers/EmailMessageSubscriber.cs
+++ b/src/Aquifer.Jobs/Subscribers/EmailMessageSubscriber.cs
@@ -75,8 +75,7 @@ public sealed class EmailMessageSubscriber(
             source.Subject,
             source.HtmlContent,
             source.Tos.Select(MapToEmailAddress).ToList(),
-            source.Ccs?.Select(MapToEmailAddress).ToList(),
-            source.Bccs?.Select(MapToEmailAddress).ToList());
+            source.ReplyTos?.Select(MapToEmailAddress).ToList());
     }
 
     private static EmailAddress MapToEmailAddress(Aquifer.Common.Messages.Models.EmailAddress source)
@@ -91,9 +90,9 @@ public sealed class EmailMessageSubscriber(
         return new TemplatedEmail(
             MapToEmailAddress(source.From),
             source.TemplateId,
-            source.DynamicTemplateData,
             source.Tos.Select(MapToEmailAddress).ToList(),
-            source.Ccs?.Select(MapToEmailAddress).ToList(),
-            source.Bccs?.Select(MapToEmailAddress).ToList());
+            source.DynamicTemplateData,
+            source.EmailSpecificDynamicTemplateDataByToEmailAddressMap,
+            source.ReplyTos?.Select(MapToEmailAddress).ToList());
     }
 }


### PR DESCRIPTION
Changes:
* Notification emails are now sent using the To field instead of the Bcc field.
* Notification emails now use a reply-to address of `no-reply@aquifer.bible` (instead of putting that in the To field).
* Notification emails now also support bulk send with unique personalization content for templated emails.

Additional details:

Initially I was unable to prevent the sending of a single email with multiple recipients in the To field.  I was able to address this by sending multiple personalizations in the SendGrid email, one per To, instead of only one personalization with all of the Tos.  This also allows for unique personalization dynamic template data for each To email address (the third bullet point above). To confirm that this new personalization worked correctly I updated all notifications emails to begin with:
```
Recipient Name,

...
```

A byproduct of this change is that now we send up dynamic template data multiple times, once for each To email address, even though most of it is redundant.  Because of this I added batching to the email send at 1000 emails per SendGrid API call (their limit is 1000) but we could further reduce this if the JSON request body size to SendGrid ends up being very large.

Furthermore, testing with multiple email addresses using `+` in the email address with same base email will not result in all emails being delivered by email providers even though SendGrid is successfully sending them.  One way around this is to send multiple batches, one for each unique `+` email address for each base email address, so that email providers won't consider them the same email due to different `Message-ID`s.  I implemented a solution for this because we commonly use plus-aliased email addresses in testing.