### PR TITLE
Add logging for IP address lookup failures.

### DIFF
--- a/src/Aquifer.Common/Clients/Http/IpAddressLookup/IpAddressLookupHttpClient.cs
+++ b/src/Aquifer.Common/Clients/Http/IpAddressLookup/IpAddressLookupHttpClient.cs
@@ -1,4 +1,5 @@
 ﻿using Aquifer.Common.Utilities;
+using Microsoft.Extensions.Logging;
 
 namespace Aquifer.Common.Clients.Http.IpAddressLookup;
 
@@ -11,9 +12,12 @@ public class IpAddressLookupHttpClient : IIpAddressLookupHttpClient
 {
     private const string BaseUri = "https://ipapi.co";
     private readonly HttpClient _httpClient;
+    private readonly ILogger<IpAddressLookupHttpClient> _logger;
 
-    public IpAddressLookupHttpClient(HttpClient httpClient)
+    public IpAddressLookupHttpClient(HttpClient httpClient, ILogger<IpAddressLookupHttpClient> logger)
     {
+        _logger = logger;
+
         _httpClient = httpClient;
         _httpClient.BaseAddress = new Uri(BaseUri);
         // request will fail without User-Agent
@@ -23,7 +27,18 @@ public class IpAddressLookupHttpClient : IIpAddressLookupHttpClient
     public async Task<IpAddressLookupResponse> LookupIpAddressAsync(string ipAddress, CancellationToken ct)
     {
         var response = await _httpClient.GetAsync($"{ipAddress}/json", ct);
-        var responseContent = await response.Content.ReadAsStringAsync(ct);
-        return JsonUtilities.DefaultDeserialize<IpAddressLookupResponse>(responseContent);
+        if (response.IsSuccessStatusCode)
+        {
+            var responseContent = await response.Content.ReadAsStringAsync(ct);
+            return JsonUtilities.DefaultDeserialize<IpAddressLookupResponse>(responseContent);
+        }
+
+        _logger.LogError(
+            "Unable to fetch IP address information for {ipAddress}. Response code: {responseCode}; Response: {response}.",
+            ipAddress,
+            response.StatusCode,
+            await response.Content.ReadAsStringAsync(ct));
+
+        throw new Exception($"IP address lookup failed for {ipAddress}. If this happens regularly we should build in automated retries with Polly.");
     }
 }


### PR DESCRIPTION
Add logging to help diagnose alerts like [this](https://biblionexusworkspace.slack.com/archives/C0662HZ7RKM/p1731011332287459).