### PR TITLE
Add Public API integration tests.

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -32,4 +32,8 @@ jobs:
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
                   subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
             - name: Test
-              run: dotnet test -e ASPNETCORE_ENVIRONMENT="${{ vars.ASPNETCORE_ENVIRONMENT }}" -e ConnectionStrings__AzureStorageAccount="${{ secrets.AZURE_STORAGE_ACCOUNT_CONNECTION_STRING }}" -e ConnectionStrings__BiblioNexusDb="${{ secrets.BIBLIONEXUS_DB_CONNECTION_STRING }}"
+              run: |
+                  dotnet test \
+                      -e ASPNETCORE_ENVIRONMENT="${{ vars.ASPNETCORE_ENVIRONMENT }}" \
+                      -e ConnectionStrings__AzureStorageAccount="${{ secrets.AZURE_STORAGE_ACCOUNT_CONNECTION_STRING }}" \
+                      -e ConnectionStrings__BiblioNexusDb="${{ secrets.BIBLIONEXUS_DB_CONNECTION_STRING }}"

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -20,5 +20,15 @@ jobs:
                   dotnet-version: '9.x'
             - name: Build
               run: dotnet build --no-incremental --configuration Release /p:WarningsAsErrors=true /warnaserror
+            - name: Login to Azure
+              uses: azure/login@v2.1.1
+              with:
+                  client-id: ${{ secrets.AZURE_CLIENT_ID }}
+                  tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+                  subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
             - name: Test
-              run: dotnet test
+              run: |
+                dotnet test \
+                  -e ASPNETCORE_ENVIRONMENT="${{ vars.ASPNETCORE_ENVIRONMENT }}" \
+                  -e ConnectionStrings__AzureStorageAccount="${{ secrets.AZURE_STORAGE_ACCOUNT_CONNECTION_STRING }}" \
+                  -e ConnectionStrings__BiblioNexusDb="${{ secrets.BIBLIONEXUS_DB_CONNECTION_STRING }}"

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -6,7 +6,7 @@ on:
             - '**'
 
 permissions:
-    id-token: read
+    id-token: write
 
 jobs:
     lint_and_test:

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -32,8 +32,4 @@ jobs:
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
                   subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
             - name: Test
-              run: |
-                  dotnet test \
-                      -e ASPNETCORE_ENVIRONMENT="${{ vars.ASPNETCORE_ENVIRONMENT }}" \
-                      -e ConnectionStrings__AzureStorageAccount="${{ secrets.AZURE_STORAGE_ACCOUNT_CONNECTION_STRING }}" \
-                      -e ConnectionStrings__BiblioNexusDb="${{ secrets.BIBLIONEXUS_DB_CONNECTION_STRING }}"
+              run: dotnet test -e ASPNETCORE_ENVIRONMENT="${{ vars.ASPNETCORE_ENVIRONMENT }}" -e ConnectionStrings__AzureStorageAccount="${{ secrets.AZURE_STORAGE_ACCOUNT_CONNECTION_STRING }}" -e ConnectionStrings__BiblioNexusDb="${{ secrets.BIBLIONEXUS_DB_CONNECTION_STRING }}"

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -9,6 +9,8 @@ jobs:
     lint_and_test:
         name: Lint and test
         runs-on: ubuntu-latest
+        environment:
+            name: qa-tests
         steps:
             - name: Checkout source code
               uses: actions/checkout@v4.1.7

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -5,6 +5,9 @@ on:
         branches:
             - '**'
 
+permissions:
+    id-token: read
+
 jobs:
     lint_and_test:
         name: Lint and test
@@ -30,7 +33,7 @@ jobs:
                   subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
             - name: Test
               run: |
-                dotnet test \
-                  -e ASPNETCORE_ENVIRONMENT="${{ vars.ASPNETCORE_ENVIRONMENT }}" \
-                  -e ConnectionStrings__AzureStorageAccount="${{ secrets.AZURE_STORAGE_ACCOUNT_CONNECTION_STRING }}" \
-                  -e ConnectionStrings__BiblioNexusDb="${{ secrets.BIBLIONEXUS_DB_CONNECTION_STRING }}"
+                  dotnet test \
+                      -e ASPNETCORE_ENVIRONMENT="${{ vars.ASPNETCORE_ENVIRONMENT }}" \
+                      -e ConnectionStrings__AzureStorageAccount="${{ secrets.AZURE_STORAGE_ACCOUNT_CONNECTION_STRING }}" \
+                      -e ConnectionStrings__BiblioNexusDb="${{ secrets.BIBLIONEXUS_DB_CONNECTION_STRING }}"

