### PR TITLE
Add handler for bad translation pair keys

### DIFF
--- a/src/Aquifer.Data/AquiferDbContext.cs
+++ b/src/Aquifer.Data/AquiferDbContext.cs
@@ -18,7 +18,8 @@ public class AquiferDbContext : DbContext
         // a wrapper around it. https://www.jetbrains.com/help/resharper/VirtualMemberCallInConstructor.html
         // It's likely irrelevant anyway, because the events are additive.
         ChangeTracker.StateChanged += OnStateChange;
-        SavedChanges += async (s, e) => await OnSavingChanges(s, e);
+        SavedChanges += async (s, e) => await OnSavedChanges(s, e);
+        SavingChanges += OnSavingChanges;
     }
 
     public DbSet<AssociatedResourceEntity> AssociatedResources { get; set; }
@@ -100,9 +101,15 @@ public class AquiferDbContext : DbContext
         UpdatedTimestampHandler.Handle(e.Entry);
     }
 
-    private async Task OnSavingChanges(object? sender, SavedChangesEventArgs e)
+    private async Task OnSavedChanges(object? sender, SavedChangesEventArgs e)
     {
         var entries = ChangeTracker.Entries();
         await ResourceStatusChangeHandler.HandleAsync(_options, entries);
+    }
+
+    private void OnSavingChanges(object? sender, SavingChangesEventArgs e)
+    {
+        var entries = ChangeTracker.Entries();
+        BadTranslationPairHandler.Handle(entries);
     }
 }

--- a/src/Aquifer.Data/EventHandlers/BadTranslationPairHandler.cs
+++ b/src/Aquifer.Data/EventHandlers/BadTranslationPairHandler.cs
@@ -7,7 +7,11 @@ namespace Aquifer.Data.EventHandlers;
 
 public static class BadTranslationPairHandler
 {
-    private static readonly IReadOnlyList<string> s_KeyBlacklist = ["span", "div"];
+    private static readonly IReadOnlySet<string> s_KeyBlacklist = new HashSet<string>
+    {
+        "span",
+        "div"
+    };
 
     public static void Handle(IEnumerable<EntityEntry> entityEntries)
     {
@@ -16,9 +20,15 @@ public static class BadTranslationPairHandler
             .ToList()
             .ForEach(x =>
             {
-                if (s_KeyBlacklist.Contains(x?.Key))
+                if (x is null)
                 {
-                    throw new TranslationPairKeyNotAllowedException();
+                    return;
+                }
+
+                if (x.Key.Length < 3 || s_KeyBlacklist.Contains(x.Key))
+                {
+                    throw new TranslationPairKeyNotAllowedException(
+                        $"The key ${x.Key} is not allowed. Keys 2 or fewer characters and some specific keys are not allowed.");
                 }
             });
     }

--- a/src/Aquifer.Data/EventHandlers/BadTranslationPairHandler.cs
+++ b/src/Aquifer.Data/EventHandlers/BadTranslationPairHandler.cs
@@ -1,0 +1,25 @@
+﻿using Aquifer.Data.Entities;
+using Aquifer.Data.Exceptions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace Aquifer.Data.EventHandlers;
+
+public static class BadTranslationPairHandler
+{
+    private static readonly IReadOnlyList<string> s_KeyBlacklist = ["span", "div"];
+
+    public static void Handle(IEnumerable<EntityEntry> entityEntries)
+    {
+        entityEntries.Where(entry => entry is { Entity: TranslationPairEntity, State: EntityState.Modified or EntityState.Added })
+            .Select(x => x.Entity as TranslationPairEntity)
+            .ToList()
+            .ForEach(x =>
+            {
+                if (s_KeyBlacklist.Contains(x?.Key))
+                {
+                    throw new TranslationPairKeyNotAllowedException();
+                }
+            });
+    }
+}

--- a/src/Aquifer.Data/Exceptions/TranslationPairKeyNotAllowedException.cs
+++ b/src/Aquifer.Data/Exceptions/TranslationPairKeyNotAllowedException.cs
@@ -1,0 +1,16 @@
+﻿namespace Aquifer.Data.Exceptions;
+
+public class TranslationPairKeyNotAllowedException : Exception
+{
+    public TranslationPairKeyNotAllowedException()
+    {
+    }
+
+    public TranslationPairKeyNotAllowedException(string message) : base(message)
+    {
+    }
+
+    public TranslationPairKeyNotAllowedException(string message, Exception inner) : base(message, inner)
+    {
+    }
+}


### PR DESCRIPTION
Originally was going to use an interceptor (hence the branch name), but just adding to the saving event was simpler. Noticed that the other method was misnamed, and it runs after the records are already saved (so that was a nice waste of time).