### PR TITLE
Reduce calls to 3rd party IP address service and handle rate limiting.

### DIFF
--- a/src/Aquifer.Data/AquiferDbContext.cs
+++ b/src/Aquifer.Data/AquiferDbContext.cs
@@ -52,7 +52,7 @@ public class AquiferDbContext : DbContext
     public DbSet<GreekSenseGlossEntity> GreekSenseGlosses { get; set; }
     public DbSet<GreekWordEntity> GreekWords { get; set; }
     public DbSet<HelpDocumentEntity> HelpDocuments { get; set; }
-    public DbSet<IpAddressData> IpAddressData { get; set; }
+    public DbSet<IpAddressDataEntity> IpAddressData { get; set; }
     public DbSet<JobHistoryEntity> JobHistory { get; set; }
     public DbSet<LanguageEntity> Languages { get; set; }
     public DbSet<NewTestamentAlignmentEntity> NewTestamentAlignments { get; set; }

--- a/src/Aquifer.Data/Entities/IpAddressData.cs
+++ b/src/Aquifer.Data/Entities/IpAddressData.cs
@@ -8,13 +8,13 @@ public class IpAddressData
     public string IpAddress { get; set; } = null!;
 
     [MaxLength(256)]
-    public string City { get; set; } = null!;
+    public string? City { get; set; }
 
     [MaxLength(256)]
-    public string Region { get; set; } = null!;
+    public string? Region { get; set; }
 
     [MaxLength(256)]
-    public string Country { get; set; } = null!;
+    public string? Country { get; set; }
 
     [SqlDefaultValue("getutcdate()")]
     public DateTime Created { get; set; } = DateTime.UtcNow;

--- a/src/Aquifer.Data/Entities/IpAddressDataEntity.cs
+++ b/src/Aquifer.Data/Entities/IpAddressDataEntity.cs
@@ -2,7 +2,7 @@
 
 namespace Aquifer.Data.Entities;
 
-public class IpAddressData
+public class IpAddressDataEntity
 {
     [Key, MaxLength(64)]
     public string IpAddress { get; set; } = null!;

--- a/src/Aquifer.Data/Migrations/20250106161348_MakeIpAddressColumnsNullable.Designer.cs
+++ b/src/Aquifer.Data/Migrations/20250106161348_MakeIpAddressColumnsNullable.Designer.cs
@@ -4,6 +4,7 @@ using Aquifer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Aquifer.Data.Migrations
 {
     [DbContext(typeof(AquiferDbContext))]
-    partial class AquiferDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250106161348_MakeIpAddressColumnsNullable")]
+    partial class MakeIpAddressColumnsNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Aquifer.Data/Migrations/20250106161348_MakeIpAddressColumnsNullable.cs
+++ b/src/Aquifer.Data/Migrations/20250106161348_MakeIpAddressColumnsNullable.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Aquifer.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeIpAddressColumnsNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Region",
+                table: "IpAddressData",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Country",
+                table: "IpAddressData",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "City",
+                table: "IpAddressData",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Region",
+                table: "IpAddressData",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Country",
+                table: "IpAddressData",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "City",
+                table: "IpAddressData",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Aquifer.Jobs/Program.cs
+++ b/src/Aquifer.Jobs/Program.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Aquifer.AI;
 using Aquifer.Common.Clients;
 using Aquifer.Common.Clients.Http.IpAddressLookup;
@@ -54,7 +55,8 @@ var host = new HostBuilder()
         services.AddSingleton<IAquiferApiManagementClient, AquiferApiManagementClient>();
         services.AddHttpClient<IIpAddressLookupHttpClient, IpAddressLookupHttpClient>()
             .AddPolicyHandler(HttpPolicyExtensions.HandleTransientHttpError()
-                .WaitAndRetryAsync(Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromSeconds(0.5), 2)));
+                .OrResult(res => res.StatusCode == HttpStatusCode.TooManyRequests)
+                .WaitAndRetryAsync(Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromSeconds(5), 2)));
         services.AddSingleton<IAzureKeyVaultClient, AzureKeyVaultClient>();
         services.AddScoped<IResourceHistoryService, ResourceHistoryService>();
         services.AddSingleton<IEmailMessagePublisher, EmailMessagePublisher>();

--- a/src/Aquifer.Jobs/Subscribers/TrackResourceContentRequestMessageSubscriber.cs
+++ b/src/Aquifer.Jobs/Subscribers/TrackResourceContentRequestMessageSubscriber.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Aquifer.Common.Clients.Http.IpAddressLookup;
 using Aquifer.Common.Messages;
 using Aquifer.Common.Messages.Models;
@@ -61,14 +62,32 @@ public class TrackResourceContentRequestMessageSubscriber(
                 return;
             }
 
