### PR TITLE
Use LicenseInfo strongly typed models and make DB column non-nullable.

### DIFF
--- a/src/Aquifer.API/Endpoints/Bibles/BibleLicenseInfo.cs
+++ b/src/Aquifer.API/Endpoints/Bibles/BibleLicenseInfo.cs
@@ -1,0 +1,33 @@
+﻿namespace Aquifer.API.Endpoints.Bibles;
+
+public sealed class BibleLicenseInfo
+{
+    public required string Title { get; init; }
+    public required LicenseCopyright Copyright { get; init; }
+    public required IReadOnlyList<LicenseDetails> Licenses { get; init; }
+
+    public sealed class LicenseCopyright
+    {
+        public string? Dates { get; set; }
+        public required LicenseCopyrightHolder Holder { get; init; }
+    }
+
+    public sealed class LicenseCopyrightHolder
+    {
+        public required string Name { get; init; }
+
+        // missing for some Bibles
+        public string? Url { get; set; }
+    }
+
+    public sealed class LicenseDetails
+    {
+        public required LicenseData Eng { get; init; }
+    }
+
+    public sealed class LicenseData
+    {
+        public required string Name { get; init; }
+        public required string Url { get; init; }
+    }
+}

--- a/src/Aquifer.API/Endpoints/Bibles/Language/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Bibles/Language/List/Endpoint.cs
@@ -23,7 +23,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, List<Respo
             {
                 Name = bible.Name,
                 Abbreviation = bible.Abbreviation,
-                SerializedLicenseInfo = bible.LicenseInfo,
+                LicenseInfo = JsonUtilities.DefaultDeserialize<BibleLicenseInfo>(bible.LicenseInfo),
                 Id = bible.Id,
                 LanguageId = bible.LanguageId,
                 RestrictedLicense = bible.RestrictedLicense,

--- a/src/Aquifer.API/Endpoints/Bibles/Language/List/Response.cs
+++ b/src/Aquifer.API/Endpoints/Bibles/Language/List/Response.cs
@@ -1,6 +1,3 @@
-using System.Text.Json.Serialization;
-using Aquifer.Common.Utilities;
-
 namespace Aquifer.API.Endpoints.Bibles.Language.List;
 
 public record Response
@@ -10,13 +7,7 @@ public record Response
     public required string Abbreviation { get; set; }
     public required int LanguageId { get; set; }
     public required bool RestrictedLicense { get; set; }
-
-    public object? LicenseInfo =>
-        SerializedLicenseInfo == null ? null : JsonUtilities.DefaultDeserialize(SerializedLicenseInfo);
-
-    [JsonIgnore]
-    public string? SerializedLicenseInfo { get; init; }
-
+    public required BibleLicenseInfo LicenseInfo { get; init; }
     public required IEnumerable<BibleBookMetadataResponse> Books { get; set; }
 }
 

--- a/src/Aquifer.API/Endpoints/Bibles/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Bibles/List/Endpoint.cs
@@ -1,4 +1,5 @@
 using Aquifer.API.Helpers;
+using Aquifer.Common.Utilities;
 using Aquifer.Data;
 using FastEndpoints;
 using Microsoft.EntityFrameworkCore;
@@ -23,7 +24,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, List<Respo
                 Name = bible.Name,
                 Abbreviation = bible.Abbreviation,
                 Id = bible.Id,
-                SerializedLicenseInfo = bible.LicenseInfo,
+                LicenseInfo = JsonUtilities.DefaultDeserialize<BibleLicenseInfo>(bible.LicenseInfo),
                 LanguageId = bible.LanguageId,
                 IsLanguageDefault = bible.LanguageDefault,
                 RestrictedLicense = bible.RestrictedLicense,

--- a/src/Aquifer.API/Endpoints/Bibles/List/Response.cs
+++ b/src/Aquifer.API/Endpoints/Bibles/List/Response.cs
@@ -1,6 +1,3 @@
-using System.Text.Json.Serialization;
-using Aquifer.Common.Utilities;
-
 namespace Aquifer.API.Endpoints.Bibles.List;
 
 public record Response
