### PR TITLE
add AquiferizeAiDraftComplete to relevant places

### DIFF
--- a/src/Aquifer.API/Endpoints/Projects/ProjectResourceStatusCounts.cs
+++ b/src/Aquifer.API/Endpoints/Projects/ProjectResourceStatusCounts.cs
@@ -29,7 +29,9 @@ public class ProjectResourceStatusCounts
     [
         ResourceContentStatus.New,
         ResourceContentStatus.TranslationAwaitingAiDraft,
-        ResourceContentStatus.TranslationAiDraftComplete
+        ResourceContentStatus.TranslationAiDraftComplete,
+        ResourceContentStatus.AquiferizeAwaitingAiDraft,
+        ResourceContentStatus.AquiferizeAiDraftComplete
     ];
 
     internal static readonly List<ResourceContentStatus> CompletedStatuses =

--- a/src/Aquifer.API/Endpoints/Resources/Content/AssignedToOwnCompany/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/AssignedToOwnCompany/List/Endpoint.cs
@@ -23,11 +23,12 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
         List<ResourceContentStatus> statuses =
         [
             ResourceContentStatus.New,
+            ResourceContentStatus.AquiferizeAiDraftComplete,
+            ResourceContentStatus.AquiferizeCompanyReview,
             ResourceContentStatus.AquiferizeEditorReview,
             ResourceContentStatus.TranslationAiDraftComplete,
-            ResourceContentStatus.TranslationEditorReview,
-            ResourceContentStatus.AquiferizeCompanyReview,
-            ResourceContentStatus.TranslationCompanyReview
+            ResourceContentStatus.TranslationCompanyReview,
+            ResourceContentStatus.TranslationEditorReview
         ];
 
         var query = $"""
@@ -62,7 +63,11 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
             SortOrder = x.SortOrder,
             StatusValue = x.StatusValue,
             StatusDisplayName = x.StatusValue.GetDisplayName(),
-            AssignedUser = new UserDto { Id = x.UserId, Name = $"{x.UserFirstName} {x.UserLastName}" },
+            AssignedUser = new UserDto
+            {
+                Id = x.UserId,
+                Name = $"{x.UserFirstName} {x.UserLastName}"
+            },
             DaysSinceContentUpdated = x.ContentUpdated == null ? null : (DateTime.UtcNow - (DateTime)x.ContentUpdated).Days,
             DaysUntilProjectDeadline =
                     x.ProjectProjectedDeliveryDate == null

--- a/src/Aquifer.API/Endpoints/Resources/Content/SendForEditorReview/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/SendForEditorReview/Endpoint.cs
@@ -19,6 +19,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
             "/resources/content/{ContentId}/send-for-editor-review");
         Permissions(PermissionName.AssignContent, PermissionName.AssignOverride, PermissionName.AssignOutsideCompany);
     }
+
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
         var user = await userService.GetUserFromJwtAsync(ct);
@@ -31,7 +32,8 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
 
         var draftVersions = await ResourceStatusHelpers.GetDraftVersions<Request>(contentIds,
         [
-            ResourceContentStatus.TranslationEditorReview, ResourceContentStatus.TranslationAiDraftComplete, ResourceContentStatus.New,
+            ResourceContentStatus.TranslationEditorReview, ResourceContentStatus.TranslationAiDraftComplete,
+            ResourceContentStatus.New, ResourceContentStatus.AquiferizeAiDraftComplete,
             ResourceContentStatus.AquiferizeEditorReview, ResourceContentStatus.AquiferizeCompanyReview,
             ResourceContentStatus.TranslationCompanyReview
         ], dbContext, ct);
@@ -63,7 +65,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
         {
             draftVersion.ResourceContent.Status = ResourceContentStatus.TranslationEditorReview;
         }
-        else if (originalStatus == ResourceContentStatus.New)
+        else if (originalStatus is ResourceContentStatus.New or ResourceContentStatus.AquiferizeAiDraftComplete)
         {
             draftVersion.ResourceContent.Status = ResourceContentStatus.AquiferizeEditorReview;
         }

--- a/src/Aquifer.API/Endpoints/Resources/Content/ToAssign/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/ToAssign/List/Endpoint.cs
@@ -30,7 +30,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
                               INNER JOIN ProjectResourceContents PRC ON PRC.ResourceContentId = RC.Id
                               INNER JOIN Projects P ON P.Id = PRC.ProjectId
                      WHERE RCV.IsDraft = 1 AND RCV.AssignedUserId = {user.Id}
-                       AND RC.Status IN ({(int)ResourceContentStatus.New}, {(int)ResourceContentStatus.TranslationAiDraftComplete})
+                       AND RC.Status IN ({(int)ResourceContentStatus.New}, {(int)ResourceContentStatus.AquiferizeAiDraftComplete}, {(int)ResourceContentStatus.TranslationAiDraftComplete})
                      """;
 
         var resources = await dbContext.Database.SqlQueryRaw<Response>(query).ToListAsync(ct);


### PR DESCRIPTION
Fixed the following places:
- all project resource counts so they show Aquiferize AI drafts as not started
- assigned-to-own-company so the Manage Tab shows AquiferizeAiDraftComplete items
- assigned-to-self so it doesn't show AquiferizeAiDraftComplete items (so managers don't see their to-assign items in My Work)
- send-for-editor-review so it allows assigning AquiferizeAiDraftComplete items
- to-assign so it shows AquiferizeAiDraftComplete so the To Assign tab shows those items
- next-up so it takes into account AquiferizeAiDraftComplete and TranslationAiDraftComplete