### PR TITLE
Fix ChatCompletionOptions race condition.

### DIFF
--- a/src/Aquifer.AI/OpenAiTranslationService.cs
+++ b/src/Aquifer.AI/OpenAiTranslationService.cs
@@ -60,7 +60,7 @@ public sealed partial class OpenAiTranslationService : ITranslationService
     private static readonly TimeSpan s_openAiNetworkTimeout = TimeSpan.FromMinutes(10);
 
     private readonly ChatClient _chatClient;
-    private readonly ChatCompletionOptions _chatCompletionOptions;
+    private readonly float _temperature;
 
     private readonly OpenAiTranslationOptions _options;
 
@@ -83,10 +83,7 @@ public sealed partial class OpenAiTranslationService : ITranslationService
                 NetworkTimeout = s_openAiNetworkTimeout,
             });
 
-        _chatCompletionOptions = new ChatCompletionOptions
-        {
-            Temperature = _options.Temperature,
-        };
+        _temperature = _options.Temperature;
     }
 
     public async Task<string> TranslateTextAsync(
@@ -172,7 +169,10 @@ public sealed partial class OpenAiTranslationService : ITranslationService
                 ChatMessage.CreateSystemMessage(prompt),
                 ChatMessage.CreateUserMessage(text),
             ],
-            _chatCompletionOptions,
+            new ChatCompletionOptions
+            {
+                Temperature = _temperature,
+            },
             cancellationToken);
 
         if (chatCompletion.Value.FinishReason != ChatFinishReason.Stop)
@@ -193,7 +193,10 @@ public sealed partial class OpenAiTranslationService : ITranslationService
                 ChatMessage.CreateSystemMessage(prompt),
                 ChatMessage.CreateUserMessage(html),
             ],
-            _chatCompletionOptions,
+            new ChatCompletionOptions
+            {
+                Temperature = _temperature,
+            },
             cancellationToken);
 
         if (chatCompletion.Value.FinishReason != ChatFinishReason.Stop)


### PR DESCRIPTION
The OpenAI client mutated the `ChatCompletionOptions` singleton passed in by our calling code on every chat completion request and add the chat messages to an `internal` property.  This meant that multiple translation requests could end up using the same chat messages during race conditions resulting in incorrect translations based upon the content or display names of other resources.

![image](https://github.com/user-attachments/assets/ca1d8005-abdb-429d-9427-b59edcf00950)