@@ -12,10 +9,5 @@ public record Response
     public required bool IsLanguageDefault { get; set; }
     public required bool RestrictedLicense { get; set; }
     public required bool GreekAlignment { get; set; }
-
-    public object? LicenseInfo =>
-        SerializedLicenseInfo == null ? null : JsonUtilities.DefaultDeserialize(SerializedLicenseInfo);
-
-    [JsonIgnore]
-    public string? SerializedLicenseInfo { get; init; }
+    public required BibleLicenseInfo LicenseInfo { get; init; }
 }

--- a/src/Aquifer.API/Endpoints/Marketing/ParentResourceStatuses/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Marketing/ParentResourceStatuses/List/Endpoint.cs
@@ -28,7 +28,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IEnumerabl
                                                                                    COUNT(RC.Id) AS TotalResources,
                                                                                    OtherLanguage.Total AS TotalLanguageResources,
                                                                                    OtherLanguage.LastPublished AS LastPublished,
-                                                                                   PR.LicenseInfo AS LicenseInfoValue,
+                                                                                   PR.LicenseInfo,
                                                                                    PR.ResourceType AS ResourceType
                                                                             FROM ResourceContents RC
                                                                                      INNER JOIN Resources R ON R.Id = RC.ResourceId
@@ -51,7 +51,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IEnumerabl
                 ResourceId = null,
                 ResourceType = "Bible(s)",
                 Title = b.Name,
-                LicenseInfo = b.LicenseInfo != null ? JsonUtilities.DefaultDeserialize<object>(b.LicenseInfo) : null,
+                LicenseInfo = JsonUtilities.DefaultDeserialize<Response.MarketingLicenseInfo>(b.LicenseInfo),
                 Status = ParentResourceStatus.Complete
             })
             .ToListAsync(ct);
@@ -73,7 +73,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IEnumerabl
             ResourceId = x.ResourceId,
             ResourceType = x.ResourceType.GetDisplayName(),
             Title = x.Title,
-            LicenseInfo = x.LicenseInfoValue is not null ? JsonUtilities.DefaultDeserialize<object>(x.LicenseInfoValue) : null,
+            LicenseInfo = JsonUtilities.DefaultDeserialize<Response.MarketingLicenseInfo>(x.LicenseInfo),
             Status = ParentResourceStatusHelpers.GetStatus(x.TotalResources, x.TotalLanguageResources, x.LastPublished)
         });
 
@@ -86,7 +86,7 @@ internal class ParentAndLanguageRow
     public ResourceType ResourceType { get; set; }
     public string Title { get; set; } = null!;
     public int ResourceId { get; set; }
-    public string? LicenseInfoValue { get; set; }
+    public required string LicenseInfo { get; set; }
     public int TotalResources { get; set; }
     public int TotalLanguageResources { get; set; }
     public DateTime? LastPublished { get; set; }

--- a/src/Aquifer.API/Endpoints/Marketing/ParentResourceStatuses/List/Response.cs
+++ b/src/Aquifer.API/Endpoints/Marketing/ParentResourceStatuses/List/Response.cs
@@ -5,6 +5,43 @@ public class Response
     public required int? ResourceId { get; set; }
     public required string ResourceType { get; set; }
     public required string Title { get; set; }
-    public required object? LicenseInfo { get; set; }
+    public required MarketingLicenseInfo? LicenseInfo { get; set; }
     public required ParentResourceStatus Status { get; set; }
