### PR TITLE
Use ChapterCount column instead of counting chapters.

### DIFF
--- a/src/Aquifer.API/Endpoints/Bibles/Book/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Bibles/Book/Get/Endpoint.cs
@@ -24,7 +24,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
                 AudioSize = bbc.AudioSize,
                 AudioUrls = bbc.AudioUrls != null ? JsonUtilities.DefaultDeserialize(bbc.AudioUrls) : null,
                 BookCode = BibleBookCodeUtilities.CodeFromId(bbc.BookId),
-                ChapterCount = bbc.Book.Chapters.Count,
+                ChapterCount = bbc.ChapterCount,
                 DisplayName = bbc.DisplayName,
                 TextSize = bbc.TextSize
             })

--- a/src/Aquifer.API/Endpoints/Bibles/Book/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Bibles/Book/List/Endpoint.cs
@@ -23,7 +23,10 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, List<Respo
                 Code = bbc.Book.Code,
                 Number = (int)bbc.BookId,
                 LocalizedName = bbc.DisplayName,
-                TotalChapters = bbc.Book.Chapters.Count,
+                TotalChapters = bbc.ChapterCount,
+
+                // TODO TotalVerses here should come from actual Bible data, not the standard BookChapters English versification data.
+                // After this usage of Book.Chapters is removed we should also delete that association altogether.
                 Chapters = bbc.Book.Chapters.OrderBy(c => c.Number).Select(c => new ResponseChapter
                 {
                     Number = c.Number,

--- a/src/Aquifer.API/Endpoints/Bibles/Language/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Bibles/Language/List/Endpoint.cs
@@ -27,15 +27,17 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, List<Respo
                 Id = bible.Id,
                 LanguageId = bible.LanguageId,
                 RestrictedLicense = bible.RestrictedLicense,
-                Books = bible.BibleBookContents.OrderBy(book => book.BookId).Select(book =>
-                    new BibleBookMetadataResponse
+                Books = bible.BibleBookContents
+                    .OrderBy(bbc => bbc.BookId)
+                    .Select(bbc => new BibleBookMetadataResponse
                     {
-                        BookCode = BibleBookCodeUtilities.CodeFromId(book.BookId),
-                        DisplayName = book.DisplayName,
-                        TextSize = book.TextSize,
-                        AudioSize = book.AudioSize,
-                        ChapterCount = book.Book.Chapters.Count
+                        BookCode = BibleBookCodeUtilities.CodeFromId(bbc.BookId),
+                        DisplayName = bbc.DisplayName,
+                        TextSize = bbc.TextSize,
+                        AudioSize = bbc.AudioSize,
+                        ChapterCount = bbc.ChapterCount,
                     })
+                    .ToList(),
             }).ToListAsync(ct);
 
         await SendOkAsync(bibles, ct);

--- a/src/Aquifer.Data/Entities/BookEntity.cs
+++ b/src/Aquifer.Data/Entities/BookEntity.cs
@@ -12,5 +12,7 @@ public class BookEntity
     [MaxLength(5)]
     public string Code { get; set; } = null!;
 
+    // TODO delete this after there aren't any usages left.
+    // Each Bible has potentially unique chapter/verse information.
     public ICollection<BookChapterEntity> Chapters { get; set; } = null!;
 }


### PR DESCRIPTION
This improves both query performance and correctness by removing unnecessary and incorrect JOINs on BSB chapter count data in `BookChapters` and using the `BibleBookContents.ChapterCount` information instead for the given Bible.

I confirmed that:
1. JSON matches before/after for affected routes.
2. All Bibles in the DB have the same number of chapters for all books, so switching from BSB's chapter counts to the specific Bible's chapter counts (in `BibleBookContents`) should have no consumer impact.  SQL for that:
```
SELECT b1.BibleId, b2.BookId, b1.ChapterCount, b2.ChapterCount
FROM 
(
    (SELECT bbc1.BibleId, bbc1.BookId, bbc1.ChapterCount FROM BibleBookContents bbc1) b1
    CROSS JOIN
    (SELECT bbc2.BibleId, bbc2.BookId, bbc2.ChapterCount FROM BibleBookContents bbc2) b2
)
WHERE
    b1.BibleId <> b2.BibleId AND
    b1.BookId = b2.BookId AND
    b1.ChapterCount <> b2.ChapterCount
```
3.  I also confirmed that `BibleTexts` data matched `BibleBookContents` data for chapter count.  SQL for that:
```
SELECT bbc.BibleId, bbc.BookId, bbc.ChapterCount AS BibleBookContentsChapterCount, x.ChapterCount AS BibleTextsChapterCount
FROM BibleBookContents bbc
JOIN
(
    SELECT bt.BibleId, bt.BookId, MAX(bt.ChapterNumber) AS ChapterCount
    FROM BibleTexts bt
    GROUP BY bt.BibleId, bt.BookId
) x
ON bbc.BibleId = x.BibleId AND bbc.BookId = x.BookId
WHERE bbc.ChapterCount <> x.ChapterCount
```

So all that said, this PR should have no impact on data returned to consumers.