--- a/Aquifer.sln
+++ b/Aquifer.sln
@@ -48,6 +48,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aquifer.JsEngine.UnitTests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aquifer.AI", "src\Aquifer.AI\Aquifer.AI.csproj", "{2F91DE0E-17AB-4DDD-9D73-9BE6CC1B1355}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aquifer.Public.API.IntegrationTests", "tests\Aquifer.Public.API.IntegrationTests\Aquifer.Public.API.IntegrationTests.csproj", "{0CF81CD4-6257-4A36-BF67-C1C581E93951}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -104,6 +106,10 @@ Global
 		{2F91DE0E-17AB-4DDD-9D73-9BE6CC1B1355}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2F91DE0E-17AB-4DDD-9D73-9BE6CC1B1355}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2F91DE0E-17AB-4DDD-9D73-9BE6CC1B1355}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0CF81CD4-6257-4A36-BF67-C1C581E93951}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0CF81CD4-6257-4A36-BF67-C1C581E93951}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0CF81CD4-6257-4A36-BF67-C1C581E93951}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0CF81CD4-6257-4A36-BF67-C1C581E93951}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -122,6 +128,7 @@ Global
 		{A89EF560-F8D2-4BEF-ACE2-63ABB30FF999} = {795E7203-D40F-4962-837D-DD39BAF2C930}
 		{75A88D22-58A0-4F4F-B235-3A01AB40914D} = {51DD9DE3-DA20-4C0B-82D6-029445F6BD42}
 		{2F91DE0E-17AB-4DDD-9D73-9BE6CC1B1355} = {795E7203-D40F-4962-837D-DD39BAF2C930}
+		{0CF81CD4-6257-4A36-BF67-C1C581E93951} = {51DD9DE3-DA20-4C0B-82D6-029445F6BD42}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8E32492B-EA66-40E4-A7A8-67E4ABA14A53}

--- a/Aquifer.sln
+++ b/Aquifer.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{51DD9DE3-DA20-4C0B-82D6-029445F6BD42}"
 	ProjectSection(SolutionItems) = preProject
 		tests\Directory.Build.props = tests\Directory.Build.props
+		tests\readme.md = tests\readme.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aquifer.API", "src\Aquifer.API\Aquifer.API.csproj", "{831A381B-68CF-4ED8-A5FC-FD2A4D94F18B}"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,8 +13,9 @@
     <PackageVersion Include="Azure.Storage.Queues" Version="12.21.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
-    <PackageVersion Include="FastEndpoints" Version="5.31.0" />
-    <PackageVersion Include="FastEndpoints.Swagger" Version="5.31.0" />
+    <PackageVersion Include="FastEndpoints" Version="5.32.0" />
+    <PackageVersion Include="FastEndpoints.Swagger" Version="5.32.0" />
+    <PackageVersion Include="FastEndpoints.Testing" Version="5.32.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageVersion Include="JavaScriptEngineSwitcher.V8" Version="3.24.2" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
@@ -37,7 +38,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="OpenAI" Version="2.0.0" />
     <PackageVersion Include="Polly" Version="8.5.0" />
@@ -45,7 +46,7 @@
     <PackageVersion Include="ReverseMarkdown" Version="4.6.0" />
     <PackageVersion Include="SendGrid" Version="9.29.3" />
     <PackageVersion Include="SendGrid.Extensions.DependencyInjection" Version="1.0.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.1.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/src/Aquifer.Public.API/Program.cs
+++ b/src/Aquifer.Public.API/Program.cs
@@ -60,3 +60,6 @@ app.UseHealthChecks("/_health")
 app.UseResponseCachingVaryByAllQueryKeys();
 
 app.Run();
+
+// make this class public in order to access from integration tests
+public partial class Program;