+
+    // this is a merger of the BibleLicenseInfo and ResourceLicenseInfo types
+    public sealed class MarketingLicenseInfo
+    {
+        public required string Title { get; init; }
+        public required LicenseCopyright Copyright { get; init; }
+        public required IReadOnlyList<LicenseDetails> Licenses { get; init; }
+
+        // not present in Bibles
+        public bool? ShowAdaptationNoticeForEnglish { get; set; }
+        public bool? ShowAdaptationNoticeForNonEnglish { get; set; }
+
+        public sealed class LicenseCopyright
+        {
+            public string? Dates { get; set; }
+            public required LicenseCopyrightHolder Holder { get; init; }
+        }
+
+        public sealed class LicenseCopyrightHolder
+        {
+            public required string Name { get; init; }
+
+            // missing for some Bibles
+            public string? Url { get; set; }
+        }
+
+        public sealed class LicenseDetails
+        {
+            public required LicenseData Eng { get; init; }
+        }
+
+        public sealed class LicenseData
+        {
+            public required string Name { get; init; }
+            public required string Url { get; init; }
+        }
+    }
 }

--- a/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
@@ -27,10 +27,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
             {
                 EnglishLabel = rc.Resource.EnglishLabel,
                 ParentResourceName = rc.Resource.ParentResource.DisplayName,
-                ParentResourceLicenseInfo =
-                    rc.Resource.ParentResource.LicenseInfo == null
-                        ? null
-                        : JsonUtilities.DefaultDeserialize(rc.Resource.ParentResource.LicenseInfo),
+                ParentResourceLicenseInfo = JsonUtilities.DefaultDeserialize<ResourceLicenseInfo>(rc.Resource.ParentResource.LicenseInfo),
                 ResourceContentId = rc.Id,
                 ResourceId = rc.ResourceId,
                 Language = new LanguageResponse

--- a/src/Aquifer.API/Endpoints/Resources/Content/Get/Response.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Get/Response.cs
@@ -8,7 +8,7 @@ namespace Aquifer.API.Endpoints.Resources.Content.Get;
 public class Response
 {
     public required string ParentResourceName { get; set; }
-    public required object? ParentResourceLicenseInfo { get; set; }
+    public required ResourceLicenseInfo ParentResourceLicenseInfo { get; set; }
     public required string EnglishLabel { get; set; }
     public IEnumerable<VerseReferenceResponse> VerseReferences { get; set; } = null!;
     public IEnumerable<PassageReferenceResponse> PassageReferences { get; set; } = null!;

--- a/src/Aquifer.API/Endpoints/Resources/ParentResources/List/Response.cs
+++ b/src/Aquifer.API/Endpoints/Resources/ParentResources/List/Response.cs
@@ -14,10 +14,8 @@ public class Response
     public required int ResourceCountForLanguage { get; set; }
 
     [JsonIgnore]
-    public string? LicenseInfoValue { get; set; }
-
-    public object? LicenseInfo =>
-        LicenseInfoValue != null ? JsonUtilities.DefaultDeserialize(LicenseInfoValue) : null;
+    public required string LicenseInfoValue { get; set; }
+    public ResourceLicenseInfo LicenseInfo => JsonUtilities.DefaultDeserialize<ResourceLicenseInfo>(LicenseInfoValue);
 
     public required ResourceTypeComplexityLevel ComplexityLevel { get; set; }
     public required ResourceType ResourceType { get; set; }

--- a/src/Aquifer.API/Endpoints/Resources/ResourceLicenseInfo.cs
+++ b/src/Aquifer.API/Endpoints/Resources/ResourceLicenseInfo.cs
@@ -1,0 +1,33 @@
+﻿namespace Aquifer.API.Endpoints.Resources;
+
+public sealed class ResourceLicenseInfo
+{
+    public required string Title { get; init; }
+    public required LicenseCopyright Copyright { get; init; }
+    public required IReadOnlyList<LicenseDetails> Licenses { get; init; }
+    public required bool ShowAdaptationNoticeForEnglish { get; init; }
+    public required bool ShowAdaptationNoticeForNonEnglish { get; init; }
+
+    public sealed class LicenseCopyright
+    {
+        public string? Dates { get; set; }
+        public required LicenseCopyrightHolder Holder { get; init; }
+    }
+
+    public sealed class LicenseCopyrightHolder
+    {
+        public required string Name { get; init; }
+        public required string Url { get; init; }
+    }
+
+    public sealed class LicenseDetails
+    {
+        public required LicenseData Eng { get; init; }
+    }
+
+    public sealed class LicenseData
+    {
+        public required string Name { get; init; }
+        public required string Url { get; init; }
+    }
+}

--- a/src/Aquifer.Data/Entities/BibleEntity.cs
+++ b/src/Aquifer.Data/Entities/BibleEntity.cs
@@ -11,7 +11,7 @@ public class BibleEntity : IHasUpdatedTimestamp
     public int LanguageId { get; set; }
     public string Name { get; set; } = null!;
     public string Abbreviation { get; set; } = null!;
-    public string? LicenseInfo { get; set; }
+    public string LicenseInfo { get; set; } = null!;
     public bool Enabled { get; set; }
     public bool LanguageDefault { get; set; }
     public bool RestrictedLicense { get; set; }

--- a/src/Aquifer.Data/Entities/ParentResourceEntity.cs
+++ b/src/Aquifer.Data/Entities/ParentResourceEntity.cs
@@ -9,7 +9,7 @@ public class ParentResourceEntity : IHasUpdatedTimestamp
     public string ShortName { get; set; } = null!;
     public string Code { get; set; } = null!;
     public string DisplayName { get; set; } = null!;
-    public string? LicenseInfo { get; set; }
+    public string LicenseInfo { get; set; } = null!;
     public ResourceTypeComplexityLevel ComplexityLevel { get; set; }
     public ResourceType ResourceType { get; set; }
     public bool Enabled { get; set; }

--- a/src/Aquifer.Data/Migrations/20241218214155_Make_LicenseInfo_Nullable.Designer.cs
+++ b/src/Aquifer.Data/Migrations/20241218214155_Make_LicenseInfo_Nullable.Designer.cs
@@ -4,6 +4,7 @@ using Aquifer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Aquifer.Data.Migrations
 {
     [DbContext(typeof(AquiferDbContext))]
-    partial class AquiferDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241218214155_Make_LicenseInfo_Nullable")]
+    partial class Make_LicenseInfo_Nullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Aquifer.Data/Migrations/20241218214155_Make_LicenseInfo_Nullable.cs
+++ b/src/Aquifer.Data/Migrations/20241218214155_Make_LicenseInfo_Nullable.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Aquifer.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Make_LicenseInfo_Nullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "LicenseInfo",
+                table: "ParentResources",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LicenseInfo",
+                table: "Bibles",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "LicenseInfo",
+                table: "ParentResources",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LicenseInfo",
+                table: "Bibles",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+    }
+}

--- a/src/Aquifer.Public.API/Endpoints/Bibles/BibleLicenseInfo.cs
+++ b/src/Aquifer.Public.API/Endpoints/Bibles/BibleLicenseInfo.cs
@@ -1,0 +1,33 @@
+﻿namespace Aquifer.Public.API.Endpoints.Bibles;
+
+public sealed class BibleLicenseInfo
+{
+    public required string Title { get; init; }
+    public required LicenseCopyright Copyright { get; init; }
+    public required IReadOnlyList<LicenseDetails> Licenses { get; init; }
+
+    public sealed class LicenseCopyright
+    {
+        public string? Dates { get; set; }
+        public required LicenseCopyrightHolder Holder { get; init; }
+    }
+
+    public sealed class LicenseCopyrightHolder
+    {
+        public required string Name { get; init; }
+
+        // missing for some Bibles
+        public string? Url { get; set; }
+    }
+
+    public sealed class LicenseDetails
+    {
+        public required LicenseData Eng { get; init; }
+    }
+
+    public sealed class LicenseData
+    {
+        public required string Name { get; init; }
+        public required string Url { get; init; }
+    }
+}

--- a/src/Aquifer.Public.API/Endpoints/Bibles/List/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Bibles/List/Endpoint.cs
@@ -1,4 +1,5 @@
-﻿using Aquifer.Data;
+﻿using Aquifer.Common.Utilities;
+using Aquifer.Data;
 using FastEndpoints;
 using Microsoft.EntityFrameworkCore;
 
@@ -36,7 +37,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IReadOnlyL
                 Name = bible.Name,
                 Abbreviation = bible.Abbreviation,
                 Id = bible.Id,
-                LicenseInfo = bible.LicenseInfo,
+                LicenseInfo = JsonUtilities.DefaultDeserialize<BibleLicenseInfo>(bible.LicenseInfo),
                 LanguageId = bible.LanguageId,
                 IsLanguageDefault = bible.LanguageDefault,
                 HasAudio = bible.BibleBookContents.Any(bbc => bbc.AudioUrls != null),

--- a/src/Aquifer.Public.API/Endpoints/Bibles/List/Response.cs
+++ b/src/Aquifer.Public.API/Endpoints/Bibles/List/Response.cs
@@ -1,7 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using Aquifer.Common.Utilities;
-
-namespace Aquifer.Public.API.Endpoints.Bibles.List;
+﻿namespace Aquifer.Public.API.Endpoints.Bibles.List;
 
 public record Response
 {
@@ -12,7 +9,5 @@ public record Response
     public required bool IsLanguageDefault { get; init; }
     public required bool HasAudio { get; init; }
     public required bool HasGreekAlignment { get; init; }
-
-    [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
-    public required object? LicenseInfo { get; init; }
+    public required BibleLicenseInfo LicenseInfo { get; init; }
 }

--- a/src/Aquifer.Public.API/Endpoints/Resources/Collections/Get/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Collections/Get/Endpoint.cs
@@ -1,5 +1,6 @@
 using System.Data.Common;
 using Aquifer.Common.Services.Caching;
+using Aquifer.Common.Utilities;
 using Aquifer.Data;
 using Aquifer.Data.Entities;
 using Aquifer.Public.API.Helpers;
@@ -68,7 +69,7 @@ public sealed class Endpoint(AquiferDbContext _dbContext, ICachingLanguageServic
             DisplayName = parentResource.DisplayName,
             ShortName = parentResource.ShortName,
             ResourceType = parentResource.ResourceType,
-            LicenseInfo = parentResource.LicenseInfo,
+            LicenseInfo = JsonUtilities.DefaultDeserialize<ResourceLicenseInfo>(parentResource.LicenseInfo),
             AvailableLanguages = localizations
                 .Select(l => new AvailableLanguageResponse
                 {

--- a/src/Aquifer.Public.API/Endpoints/Resources/Collections/Get/Response.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Collections/Get/Response.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-using Aquifer.Common.Utilities;
 using Aquifer.Data.Entities;
 
 namespace Aquifer.Public.API.Endpoints.Resources.Collections.Get;
@@ -10,10 +8,7 @@ public sealed class Response
     public required string DisplayName { get; init; }
     public required string ShortName { get; init; }
     public required ResourceType ResourceType { get; init; }
-
-    [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
-    public required object? LicenseInfo { get; init; }
-
+    public required ResourceLicenseInfo LicenseInfo { get; init; }
     public required IReadOnlyList<AvailableLanguageResponse> AvailableLanguages { get; init; }
 }
 

--- a/src/Aquifer.Public.API/Endpoints/Resources/Get/ResourceHelper.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Get/ResourceHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Aquifer.Common.Tiptap;
+using Aquifer.Common.Utilities;
 using Aquifer.Data;
 using Aquifer.Data.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -37,7 +38,7 @@ public static class ResourceHelper
                     Name = x.ResourceContent.Resource.ParentResource.DisplayName,
                     Type = x.ResourceContent.Resource.ParentResource.ResourceType,
                     MediaTypeValue = x.ResourceContent.MediaType,
-                    LicenseInfo = x.ResourceContent.Resource.ParentResource.LicenseInfo
+                    LicenseInfo = JsonUtilities.DefaultDeserialize<ResourceLicenseInfo>(x.ResourceContent.Resource.ParentResource.LicenseInfo),
                 }
             })
             .ToListAsync(ct);

--- a/src/Aquifer.Public.API/Endpoints/Resources/Get/Response.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Get/Response.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json.Serialization;
-using Aquifer.Common.Utilities;
 using Aquifer.Data.Entities;
 
 namespace Aquifer.Public.API.Endpoints.Resources.Get;
@@ -34,8 +33,7 @@ public class ResourceTypeMetadata
 
     public string MediaType => MediaTypeValue.ToString();
 
-    [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
-    public required object? LicenseInfo { get; init; }
+    public required ResourceLicenseInfo LicenseInfo { get; init; }
 }
 
 public class ResourceContentLanguage

--- a/src/Aquifer.Public.API/Endpoints/Resources/ResourceLicenseInfo.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/ResourceLicenseInfo.cs
@@ -1,0 +1,33 @@
+﻿namespace Aquifer.Public.API.Endpoints.Resources;
+
+public sealed class ResourceLicenseInfo
+{
+    public required string Title { get; init; }
+    public required LicenseCopyright Copyright { get; init; }
+    public required IReadOnlyList<LicenseDetails> Licenses { get; init; }
+    public required bool ShowAdaptationNoticeForEnglish { get; init; }
+    public required bool ShowAdaptationNoticeForNonEnglish { get; init; }
+
+    public sealed class LicenseCopyright
+    {
+        public string? Dates { get; set; }
+        public required LicenseCopyrightHolder Holder { get; init; }
+    }
+
+    public sealed class LicenseCopyrightHolder
+    {
+        public required string Name { get; init; }
+        public required string Url { get; init; }
+    }
+
+    public sealed class LicenseDetails
+    {
+        public required LicenseData Eng { get; init; }
+    }
+
+    public sealed class LicenseData
+    {
+        public required string Name { get; init; }
+        public required string Url { get; init; }
+    }
+}

--- a/src/Aquifer.Public.API/Endpoints/Resources/Types/List/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Types/List/Endpoint.cs
@@ -1,4 +1,5 @@
 using Aquifer.Common.Extensions;
+using Aquifer.Common.Utilities;
 using Aquifer.Data;
 using Aquifer.Data.Entities;
 using Aquifer.Public.API.Helpers;
@@ -40,7 +41,7 @@ public class Endpoint(AquiferDbContext dbContext) : EndpointWithoutRequest<List<
                 {
                     Code = x.Code,
                     Title = x.DisplayName,
-                    LicenseInformation = x.LicenseInfo,
+                    LicenseInformation = JsonUtilities.DefaultDeserialize<ResourceLicenseInfo>(x.LicenseInfo),
                 }).ToList()
             });
         }

--- a/src/Aquifer.Public.API/Endpoints/Resources/Types/List/Response.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Types/List/Response.cs
@@ -1,7 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using Aquifer.Common.Utilities;
-
-namespace Aquifer.Public.API.Endpoints.Resources.Types.List;
+﻿namespace Aquifer.Public.API.Endpoints.Resources.Types.List;
 
 public class Response
 {
@@ -13,7 +10,5 @@ public class AvailableResourceCollection
 {
     public required string Code { get; set; }
     public required string Title { get; set; }
-
-    [JsonConverter(typeof(JsonUtilities.RawJsonConverter))]
-    public required object? LicenseInformation { get; init; }
+    public required ResourceLicenseInfo LicenseInformation { get; init; }
 }


### PR DESCRIPTION
This is a step on the way to using relational DB tables for the license info JSON.  I confirmed that all public API routes match production/QA and the internal API routes all load correctly.  The main difference is that `null`s are now populated:
![image](https://github.com/user-attachments/assets/c6523132-b75c-4c81-83e2-011a9acb3047)