-            var ipDataRecord = await dbContext.IpAddressData
-                .AsTracking()
-                .SingleOrDefaultAsync(x => x.IpAddress == trackingMetadata.IpAddress, ct);
-            if (ipDataRecord is null)
+            // Use a serializable transaction with UPDLOCK on SELECT to exclusive lock on row reads (including empty range).
+            // This locks other threads from SELECTing a null value in the DB for the given IP and thus prevents duplicate calls to the
+            // IP service for the same IP address at the same time.
+            // Using a transaction requires explicitly defining an execution strategy so that EF knows exactly what to replay in the event
+            // of a transient failure.
+            await dbContext.Database.CreateExecutionStrategy().ExecuteAsync(async () =>
             {
-                var ipData = await ipAddressClient.LookupIpAddressAsync(trackingMetadata.IpAddress, ct);
-                if (ipData.City is not null && ipData.Country is not null && ipData.Region is not null)
+                await using var transaction = await dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable, ct);
+
+                var ipDataRecord = await dbContext.Database
+                    .SqlQuery<IpAddressData>($"""
+                        SELECT
+                            IpAddress,
+                            City,
+                            Region,
+                            Country,
+                            Created
+                        FROM IpAddressData WITH (UPDLOCK)
+                        WHERE IpAddress = {trackingMetadata.IpAddress}
+                        """)
+                    .SingleOrDefaultAsync(ct);
+
+                if (ipDataRecord is null)
                 {
+                    var ipData = await ipAddressClient.LookupIpAddressAsync(trackingMetadata.IpAddress, ct);
+
                     var newRecord = new IpAddressData
                     {
                         IpAddress = trackingMetadata.IpAddress,
@@ -77,19 +96,11 @@ public class TrackResourceContentRequestMessageSubscriber(
                         Country = ipData.Country
                     };
 
-                    try
-                    {
-                        await dbContext.IpAddressData.AddAsync(newRecord, ct);
-                        await dbContext.SaveChangesAsync(ct);
-                    }
-                    catch (DbUpdateException)
-                    {
-                        // Don't care about this since it's a concurrency issue. Need to remove it though or the next Save
-                        // will pick it up and blow up.
-                        dbContext.IpAddressData.Remove(newRecord);
-                    }
+                    await dbContext.IpAddressData.AddAsync(newRecord, ct);
+                    await dbContext.SaveChangesAsync(ct);
+                    await transaction.CommitAsync(ct);
                 }
-            }
+            });
         }
         catch (Exception e)
         {

--- a/src/Aquifer.Jobs/Subscribers/TrackResourceContentRequestMessageSubscriber.cs
+++ b/src/Aquifer.Jobs/Subscribers/TrackResourceContentRequestMessageSubscriber.cs
@@ -72,7 +72,7 @@ public class TrackResourceContentRequestMessageSubscriber(
                 await using var transaction = await dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable, ct);
 
                 var ipDataRecord = await dbContext.Database
-                    .SqlQuery<IpAddressData>($"""
+                    .SqlQuery<IpAddressDataEntity>($"""
                         SELECT
                             IpAddress,
                             City,
@@ -88,7 +88,7 @@ public class TrackResourceContentRequestMessageSubscriber(
                 {
                     var ipData = await ipAddressClient.LookupIpAddressAsync(trackingMetadata.IpAddress, ct);
 
-                    var newRecord = new IpAddressData
+                    var newRecord = new IpAddressDataEntity
                     {
                         IpAddress = trackingMetadata.IpAddress,
                         City = ipData.City,

--- a/src/Aquifer.Jobs/local.settings.example.json
+++ b/src/Aquifer.Jobs/local.settings.example.json
@@ -8,11 +8,6 @@
 
         // The below settings are optional and only for local development (disabling jobs can help reduce noise).
 
-        // analytics jobs
-        "AzureWebJobs.SyncApiRequestStatsToStorageTableManager.Disabled": false,
-        "AzureWebJobs.SyncCustomEventsToStorageTableManager.Disabled": false,
-        "AzureWebJobs.SyncPageViewsToStorageTableManager.Disabled": false,
-
         // email jobs (suggest leaving disabled unless doing email testing)
         "AzureWebJobs.SendEmailMessageSubscriber.Disabled": true,
         "AzureWebJobs.SendTemplatedEmailMessageSubscriber.Disabled": true,


### PR DESCRIPTION
1. Only allow one simultaneous request to the IP address service for a given IP address.  This is accomplished with DB read row locking because Azure functions don't necessarily share the same memory caching instance so a `MemoryCache`/`HybridCache` won't work and the only other way to do distributed locking would be to stand up a distributed redis cache instance.  Using a DB transaction isn't the most ideal way to lock because the transaction is held open during the duration of the IP address service lookup (including Polly retries with delays) but being that the lock is for a single row (including an empty row) it should be acceptable.
2. Retry with Polly on 429 (Too Many Requests) responses with a delay.
3. Record IP lookup data _even if_ it's null.  Right now we don't record it which means we'll keep looking that IP up indefinitely which causes us to hit limits.