### PR TITLE
Generate Clients for Public API.

### DIFF
--- a/Aquifer.sln
+++ b/Aquifer.sln
@@ -33,6 +33,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
+		Directory.Solution.props = Directory.Solution.props
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+        <WarningsNotAsErrors>NU1608;NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
         <NoWarn>MSB3245</NoWarn>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <GitHubOrganization>BiblioNexusStudio</GitHubOrganization>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,8 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <WarningsNotAsErrors>NU1608;NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-        <NoWarn>MSB3245</NoWarn>
+        <WarningsNotAsErrors>MSB3245;NU1608;NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <GitHubOrganization>BiblioNexusStudio</GitHubOrganization>
         <RepositoryName>aquifer-server</RepositoryName>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
     <PackageVersion Include="FastEndpoints" Version="5.32.0" />
+    <PackageVersion Include="FastEndpoints.ClientGen.Kiota" Version="5.32.0" />
     <PackageVersion Include="FastEndpoints.Swagger" Version="5.32.0" />
     <PackageVersion Include="FastEndpoints.Testing" Version="5.32.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.71" />

--- a/Directory.Solution.props
+++ b/Directory.Solution.props
@@ -1,0 +1,13 @@
+<Project>
+
+    <!-- This implements the equivalent of running `dotnet build /warnaserror -warnNotAsError:NU1608` from the command line.
+         If https://github.com/dotnet/msbuild/issues/10871 is fixed then we can probably delete this file because these settings
+         will be inherited from the `Directory.Build.Props`'s `TreatWarningsAsErrors` and `WarningsNotAsErrors` properties.
+         For now only the warning codes that still error with the above command despite being in `WarningsNotAsErrors`
+         need to be duplicated here. -->
+    <PropertyGroup>
+        <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
+        <MSBuildWarningsNotAsErrors>NU1608;MSB3245</MSBuildWarningsNotAsErrors>
+    </PropertyGroup>
+
+</Project>

--- a/src/Aquifer.Common/Tiptap/TiptapConverter.cs
+++ b/src/Aquifer.Common/Tiptap/TiptapConverter.cs
@@ -98,6 +98,6 @@ public static class TiptapConverter
         ///     Keep the Tiptap JSON as-is.
         /// </summary>
         [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
-        public required string Tiptap { get; init; }
+        public required object Tiptap { get; init; }
     }
 }

--- a/src/Aquifer.Common/Utilities/JsonUtilities.cs
+++ b/src/Aquifer.Common/Utilities/JsonUtilities.cs
@@ -29,24 +29,27 @@ public static class JsonUtilities
 
     /// <summary>
     /// Serializes the contents of a string value as raw JSON.  The string is validated as being an RFC 8259-compliant JSON payload.
+    /// The property is represented as an <see cref="object"/> instead of a <see cref="string"/> for API spec generation purposes.
     /// </summary>
     /// <example>
     /// [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
-    /// public required string Data { get; init; } // JSON string
+    /// public required object Data { get; init; } // JSON string
     /// </example>
-    public sealed class RawJsonConverter : JsonConverter<string>
+    public sealed class RawJsonConverter : JsonConverter<object>
     {
-        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             using var doc = JsonDocument.ParseValue(ref reader);
             return doc.RootElement.GetRawText();
         }
 
-        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
         {
             // Setting skipInputValidation to true will result in better performance.
             // However, unless the data is guaranteed to be valid JSON it should not be used.
-            writer.WriteRawValue(value, skipInputValidation: false);
+            writer.WriteRawValue(
+                value as string ?? throw new ArgumentException("Value must be a string", nameof(value)),
+                skipInputValidation: false);
         }
     }
 }

--- a/src/Aquifer.JsEngine/Aquifer.JsEngine.csproj
+++ b/src/Aquifer.JsEngine/Aquifer.JsEngine.csproj
@@ -2,8 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Aquifer.Public.API/Aquifer.Public.API.csproj
+++ b/src/Aquifer.Public.API/Aquifer.Public.API.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -8,6 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Azure.Storage.Queues" />
         <PackageReference Include="FastEndpoints" />
+        <PackageReference Include="FastEndpoints.ClientGen.Kiota" />
         <PackageReference Include="FastEndpoints.Swagger" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" />

--- a/src/Aquifer.Public.API/Endpoints/Bibles/List/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Bibles/List/Endpoint.cs
@@ -36,12 +36,11 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IReadOnlyL
                 Name = bible.Name,
                 Abbreviation = bible.Abbreviation,
                 Id = bible.Id,
