### PR TITLE
Update `/resources/content/machine-translation/{Id}` sql 

### DIFF
--- a/src/Aquifer.API/Endpoints/Resources/Content/MachineTranslation/Update/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/MachineTranslation/Update/Endpoint.cs
@@ -1,6 +1,5 @@
 ﻿using Aquifer.API.Services;
 using Aquifer.Data;
-using Aquifer.Data.Entities;
 using FastEndpoints;
 using Microsoft.EntityFrameworkCore;
 
@@ -16,47 +15,41 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
     public override async Task HandleAsync(Request req, CancellationToken ct)
     {
         var user = await userService.GetUserFromJwtAsync(ct);
-        var existingRcv = await dbContext
-            .ResourceContentVersionMachineTranslations
-            .AsTracking()
-            .Join(
-                dbContext.ResourceContentVersionAssignedUserHistory,
-                mt => mt.ResourceContentVersionId,
-                rah => rah.ResourceContentVersionId,
-                (mt, rah) => new{ mt, rah })
+        var existingMt = await dbContext.ResourceContentVersionMachineTranslations.AsTracking()
             .FirstOrDefaultAsync(x =>
-                    x.mt.Id == req.Id &&
-                    (
-                        (x.mt.ResourceContentVersion.AssignedUserId == user.Id && 
-                         x.mt.ResourceContentVersion.ResourceContent.Status == ResourceContentStatus.TranslationEditorReview)
-                     || x.rah.AssignedUserId == user.Id),
+                    x.Id == req.Id &&
+                    x.ResourceContentVersion
+                        .ResourceContentVersionAssignedUserHistories
+                        .Any(h => h.AssignedUserId == user.Id),
                 ct);
 
-        if (existingRcv!.mt is null)
+         
+        
+        if (existingMt is null)
         {
             ThrowError(x => x.Id, "No machine translation exists for user");
         }
 
-        existingRcv.mt.UserId = user.Id;
+        existingMt.UserId = user.Id;
 
         if (req.UserRating.HasValue)
         {
-            existingRcv.mt.UserRating = req.UserRating.Value;
+            existingMt.UserRating = req.UserRating.Value;
         }
 
         if (req.ImproveClarity.HasValue)
         {
-            existingRcv.mt.ImproveClarity = req.ImproveClarity.Value;
+            existingMt.ImproveClarity = req.ImproveClarity.Value;
         }
 
         if (req.ImproveConsistency.HasValue)
         {
-            existingRcv.mt.ImproveConsistency = req.ImproveConsistency.Value;
+            existingMt.ImproveConsistency = req.ImproveConsistency.Value;
         }
 
         if (req.ImproveTone.HasValue)
         {
-            existingRcv.mt.ImproveTone = req.ImproveTone.Value;
+            existingMt.ImproveTone = req.ImproveTone.Value;
         }
 
         await dbContext.SaveChangesAsync(ct);

--- a/src/Aquifer.API/Endpoints/Resources/Content/MachineTranslation/Update/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/MachineTranslation/Update/Endpoint.cs
@@ -22,8 +22,6 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
                         .ResourceContentVersionAssignedUserHistories
                         .Any(h => h.AssignedUserId == user.Id),
                 ct);
-
-         
         
         if (existingMt is null)
         {


### PR DESCRIPTION
Update endpoint to allow users that have been assigned the resource at all to update machine translation scores.

This resolves the error messages when a user clicks the machine translation score and then the `Send to Review` too quickly.

<img width="877" alt="Screenshot 2024-12-27 at 12 45 38 PM" src="https://github.com/user-attachments/assets/eeec152b-26f4-44b8-9f52-991f84a4ef69" />
