### PR TITLE
Downgrade NuGet package security errors to warnings.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
         <NoWarn>MSB3245</NoWarn>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <GitHubOrganization>BiblioNexusStudio</GitHubOrganization>


### PR DESCRIPTION
The build is currently failing with:
```
error NU1903: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability
```

These warnings should remain warnings and should not fail the build because we may not have control over fixing them.