-                SerializedLicenseInfo = bible.LicenseInfo,
+                LicenseInfo = bible.LicenseInfo,
                 LanguageId = bible.LanguageId,
                 IsLanguageDefault = bible.LanguageDefault,
                 HasAudio = bible.BibleBookContents.Any(bbc => bbc.AudioUrls != null),
                 HasGreekAlignment = bible.GreekAlignment,
-                LicenseInfo = bible.LicenseInfo,
             })
             .ToListAsync(ct);
 

--- a/src/Aquifer.Public.API/Endpoints/Bibles/List/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Bibles/List/Endpoint.cs
@@ -41,6 +41,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IReadOnlyL
                 IsLanguageDefault = bible.LanguageDefault,
                 HasAudio = bible.BibleBookContents.Any(bbc => bbc.AudioUrls != null),
                 HasGreekAlignment = bible.GreekAlignment,
+                LicenseInfo = bible.LicenseInfo,
             })
             .ToListAsync(ct);
 

--- a/src/Aquifer.Public.API/Endpoints/Bibles/List/Response.cs
+++ b/src/Aquifer.Public.API/Endpoints/Bibles/List/Response.cs
@@ -14,8 +14,5 @@ public record Response
     public required bool HasGreekAlignment { get; init; }
 
     [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
-    public required string? LicenseInfo { get; init; }
-
-    [JsonIgnore]
-    public string? SerializedLicenseInfo { get; init; }
+    public required object? LicenseInfo { get; init; }
 }

--- a/src/Aquifer.Public.API/Endpoints/Bibles/List/Response.cs
+++ b/src/Aquifer.Public.API/Endpoints/Bibles/List/Response.cs
@@ -13,8 +13,8 @@ public record Response
     public required bool HasAudio { get; init; }
     public required bool HasGreekAlignment { get; init; }
 
-    public object? LicenseInfo =>
-        SerializedLicenseInfo == null ? null : JsonUtilities.DefaultDeserialize(SerializedLicenseInfo);
+    [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
+    public required string? LicenseInfo { get; init; }
 
     [JsonIgnore]
     public string? SerializedLicenseInfo { get; init; }

--- a/src/Aquifer.Public.API/Endpoints/Resources/Collections/Get/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Collections/Get/Endpoint.cs
@@ -187,8 +187,10 @@ public sealed class Endpoint(AquiferDbContext _dbContext, ICachingLanguageServic
             parameters,
             cancellationToken: ct);
 
+#pragma warning disable VSTHRD103 // using the non-async Read() method is correct because I/O was already awaited above in QueryMultipleAsync()
         var parentResourceLocalizations = reader.Read<ParentResourceLocalization>().ToList();
         var resourceContentCounts = reader.Read<ResourceContentCount>().ToList();
+#pragma warning restore VSTHRD103
 
         // Note that there may be more ParentResourceLocalization entries than counts because we translate the parent resource names
         // before resource contents begin translation.  If this happens, then due to the Join() call here all

--- a/src/Aquifer.Public.API/Endpoints/Resources/Collections/Get/Response.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Collections/Get/Response.cs
@@ -12,7 +12,7 @@ public sealed class Response
     public required ResourceType ResourceType { get; init; }
 
     [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
-    public required string? LicenseInfo { get; init; }
+    public required object? LicenseInfo { get; init; }
 
     public required IReadOnlyList<AvailableLanguageResponse> AvailableLanguages { get; init; }
 }

--- a/src/Aquifer.Public.API/Endpoints/Resources/Get/Request.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Get/Request.cs
@@ -14,7 +14,7 @@ public record Request
     ///     The type of text content to return in the `content` property of the response (JSON is always sent back for the response as a
     ///     whole by default). This parameter is optional and defaults to `None`.
     ///     <br />
-    ///     If `None` is passed, it wil return JSON specifically for the Tiptap Editor, if `Json` is specified, it will return a simplified
+    ///     If `None` is passed, it will return JSON specifically for the Tiptap Editor, if `Json` is specified, it will return a simplified
     ///     version with mention of Tiptap removed. `Markdown` and 'Html' can also be requested.
     ///     <br />
     ///     Note that this will be ignored for non-text resources. Content such as images will always return as JSON.

--- a/src/Aquifer.Public.API/Endpoints/Resources/Get/ResourceHelper.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Get/ResourceHelper.cs
@@ -63,7 +63,7 @@ public static class ResourceHelper
             ? req.ContentTextType == TiptapContentType.None ? TiptapContentType.Json : req.ContentTextType
             : TiptapContentType.None;
 
-        response.ContentObject = TiptapConverter.ConvertJsonToType(response.ContentValue, contentTextType);
+        response.Content = TiptapConverter.ConvertJsonToType(response.ContentValue, contentTextType);
         return response;
     }
 }