--- a/tests/Aquifer.Public.API.IntegrationTests/AppFixture.cs
+++ b/tests/Aquifer.Public.API.IntegrationTests/AppFixture.cs
@@ -1,0 +1,66 @@
+﻿using FastEndpoints.Testing;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Aquifer.Public.API.IntegrationTests;
+
+/// <summary>
+/// This is a FastEndpoints <see cref="AppFixture"/> that sits on top of a <see cref="WebApplicationFactory{TEntryPoint}"/>
+/// which allows for in-memory web requests to be sent and received without actual network traffic.
+/// Details:
+/// * https://fast-endpoints.com/docs/integration-unit-testing
+/// * https://learn.microsoft.com/en-us/aspnet/core/test/integration-tests
+/// </summary>
+public sealed class AppFixture : AppFixture<Program>
+{
+    /// <summary>
+    /// Configure Clients here.
+    /// The default Client is anonymous and has no API Key header value.
+    /// That is sufficient for Public API tests because all routes are anonymous and no actual web requests are sent via this fixture.
+    /// </summary>
+    /// <remarks>
+    /// Example of adding a default header to the existing client:
+    /// <example>
+    /// <code>
+    /// Client.DefaultRequestHeaders.Add("api-key", "TODO");
+    /// </code>
+    /// </example>
+    /// An entirely new client could be defined in this class and set up in this method as well (e.g. an authenticated client).
+    /// </remarks>
+    protected override Task SetupAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// The app is configured in <see cref="Program"/> before this method is called.
+    /// Only use this method to override or extend existing host configuration.
+    /// </summary>
+    protected override void ConfigureApp(IWebHostBuilder builder)
+    {
+        // The environment must be explicitly set as it will not default to "Development".
+        // On the build server this environment variable should be explicitly populated.
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")))
+        {
+            builder.UseEnvironment(Environments.Development);
+        }
+    }
+
+    /// <summary>
+    /// The service registrations in <see cref="Program"/> run before this method is called.
+    /// Only use this method to add additional services or to override existing registrations from the API.
+    /// </summary>
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+    }
+
+    /// <summary>
+    /// Use this method to dispose of any <see cref="HttpClient"/>s created in <see cref="SetupAsync"/>.
+    /// </summary>
+    protected override Task TearDownAsync()
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Aquifer.Public.API.IntegrationTests/AppFixture.cs
+++ b/tests/Aquifer.Public.API.IntegrationTests/AppFixture.cs
@@ -18,7 +18,8 @@ public sealed class AppFixture : AppFixture<Program>
     /// <summary>
     /// Configure Clients here.
     /// The default Client is anonymous and has no API Key header value.
-    /// That is sufficient for Public API tests because all routes are anonymous and no actual web requests are sent via this fixture.
+    /// This is sufficient for Public API tests because all routes are anonymous and no actual web requests are sent via this fixture.
+    /// The API key is enforced by Azure API Management when proxying requests, and thus it is not needed locally.
     /// </summary>
     /// <remarks>
     /// Example of adding a default header to the existing client:

--- a/tests/Aquifer.Public.API.IntegrationTests/Aquifer.Public.API.IntegrationTests.csproj
+++ b/tests/Aquifer.Public.API.IntegrationTests/Aquifer.Public.API.IntegrationTests.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FastEndpoints.Testing" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Aquifer.Public.API\Aquifer.Public.API.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Aquifer.Public.API.IntegrationTests/BiblesListTestFixture.cs
+++ b/tests/Aquifer.Public.API.IntegrationTests/BiblesListTestFixture.cs
@@ -1,0 +1,25 @@
+﻿using System.Net;
+using Aquifer.Public.API.Endpoints.Bibles.List;
+using FastEndpoints.Testing;
+using FastEndpoints;
+
+namespace Aquifer.Public.API.IntegrationTests;
+
+public sealed class BiblesListTestFixture(AppFixture _appFixture) : TestBase<AppFixture>
+{
+    [Fact]
+    public async Task ValidRequest_ShouldReturnSuccess()
+    {
+        var (response, result) = await _appFixture.Client.GETAsync<Endpoint, Request, IReadOnlyList<Response>>(
+            new Request
+            {
+                IsLanguageDefault = true,
+                LanguageId = 1,
+                HasAudio = true,
+                HasGreekAlignment = true,
+            });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains(result, r => r.Abbreviation == "BSB");
+    }
+}

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -8,16 +8,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Update="coverlet.collector">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="coverlet.collector" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
-        <PackageReference Update="xunit.runner.visualstudio">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="xunit.runner.visualstudio" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -1,0 +1,87 @@
+# Aquifer Tests
+
+This directory contains automated tests which must succeed as part of the CI/CD process.
+Health checks are not included here; they run as part of deployment.
+
+We currently use XUnit for testing in .net.
+
+## Running the Tests
+
+Run the following from the solution root directory:
+
+```bash
+dotnet test
+```
+
+You can also use an IDE to run one or more tests with results visible in the IDE's Test Runner UI.
+
+## Testing Philosophy
+
+Tests give us more confidence that our code works, both when writing code initially and when updating existing code.
+[Test Driven Development (TDD)](https://en.wikipedia.org/wiki/Test-driven_development) is not a developer requirement
+but the general philosophy helps developers to think like a consumer of the code that they are writing and to consider
+edge cases as part of initial development.
+
+Tests are not foolproof and manual developer testing is still an important part of the development process.
+
+There are three different kinds of test, each of which provide different levels of testing coverage:
+
+### Unit Tests
+
+Simplistic definition: Unit Tests _do not_ have I/O dependencies.
+
+1. Unit Test (simple): Test a small isolated method/class behavior with no dependencies (i.e. a utility class or utility method).
+1. Unit Test (complex): Test larger functionality by faking/stubbing/mocking dependencies
+   (using a tool like [NSubstitute](https://nsubstitute.github.io/)).
+   These tests have less value, often inject business logic into tests, are fragile tests that break easily when application logic
+   changes, and take longer to write.  Sometimes they are worth writing (if the fakes are very simple) but generally are best avoided
+   in favor of factoring out the code under test so that a simple unit test can be used.
+
+Unit tests should be very fast to execute because they run in a single process and don't make any network calls.
+
+Examples:
+* A test that ensures that a utility method correctly parses verse IDs.
+* A test that creates a fake IP lookup service (which doesn't actually make web requests) in order to ensure that complicated
+  consuming logic around IP addresses works correctly.
+* A test of a single UI view model that mocks all models and services in order to ensure that the view model acts appropriately.
+* A test of a single UI component via a tool like [Jest](https://jestjs.io/) which doesn't make any API calls by providing fake data.
+
+### Integration Tests
+
+Simplistic definition: Integration tests _do_ have I/O dependencies.
+
+Integration tests test full functionality of modules/components, ideally without any fakes/stubs/mocks.
+I/O operations are often included (which makes this kind of testing more difficult), though they are often isolated to only
+the application under test.
+
+Integration tests are slower to execute because they make network calls.
+
+Examples:
+* A test that sends a web request to a back-end API and ensures that the response is correct.  The API will do all normal operations
+  including auth, calling downstream APIs, making DB calls, etc.
+* A test of a service that makes database calls to a distributed DB and ensures that the result is correct.
+
+### End-to-end (E2E) Tests
+
+Simplistic definition: E2E tests test the application just like an end user; some people also call these Integration Tests.
+
+E2E tests are slow to execute because they emulate user behavior.
+
+Examples:
+* A test that opens a browser, interacts with UI elements to cause the front-end to send a web request to the back-end,
+waits for the UI to update, and confirms that the UI has the correct display of information.
+* A test that navigates a mobile app's menu and ensures that all main pages display content with no error messages when opened.
+  To be clear, this includes making all I/O calls from the mobile app just like normal as part of the testing
+  (e.g. talk to the API from the mobile app).
+
+### Which kind of test should I write?
+
+The more advanced the testing and the more live dependencies the more likely it is that we'll get transient test failures.
+Thus, ideally Unit Tests are more thorough (and include regression tests whenever we fix bugs) and E2E testing only tests
+the happy path to make sure that basic functionality doesn't break when we make changes.  Integration tests are a medium
+between these that test less functionality (such as only the back-end) but has transient dependencies prone to failure.
+
+As a general rule, write more unit tests but avoid writing complicated fakes/mocks/stubs.  If you need significant complexity
+for fakes/mocks/stubs then you are just rewriting the business logic in your test and should probably be using
+an integration test of the _actual_ business logic instead of duplicating it in your tests.  E2E tests are slow and fragile
+which is why we only want to use them for the happy path as an automated form of QA testing.


### PR DESCRIPTION
This PR implements integration testing of the Public API via `FastEndpoints.Testing` and `WebApplicationFactory` which create an in-memory API service which uses an `HttpClient` that doesn't actually make any network calls in order to test the `Endpoint`s using the existing `Request` and `Response` objects.

The build server won't pass the tests until we add environment variables as GitHub Secrets for the needed `appsettings.json` overrides (see "Edit Workflow" [here](https://medium.com/@gabreguarnieri/keep-your-keys-safe-while-testing-and-deploying-your-application-414a9e15b32f) for an example).  If I get good feedback on this PR I'll work on adding those.