### PR TITLE
Run DB migrations when deploying Jobs.

### DIFF
--- a/.github/workflows/post-merge-jobs.yml
+++ b/.github/workflows/post-merge-jobs.yml
@@ -63,6 +63,8 @@ jobs:
                 cd src/Aquifer.Jobs
                 dotnet build --configuration Release --output ../../build --runtime win-x64
                 cd ../..
+            - name: Bundle migrations
+              run: dotnet ef migrations bundle --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --output build/Migrate --self-contained
             - name: Publish artifact
               uses: actions/upload-artifact@v4.4.0
               with:
@@ -98,6 +100,18 @@ jobs:
               with:
                   name: build
                   path: build
+            - name: Login to Azure
+              uses: azure/login@v2.1.1
+              with:
+                  client-id: ${{ secrets.AZURE_CLIENT_ID }}
+                  tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+                  subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+            - name: Make migration script executable
+              run: chmod +x ./build/Migrate
+              shell: bash
+            - name: Run migrations
+              run: ./build/Migrate --connection '${{ vars.DB_CONNECTION_URL_DEV_QA }}'
+              shell: bash
             - name: Deploy Jobs to dev/qa
               uses: Azure/functions-action@v1.5.2
               with:
@@ -148,6 +162,18 @@ jobs:
               with:
                   name: build
                   path: build
+            - name: Login to Azure
+              uses: azure/login@v2.1.1
+              with:
+                  client-id: ${{ secrets.AZURE_CLIENT_ID }}
+                  tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+                  subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+            - name: Make migration script executable
+              run: chmod +x ./build/Migrate
+              shell: bash
+            - name: Run migrations
+              run: ./build/Migrate --connection '${{ vars.DB_CONNECTION_URL_PROD }}'
+              shell: bash
             - name: Deploy Jobs to prod
               uses: Azure/functions-action@v1.5.2
               with:


### PR DESCRIPTION
Required configuration changes:
- [x] Add `DB_CONNECTION_URL_DEV_QA` environment variable to [GitHub Actions](https://github.com/BiblioNexusStudio/aquifer-server/settings/environments/2113106726/edit) for `dev-qa-jobs`.
- [x] Add `DB_CONNECTION_URL_PROD` environment variable to [GitHub Actions](https://github.com/BiblioNexusStudio/aquifer-server/settings/environments/2113118907/edit) for `prod-jobs`.
- [x] Create [GitHub Actions federated credentials](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Credentials/appId/c2e416d1-af8f-4ea3-a58a-6bad22ef32c2/isMSAApp~/false) for `dev-qa-jobs` and `prod-jobs` to allow access to the DB using the above connection string from GitHub Actions:
     * `GithubActionsDeployDevQaJobs`: `repo:BiblioNexusStudio/aquifer-server:environment:dev-qa-jobs`
     * `GithubActionsDeployProdJobs`: `repo:BiblioNexusStudio/aquifer-server:environment:prod-jobs`