--- a/src/Aquifer.Public.API/Endpoints/Resources/Get/ResourceHelper.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Get/ResourceHelper.cs
@@ -63,7 +63,7 @@ public static class ResourceHelper
             ? req.ContentTextType == TiptapContentType.None ? TiptapContentType.Json : req.ContentTextType
             : TiptapContentType.None;
 
-        response.Content = TiptapConverter.ConvertJsonToType(response.ContentValue, contentTextType);
+        response.ContentObject = TiptapConverter.ConvertJsonToType(response.ContentValue, contentTextType);
         return response;
     }
 }

--- a/src/Aquifer.Public.API/Endpoints/Resources/Get/ResourceHelper.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Get/ResourceHelper.cs
@@ -37,7 +37,7 @@ public static class ResourceHelper
                     Name = x.ResourceContent.Resource.ParentResource.DisplayName,
                     Type = x.ResourceContent.Resource.ParentResource.ResourceType,
                     MediaTypeValue = x.ResourceContent.MediaType,
-                    LicenseInfoValue = x.ResourceContent.Resource.ParentResource.LicenseInfo
+                    LicenseInfo = x.ResourceContent.Resource.ParentResource.LicenseInfo
                 }
             })
             .ToListAsync(ct);

--- a/src/Aquifer.Public.API/Endpoints/Resources/Get/Response.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Get/Response.cs
@@ -17,16 +17,7 @@ public class Response
     [JsonIgnore]
     public string ContentValue { get; set; } = null!;
 
-    /// <summary>
-    /// Converted object from Tiptap.
-    /// </summary>
-    [JsonIgnore]
-    public object ContentObject { get; set; } = null!;
-
-    // Manually serialize the content in order to return a string instead of an object
-    // which allows auto-generated clients to work correctly.
-    [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
-    public string Content => JsonUtilities.DefaultSerialize(ContentObject);
+    public object Content { get; set; } = null!;
 
     public ResourceTypeMetadata Grouping { get; set; } = null!;
     public ResourceContentLanguage Language { get; set; } = null!;
@@ -44,7 +35,7 @@ public class ResourceTypeMetadata
     public string MediaType => MediaTypeValue.ToString();
 
     [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
-    public required string? LicenseInfo { get; init; }
+    public required object? LicenseInfo { get; init; }
 }
 
 public class ResourceContentLanguage

--- a/src/Aquifer.Public.API/Endpoints/Resources/Get/Response.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Get/Response.cs
@@ -11,10 +11,22 @@ public class Response
     public string Name { get; set; } = null!;
     public string LocalizedName { get; set; } = null!;
 
+    /// <summary>
+    /// DB Value (Tiptap string).
+    /// </summary>
     [JsonIgnore]
     public string ContentValue { get; set; } = null!;
 
-    public object Content { get; set; } = null!;
+    /// <summary>
+    /// Converted object from Tiptap.
+    /// </summary>
+    [JsonIgnore]
+    public object ContentObject { get; set; } = null!;
+
+    // Manually serialize the content in order to return a string instead of an object
+    // which allows auto-generated clients to work correctly.
+    [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
+    public string Content => JsonUtilities.DefaultSerialize(ContentObject);
 
     public ResourceTypeMetadata Grouping { get; set; } = null!;
     public ResourceContentLanguage Language { get; set; } = null!;

--- a/src/Aquifer.Public.API/Endpoints/Resources/Get/Response.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Get/Response.cs
@@ -31,10 +31,8 @@ public class ResourceTypeMetadata
 
     public string MediaType => MediaTypeValue.ToString();
 
-    [JsonIgnore]
-    public string? LicenseInfoValue { get; set; } = null!;
-
-    public object? LicenseInfo => LicenseInfoValue is null ? null : JsonUtilities.DefaultDeserialize(LicenseInfoValue);
+    [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
+    public required string? LicenseInfo { get; init; }
 }
 
 public class ResourceContentLanguage

--- a/src/Aquifer.Public.API/Endpoints/Resources/Types/List/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Types/List/Endpoint.cs
@@ -1,5 +1,4 @@
 using Aquifer.Common.Extensions;
-using Aquifer.Common.Utilities;
 using Aquifer.Data;
 using Aquifer.Data.Entities;
 using Aquifer.Public.API.Helpers;
@@ -41,7 +40,7 @@ public class Endpoint(AquiferDbContext dbContext) : EndpointWithoutRequest<List<
                 {
                     Code = x.Code,
                     Title = x.DisplayName,
-                    LicenseInformation = x.LicenseInfo != null ? JsonUtilities.DefaultDeserialize(x.LicenseInfo) : null
+                    LicenseInformation = x.LicenseInfo,
                 }).ToList()
             });
         }

--- a/src/Aquifer.Public.API/Endpoints/Resources/Types/List/Response.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Types/List/Response.cs
@@ -15,5 +15,5 @@ public class AvailableResourceCollection
     public required string Title { get; set; }
 
     [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
-    public required string? LicenseInformation { get; init; }
+    public required object? LicenseInformation { get; init; }
 }

--- a/src/Aquifer.Public.API/Endpoints/Resources/Types/List/Response.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Types/List/Response.cs
@@ -1,4 +1,7 @@
-﻿namespace Aquifer.Public.API.Endpoints.Resources.Types.List;
+﻿using System.Text.Json.Serialization;
+using Aquifer.Common.Utilities;
+
+namespace Aquifer.Public.API.Endpoints.Resources.Types.List;
 
 public class Response
 {
@@ -10,5 +13,7 @@ public class AvailableResourceCollection
 {
     public required string Code { get; set; }
     public required string Title { get; set; }
-    public object? LicenseInformation { get; set; }
+
+    [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
+    public required string? LicenseInformation { get; init; }
 }

--- a/src/Aquifer.Public.API/Endpoints/Resources/Updates/List/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Updates/List/Endpoint.cs
@@ -25,7 +25,7 @@ public class Endpoint(AquiferDbContext dbContext, ICachingLanguageService cachin
     public override async Task HandleAsync(Request req, CancellationToken ct)
     {
         ValidateCollectionCode(req);
-        var query = await GetQuery(req, ct);
+        var query = await GetQueryAsync(req, ct);
         var totalCount = await GetTotalResourceCountAsync(req, query, ct);
 
         if (totalCount == 0)
@@ -76,7 +76,7 @@ public class Endpoint(AquiferDbContext dbContext, ICachingLanguageService cachin
         return totalCount;
     }
 
-    private async Task<IQueryable<ResourceContentVersionEntity>> GetQuery(Request req, CancellationToken ct)
+    private async Task<IQueryable<ResourceContentVersionEntity>> GetQueryAsync(Request req, CancellationToken ct)
     {
         var (isValidLanguageId, isValidLanguageCode, validLanguageId) =
             await cachingLanguageService.ValidateLanguageIdOrCodeAsync(req.LanguageId, req.LanguageCode, false, ct);

--- a/src/Aquifer.Public.API/OpenApi/ClientGenerationSettings.cs
+++ b/src/Aquifer.Public.API/OpenApi/ClientGenerationSettings.cs
@@ -1,0 +1,127 @@
+﻿using FastEndpoints.ClientGen.Kiota;
+using Kiota.Builder;
+
+namespace Aquifer.Public.API.OpenApi;
+
+/// <summary>
+/// Generate client code and make it available as a zip file per language at `/clients/language-id`.
+/// See https://fast-endpoints.com/docs/swagger-support#api-client-generation.
+/// We could also generate clients from the command line or on build if desired.
+/// </summary>
+public static class ClientGenerationSettings
+{
+    private const string _clientsRouteName = "clients";
+
+    public static IEndpointRouteBuilder ConfigureClientGeneration(
+        this IEndpointRouteBuilder app,
+        string swaggerDocumentName,
+        TimeSpan clientZipCacheDuration)
+    {
+        app.MapApiClientEndpoint(
+            $"/{_clientsRouteName}/cs",
+            c =>
+            {
+                c.SwaggerDocumentName = swaggerDocumentName;
+                c.Language = GenerationLanguage.CSharp;
+                c.ClientNamespaceName = "BiblioNexus.Aquifer.API.Client";
+                c.ClientClassName = "AquiferClient";
+                c.OutputPath = Path.Combine(c.OutputPath, "cs", Path.GetRandomFileName());
+                c.ExcludePatterns = [$"**/{_clientsRouteName}/**"];
+            },
+            o =>
+            {
+                o.CacheOutput(p => p.Expire(clientZipCacheDuration));
+                o.WithTags("Clients");
+                o.WithSummary("Downloads C# client.");
+                o.WithDescription("""
+                    Downloads a zip file containing a generated C# client to use when calling this API.
+                    The generated source code uses [Kiota](https://learn.microsoft.com/en-us/openapi/kiota/) in order to make web requests. You will need to install the following dependencies:
+                      * `dotnet add package Microsoft.Kiota.Bundle --version 1.15.2` (or newer version)
+
+                    See also [this C# Kiota example](https://github.com/microsoft/kiota-samples/blob/main/get-started/quickstart/dotnet/src/Program.cs) for how to use a generated Kiota client.
+                    """);
+                o.WithOpenApi();
+            });
+
+        app.MapApiClientEndpoint(
+            $"/{_clientsRouteName}/java",
+            c =>
+            {
+                c.SwaggerDocumentName = swaggerDocumentName;
+                c.Language = GenerationLanguage.Java;
+                c.ClientNamespaceName = "org.biblionexus.aquifer.api.client";
+                c.ClientClassName = "AquiferClient";
+                c.OutputPath = Path.Combine(c.OutputPath, "java", Path.GetRandomFileName());
+                c.ExcludePatterns = [$"**/{_clientsRouteName}/**"];
+            },
+            o =>
+            {
+                o.CacheOutput(p => p.Expire(clientZipCacheDuration));
+                o.WithTags("Clients");
+                o.WithSummary("Download Java client.");
+                o.WithDescription("""
+                    Downloads a zip file containing a generated Java client to use when calling this API.
+                    The generated source code uses [Kiota](https://learn.microsoft.com/en-us/openapi/kiota/) in order to make web requests. You will need to install the following dependencies:
+                      * `com.microsoft.kiota:microsoft-kiota-bundle:1.8.0` (or newer version)
+                      * `jakarta.annotation:jakarta.annotation-api:2.1.1` (or newer version)
+
+                    See also [this Java Kiota example](https://github.com/microsoft/kiota-samples/blob/main/get-started/quickstart/java/app/src/main/java/kiotaposts/App.java) for how to use a generated Kiota client.
+                    """);
+                o.WithOpenApi();
+            });
+
+        app.MapApiClientEndpoint(
+            $"/{_clientsRouteName}/py",
+            c =>
+            {
+                c.SwaggerDocumentName = swaggerDocumentName;
+                c.Language = GenerationLanguage.Python;
+                c.ClientNamespaceName = "biblionexus_aquifer_api_client";
+                c.ClientClassName = "AquiferClient";
+                c.OutputPath = Path.Combine(c.OutputPath, "py", Path.GetRandomFileName());
+                c.ExcludePatterns = [$"**/{_clientsRouteName}/**"];
+            },
+            o =>
+            {
+                o.CacheOutput(p => p.Expire(clientZipCacheDuration));
+                o.WithTags("Clients");
+                o.WithSummary("Download Python client.");
+                o.WithDescription("""
+                    Downloads a zip file containing a generated Python client to use when calling this API.
+                    The generated source code uses [Kiota](https://learn.microsoft.com/en-us/openapi/kiota/) in order to make web requests. You will need to install the following dependencies:
+                      * `pip install microsoft-kiota-bundle==1.6.6` (or newer version)
+
+                    See also [this Python Kiota example](https://github.com/microsoft/kiota-samples/blob/main/get-started/quickstart/python/main.py) for how to use a generated Kiota client.
+                    """);
+                o.WithOpenApi();
+            });
+
+        app.MapApiClientEndpoint(
+            $"/{_clientsRouteName}/ts",
+            c =>
+            {
+                c.SwaggerDocumentName = swaggerDocumentName;
+                c.Language = GenerationLanguage.TypeScript;
+                c.ClientNamespaceName = "biblionexus-aquifer-api-client";
+                c.ClientClassName = "AquiferClient";
+                c.OutputPath = Path.Combine(c.OutputPath, "ts", Path.GetRandomFileName());
+                c.ExcludePatterns = [$"**/{_clientsRouteName}/**"];
+            },
+            o =>
+            {
+                o.CacheOutput(p => p.Expire(clientZipCacheDuration));
+                o.WithTags("Clients");
+                o.WithSummary("Download TypeScript client.");
+                o.WithDescription("""
+                    Downloads a zip file containing a generated TypeScript client to use when calling this API.
+                    The generated source code uses [Kiota](https://learn.microsoft.com/en-us/openapi/kiota/) in order to make web requests. You will need to install the following dependencies:
+                      * `npm install @microsoft/kiota-bundle@1.0.0-preview.77 -SE` (or newer version)
+
+                    See also [this TypeScript Kiota example](https://github.com/microsoft/kiota-samples/blob/main/get-started/quickstart/typescript/index.ts) for how to use a generated Kiota client.
+                    """);
+                o.WithOpenApi();
+            });
+
+        return app;
+    }
+}

--- a/src/Aquifer.Public.API/OpenApi/ClientGenerationSettings.cs
+++ b/src/Aquifer.Public.API/OpenApi/ClientGenerationSettings.cs
@@ -84,13 +84,18 @@ public static class ClientGenerationSettings
                             Retrieved Resource:
                               - ID: {resource?.Id}
                               - Name: {resource?.Name}
-                              - Content: {resource?.Content}
+                              - Content: {await GetUntypedNodeOriginalJsonAsync(resource.Content!)}
                             """);
                     }
                     catch (Exception ex)
                     {
                         Console.WriteLine($"ERROR: {ex.Message}");
                         Console.WriteLine(ex.StackTrace);
+                    }
+                    
+                    private static async Task<string> GetUntypedNodeOriginalJsonAsync(UntypedNode untypedNode)
+                    {
+                        return await KiotaJsonSerializer.SerializeAsStringAsync(untypedNode);
                     }
                     ```
                     The following class is used above to inject the API Key into the header:

--- a/src/Aquifer.Public.API/OpenApi/ClientGenerationSettings.cs
+++ b/src/Aquifer.Public.API/OpenApi/ClientGenerationSettings.cs
@@ -40,7 +40,8 @@ public static class ClientGenerationSettings
 
                     See also [this C# Kiota example](https://github.com/microsoft/kiota-samples/blob/main/get-started/quickstart/dotnet/src/Program.cs) for how to use a generated Kiota client.
                     
-                    Full example of a `Program.cs` file using the generated client and injecting an API key header:
+                    Full example of a `Program.cs` file using the generated client and injecting an API key header.
+                    The example code assumes that the downloaded client code files are contained in the same solution in the `BiblioNexus.Aquifer.API.Client` namespace.
                     ```
                     using System.Net.Http;
                     using BiblioNexus.Aquifer.API.Client;
@@ -55,14 +56,14 @@ public static class ClientGenerationSettings
                         new AnonymousAuthenticationProvider(),
                         httpClient: new HttpClient(httpMessageHandler!))
                     {
-                        BaseUrl = GetAquiferPublicApiBaseUri(environment),
+                        BaseUrl = "https://api.aquifer.bible",
                     };
                     
                     var aquiferClient = new AquiferClient(adapter);
                     
                     try
                     {
-                        // GET /biblebooks
+                        // GET /bibles/books
                         var bibleBooks = await aquiferClient.Bibles.Books.GetAsync();
                         
                         Console.WriteLine($"Retrieved {bibleBooks?.Count} Bible books.");
@@ -75,22 +76,49 @@ public static class ClientGenerationSettings
                         }))
                         ?.SingleOrDefault();
                         
-                        Console.WriteLine($"The English language default Bible is \"{englishDefaultBible?.Name}\" ({englishDefaultBible?.Abbreviation})");
+                        Console.WriteLine($"The English language default Bible is \"{englishDefaultBible?.Name}\" ({englishDefaultBible?.Abbreviation}).");
                         
                         // GET /resources/{id}
-                        var resource = await aquiferClient.Resources[1717].GetAsync();
+                        var resource = await aquiferClient.Resources[1717].GetAsync(b =>
+                        {
+                            b.QueryParameters.ContentTextType = "html";
+                        });
                         
                         Console.WriteLine($"""
                             Retrieved Resource:
-                              - ID: {resource?.Id}
-                              - Name: {resource?.Name}
-                              - Content: {await GetUntypedNodeOriginalJsonAsync(resource.Content!)}
+                              - ID: {resource!.Id}
+                              - Name: {resource.Name}
+                              - Content: {await GetUntypedNodeOriginalJsonAsync(resource.Content)}
                             """);
+                    }
+                    catch (ErrorResponse ex)
+                    {
+                        Console.WriteLine($"Error: {ex.Message}");
+                        Console.WriteLine($"Status Code: {ex.ResponseStatusCode}");
+                        if (ex.Errors != null)
+                        {
+                            foreach (var additionalData in ex.Errors.AdditionalData)
+                            {
+                                Console.WriteLine($"\"{additionalData.Key}\": \"{await GetAdditionalDataValueAsStringAsync(additionalData.Value)}\"");
+                            }
+                        }
+                        Console.WriteLine(ex.StackTrace);
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine($"ERROR: {ex.Message}");
+                        Console.WriteLine($"Error: {ex.Message}");
                         Console.WriteLine(ex.StackTrace);
+                    }
+                    
+                    private static async Task<string?> GetAdditionalDataValueAsStringAsync(object value)
+                    {
+                        if (value is UntypedNode untypedNode)
+                        {
+                            return await GetUntypedNodeOriginalJsonAsync(untypedNode);
+                        }
+                        
+                        // TODO use your JSON serialization strategy of choice to render a better string
+                        return value.ToString();
                     }
                     
                     private static async Task<string> GetUntypedNodeOriginalJsonAsync(UntypedNode untypedNode)
@@ -98,7 +126,7 @@ public static class ClientGenerationSettings
                         return await KiotaJsonSerializer.SerializeAsStringAsync(untypedNode);
                     }
                     ```
-                    The following class is used above to inject the API Key into the header:
+                    The following class is also used above in order to inject the API Key into every request header:
                     ```
                     public sealed class SetApiKeyHeaderRequestHandler(string _apiKey) : DelegatingHandler
                     {
@@ -192,6 +220,95 @@ public static class ClientGenerationSettings
                       * `npm install @microsoft/kiota-bundle@1.0.0-preview.77 -SE` (or newer version)
 
                     See also [this TypeScript Kiota example](https://github.com/microsoft/kiota-samples/blob/main/get-started/quickstart/typescript/index.ts) for how to use a generated Kiota client.
+                    
+                    The following is a full example of an `index.tx` file using the generated client and injecting an API key header.
+                    The example code assumes that the downloaded client code files are unzipped into a subdirectory named `client`.
+                    ```
+                    import { AnonymousAuthenticationProvider, SerializationWriter, serializeToJsonAsString, serializeUntypedNode, UntypedNode } from "@microsoft/kiota-abstractions";
+                    import { FetchRequestAdapter, KiotaClientFactory, MiddlewareFactory } from "@microsoft/kiota-http-fetchlibrary";
+                    import { createAquiferClient } from "./client/aquiferClient.js";
+                    import { SetApiKeyHeaderRequestHandler } from "./SetApiKeyHeaderRequestHandler.js";
+                    
+                    // see https://learn.microsoft.com/en-us/openapi/kiota/middleware?tabs=typescript
+                    const handlers = MiddlewareFactory.getDefaultMiddlewares();
+                    handlers.unshift(new SetApiKeyHeaderRequestHandler("your-api-key-goes-here"));
+                    const httpClient = KiotaClientFactory.create(undefined, handlers);
+                    const adapter = new FetchRequestAdapter(new AnonymousAuthenticationProvider(), undefined, undefined, httpClient);
+                    adapter.baseUrl = "https://api.aquifer.bible";
+                    
+                    const client = createAquiferClient(adapter);
+                    
+                    async function main(): Promise<void> {
+                      try {
+                        // GET /bibles/books
+                        const bibleBooks = await client.bibles.books.get();
+                        console.log(`Retrieved ${bibleBooks?.length} Bible books.`);
+                    
+                        // GET /bibles
+                        const getBiblesResult = await client.bibles.get({
+                            queryParameters: {
+                                languageCode: "eng",
+                                isLanguageDefault: true,
+                            },
+                        });
+                        const englishLanguageDefaultBible = getBiblesResult?.[0];
+                        console.log(`The English language default Bible is "${englishLanguageDefaultBible?.name}" (${englishLanguageDefaultBible?.abbreviation}).`);
+                    
+                        // GET /resources/{id}
+                        const resource = await client.resources.byContentId(1717).get({
+                            queryParameters: {
+                                contentTextType: "html",
+                            },
+                        });
+                        console.log(`Retrieved Resource:\n  - ID: ${resource?.id}\n  - Name: ${resource?.name}\n  - Content: ${getUntypedNodeOriginalJson(resource?.content!)}.`);
+                    
+                      } catch (error) {
+                        console.log("Error:");
+                        console.log(error);
+                      }
+                    }
+                    
+                    function getUntypedNodeOriginalJson(untypedNode: UntypedNode): string {
+                        const serializeUntypedNodeToJson = (writer: SerializationWriter, value?: Partial<UntypedNode> | null): void => {
+                            serializeUntypedNode(writer, value!);
+                        }
+                        return serializeToJsonAsString(untypedNode, serializeUntypedNodeToJson);
+                    }
+                    
+                    main();
+                    ```
+                    The following class is also used above in order to inject the API Key into every request header:
+                    ```
+                    import { RequestOption } from "@microsoft/kiota-abstractions";
+                    import { FetchRequestInit, Middleware } from "@microsoft/kiota-http-fetchlibrary";
+                    
+                    export class SetApiKeyHeaderRequestHandler implements Middleware {
+                        public constructor(private readonly _apiKey: string) {}
+                    
+                        /** @inheritdoc */
+                        next: Middleware | undefined;
+                    
+                        private setRequestHeader(options: FetchRequestInit | undefined, key: string, value: string): void {
+                            if (options) {
+                                if (!options.headers) {
+                                    options.headers = {};
+                                }
+                                options.headers[key] = value;
+                            }
+                        };
+                    
+                        /** @inheritdoc */
+                        public async execute(url: string, requestInit: RequestInit, requestOptions?: Record<string, RequestOption>): Promise<Response> {
+                            this.setRequestHeader(requestInit as FetchRequestInit, "api-key", this._apiKey);
+                    
+                            const response = await this.next?.execute(url, requestInit, requestOptions);
+                            if (!response) {
+                                throw new Error("No response returned by the next middleware.");
+                            }
+                            return response;
+                        }
+                    }
+                    ```
                     """);
                 o.WithName("AquiferPublicAPIEndpointsClientsGetTsEndpoint");
                 o.WithOpenApi();

--- a/src/Aquifer.Public.API/OpenApi/SwaggerDocumentSettings.cs
+++ b/src/Aquifer.Public.API/OpenApi/SwaggerDocumentSettings.cs
@@ -6,9 +6,11 @@ namespace Aquifer.Public.API.OpenApi;
 
 public static class SwaggerDocumentSettings
 {
-    public static IServiceCollection AddSwaggerDocumentSettings(this IServiceCollection service)
+    public const string DocumentName = "v1";
+
+    public static IServiceCollection AddSwaggerDocumentSettings(this IServiceCollection services)
     {
-        return service.SwaggerDocument(sd =>
+        return services.SwaggerDocument(sd =>
         {
             // turn off auto-grouping (but now must manually tag each endpoint using `WithTags()`)
             sd.AutoTagPathSegmentIndex = 0;
@@ -18,6 +20,7 @@ public static class SwaggerDocumentSettings
             sd.EndpointFilter = ep => ep.EndpointTags?.Contains(EndpointHelpers.EndpointTags.ExcludeFromSwaggerDocument) != true;
             sd.DocumentSettings = ds =>
             {
+                ds.DocumentName = DocumentName;
                 ds.Title = "Aquifer API Documentation";
                 ds.Description = """
                                  All endpoints require an API key in the `api-key` header.<br><br>
@@ -61,6 +64,7 @@ public static class SwaggerDocumentSettings
                 td["Resources/Types"] = "Endpoints for retrieving the different types of resource collections and resources.";
                 td["Languages"] = "Endpoints for pulling data specific to languages.";
                 td["Bibles"] = "Endpoints for discovering available Bibles and pulling down Bible text and audio information.";
+                td["Clients"] = "Endpoints for downloading generated client source code for calling this API.";
             };
         });
     }

--- a/src/Aquifer.Public.API/Program.cs
+++ b/src/Aquifer.Public.API/Program.cs
@@ -59,6 +59,8 @@ app.UseHealthChecks("/_health")
 
 app.UseResponseCachingVaryByAllQueryKeys();
 
+app.ConfigureClientGeneration(SwaggerDocumentSettings.DocumentName, TimeSpan.FromDays(365));
+
 app.Run();
 
 // make this class public in order to access from integration tests


### PR DESCRIPTION
There are now four new routes under `/docs/index.html?url=/swagger/v1/swagger.json#tag/Clients`, each of which downloads a zip file containing client source code for C#, TypeScript, Python, and Java, respectively.  For example, to download the C# client perform a GET request to `/clients/cs`.

This PR also adds substantial documentation to each of those routes about how to use the client.  The C# documentation is fully featured with a working example including how to inject the API Key into the header of every request; if we like this then examples for other languages could also be added.  See the screenshot below.  We could also consider moving this example into a standalone GitHub repo with examples for each language.

Concerns I found when consuming the generated C# client:
* The current OpenAPI spec is somewhat lacking in terms of schema names for response objects so the generated clients will use `Response1`, `Response2`, etc. (and the same for requests).  We could solve this by renaming the C# classes with descriptive names.
* We have many response properties that are `object`s in C# which get serialized to JSON but have no spec about how to deserialize them.  The ideal solution to this is to provide strongly typed objects for C# usage instead of sending JSON straight from the DB to the client (this would potentially solve `LicenseInfo` properties assuming there is a standard schema).  However, properties like a `resource.Content` have multiple representations and thus can never be strongly typed.  Therefore, I provided a method in the example C# code to convert the `UntypedNode` representation of these objects in the generated client models back to the original JSON string.  Consumers will need to write their own deserialization scheme for such properties.

Screenshot of C# client documentation:
![image](https://github.com/user-attachments/assets/246ca34d-ff91-46a8-9698-3bd1e2b2cccb)
