### PR TITLE
Enable versification to work across ranges, apply exclusions, and support base verse parts in mappings.

### DIFF
--- a/Aquifer.sln
+++ b/Aquifer.sln
@@ -56,6 +56,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aquifer.Jobs.UnitTests", "t
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aquifer.API.IntegrationTests", "tests\Aquifer.API.IntegrationTests\Aquifer.API.IntegrationTests.csproj", "{EFCB9F65-BC0A-4AB6-9A42-19A0BD15ED30}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aquifer.Common.IntegrationTests", "tests\Aquifer.Common.IntegrationTests\Aquifer.Common.IntegrationTests.csproj", "{73F5F966-C27E-47AB-8B02-7A4B48C374EC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -124,6 +126,10 @@ Global
 		{EFCB9F65-BC0A-4AB6-9A42-19A0BD15ED30}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EFCB9F65-BC0A-4AB6-9A42-19A0BD15ED30}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EFCB9F65-BC0A-4AB6-9A42-19A0BD15ED30}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73F5F966-C27E-47AB-8B02-7A4B48C374EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73F5F966-C27E-47AB-8B02-7A4B48C374EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73F5F966-C27E-47AB-8B02-7A4B48C374EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73F5F966-C27E-47AB-8B02-7A4B48C374EC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -145,6 +151,7 @@ Global
 		{0CF81CD4-6257-4A36-BF67-C1C581E93951} = {51DD9DE3-DA20-4C0B-82D6-029445F6BD42}
 		{5205B15E-7521-40A7-8C66-19C231839E4F} = {51DD9DE3-DA20-4C0B-82D6-029445F6BD42}
 		{EFCB9F65-BC0A-4AB6-9A42-19A0BD15ED30} = {51DD9DE3-DA20-4C0B-82D6-029445F6BD42}
+		{73F5F966-C27E-47AB-8B02-7A4B48C374EC} = {51DD9DE3-DA20-4C0B-82D6-029445F6BD42}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8E32492B-EA66-40E4-A7A8-67E4ABA14A53}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.21.0" />
     <PackageVersion Include="Contrib.Grpc.Core.M1" Version="2.41.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
     <PackageVersion Include="FastEndpoints" Version="5.32.0" />
     <PackageVersion Include="FastEndpoints.ClientGen.Kiota" Version="5.32.0" />
@@ -50,7 +50,7 @@
     <PackageVersion Include="SendGrid" Version="9.29.3" />
     <PackageVersion Include="SendGrid.Extensions.DependencyInjection" Version="1.0.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.1.0" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Aquifer.Common/Services/Caching/CachingVersificationService.cs
+++ b/src/Aquifer.Common/Services/Caching/CachingVersificationService.cs
@@ -72,7 +72,7 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
                             {
                                 bc.BookId,
                                 bc.Number,
-                                bc.VerseCount,
+                                bc.MaxVerseNumber,
                             })
                             .ToListAsync(cancellationToken))
                         .GroupBy(x => x.BookId)
@@ -84,7 +84,7 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
                                 MaxVerseNumberByChapterNumberMap: grp
                                     .ToDictionary(
                                         x => x.Number,
-                                        x => x.VerseCount)
+                                        x => x.MaxVerseNumber)
                                     .AsReadOnly()
                             ))
                         .AsReadOnly();

--- a/src/Aquifer.Common/Services/Caching/CachingVersificationService.cs
+++ b/src/Aquifer.Common/Services/Caching/CachingVersificationService.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using Aquifer.Data;
+using Aquifer.Data.Enums;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -11,52 +12,132 @@ public interface ICachingVersificationService
 
     Task<ReadOnlyDictionary<int, int>> GetBibleVerseIdByBaseVerseIdMapAsync(int bibleId, CancellationToken cancellationToken);
 
-    Task<ReadOnlySet<int>> GetExclusionsByBibleIdAsync(int bibleId, CancellationToken cancellationToken);
+    Task<ReadOnlySet<int>> GetExcludedVerseIdsAsync(int bibleId, CancellationToken cancellationToken);
+
+    Task<ReadOnlyDictionary<BookId, (int MaxChapterNumber, ReadOnlyDictionary<int, int> MaxVerseNumberByChapterNumberMap)>>
+        GetMaxChapterNumberAndVerseNumbersByBookIdMapAsync(int bibleId, CancellationToken cancellationToken);
 }
 
-public class CachingVersificationService(AquiferDbContext _dbContext, IMemoryCache _memoryCache) : ICachingVersificationService
+public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMemoryCache _memoryCache) : ICachingVersificationService
 {
+    public const int EngVersificationSchemeBibleId = 0;
+
     private const string BaseVerseIdByBibleVerseIdMapsCacheKey =
         $"{nameof(CachingVersificationService)}:{nameof(BaseVerseIdByBibleVerseIdMapsCacheKey)}";
 
     private const string BibleVerseIdByBaseVerseIdMapsCacheKey =
         $"{nameof(CachingVersificationService)}:{nameof(BibleVerseIdByBaseVerseIdMapsCacheKey)}";
-    private const string ExclusionDictionariesCacheKey = $"{nameof(CachingVersificationService)}:ExclusionDictionaries";
-    private static readonly TimeSpan s_cacheLifetime = TimeSpan.FromMinutes(30);
+
+    private const string ExcludedVerseIdsByBibleIdMapCacheKey =
+        $"{nameof(CachingVersificationService)}:{nameof(ExcludedVerseIdsByBibleIdMapCacheKey)}";
+
+    private const string MaxVerseNumberByChapterNumberMapByBookIdMapCacheKey =
+        $"{nameof(CachingVersificationService)}:{nameof(MaxVerseNumberByChapterNumberMapByBookIdMapCacheKey)}";
+
+    private static readonly TimeSpan s_cacheLifetime = TimeSpan.FromMinutes(120);
 
     public async Task<ReadOnlyDictionary<int, int>>
         GetBaseVerseIdByBibleVerseIdMapAsync(int bibleId, CancellationToken cancellationToken)
     {
-        var dictionaries = await GetBaseVerseIdByBibleVerseIdMapsAsync(cancellationToken);
-
-        var versificationDictionary = dictionaries?.GetValueOrDefault(bibleId) ??
-                                      new Dictionary<int, int>()
-                                          .AsReadOnly();
-        return versificationDictionary;
+        return (await GetBaseVerseIdByBibleVerseIdMapsAsync(cancellationToken))
+            .GetValueOrDefault(bibleId)
+            ?? new Dictionary<int, int>().AsReadOnly();
     }
 
     public async Task<ReadOnlyDictionary<int, int>> GetBibleVerseIdByBaseVerseIdMapAsync(int bibleId, CancellationToken cancellationToken)
     {
-        var dictionaries = await GetBibleVerseIdByBaseVerseIdMapsAsync(cancellationToken);
-
-        var versificationDictionary = dictionaries?.GetValueOrDefault(bibleId) ??
-                                      new Dictionary<int, int>()
-                                          .AsReadOnly();
-        return versificationDictionary;
+        return (await GetBibleVerseIdByBaseVerseIdMapsAsync(cancellationToken))
+            .GetValueOrDefault(bibleId)
+            ?? new Dictionary<int, int>().AsReadOnly();
     }
 
-    public async Task<ReadOnlySet<int>> GetExclusionsByBibleIdAsync(int bibleId, CancellationToken cancellationToken)
+    public async Task<ReadOnlyDictionary<BookId, (int MaxChapterNumber, ReadOnlyDictionary<int, int> MaxVerseNumberByChapterNumberMap)>>
+        GetMaxChapterNumberAndVerseNumbersByBookIdMapAsync(int bibleId, CancellationToken cancellationToken)
     {
-        var dictionaries = await GetExclusionListsFromCacheAsync(cancellationToken);
-        var exclusions = dictionaries?.GetValueOrDefault(bibleId) ?? new ReadOnlySet<int>(new HashSet<int>());
+        // Cache each Bible's data independently in order to have cheaper SQL queries for each Bible.
+        var cacheKey = $"{MaxVerseNumberByChapterNumberMapByBookIdMapCacheKey}:{bibleId}";
 
-        return exclusions;
+        // Special case: The "eng" (common superset of most English Bibles) versification scheme's max verses are saved in the
+        // BookChapters DB table because we use that scheme for Resource verse references (Bible ID 0 has no BibleTexts data).
+        if (bibleId == EngVersificationSchemeBibleId)
+        {
+            return await _memoryCache.GetOrCreateAsync(
+                cacheKey,
+                async cacheEntry =>
+                {
+                    cacheEntry.SlidingExpiration = s_cacheLifetime;
+
+                    return (await _dbContext.BookChapters
+                            .Select(bc => new
+                            {
+                                bc.BookId,
+                                bc.Number,
+                                bc.VerseCount,
+                            })
+                            .ToListAsync(cancellationToken))
+                        .GroupBy(x => x.BookId)
+                        .ToDictionary(
+                            grp => grp.Key,
+                            grp =>
+                            (
+                                MaxChapterNumber: grp.Max(x => x.Number),
+                                MaxVerseNumberByChapterNumberMap: grp
+                                    .ToDictionary(
+                                        x => x.Number,
+                                        x => x.VerseCount)
+                                    .AsReadOnly()
+                            ))
+                        .AsReadOnly();
+                })
+                ?? throw new InvalidOperationException($"\"{cacheKey}\" unexpectedly had a null value cached.");
+        }
+
+        // For regular Bibles (not the "eng" versification scheme), get the max verse numbers from the BibleTexts table.
+        return await _memoryCache.GetOrCreateAsync(
+            cacheKey,
+            async cacheEntry =>
+            {
+                cacheEntry.SlidingExpiration = s_cacheLifetime;
+
+                return (await _dbContext.BibleTexts
+                        .Where(x => x.BibleId == bibleId)
+                        .GroupBy(x => new { x.BookId, x.ChapterNumber })
+                        .Select(grp => new
+                        {
+                            grp.Key.BookId,
+                            grp.Key.ChapterNumber,
+                            MaxVerseNumber = grp.Max(x => x.VerseNumber),
+                        })
+                        .ToListAsync(cancellationToken))
+                    .GroupBy(x => x.BookId)
+                    .ToDictionary(
+                        grp => grp.Key,
+                        grp =>
+                        (
+                            MaxChapterNumber: grp.Max(x => x.ChapterNumber),
+                            MaxVerseNumberByChapterNumberMap: grp
+                                .ToDictionary(
+                                    x => x.ChapterNumber,
+                                    x => x.MaxVerseNumber)
+                                .AsReadOnly()
+                        ))
+                    .AsReadOnly();
+            })
+            ?? throw new InvalidOperationException($"\"{cacheKey}\" unexpectedly had a null value cached.");
     }
 
-    private async Task<ReadOnlyDictionary<int, ReadOnlyDictionary<int, int>>?>
+    public async Task<ReadOnlySet<int>> GetExcludedVerseIdsAsync(int bibleId, CancellationToken cancellationToken)
+    {
+        return (await GetExcludedVerseIdsByBibleIdMapAsync(cancellationToken))
+            .GetValueOrDefault(bibleId)
+            ?? new ReadOnlySet<int>(new HashSet<int>());
+    }
+
+    private async Task<ReadOnlyDictionary<int, ReadOnlyDictionary<int, int>>>
         GetBaseVerseIdByBibleVerseIdMapsAsync(CancellationToken ct)
     {
-        return await _memoryCache.GetOrCreateAsync(BaseVerseIdByBibleVerseIdMapsCacheKey,
+        return await _memoryCache.GetOrCreateAsync(
+            BaseVerseIdByBibleVerseIdMapsCacheKey,
             async cacheEntry =>
             {
                 cacheEntry.SlidingExpiration = s_cacheLifetime;
@@ -65,44 +146,52 @@ public class CachingVersificationService(AquiferDbContext _dbContext, IMemoryCac
                     .GroupBy(x => x.BibleId)
                     .ToDictionaryAsync(
                         x => x.Key,
-                        x => x.ToDictionary(g => g.BibleVerseId, g
-                            => g.BaseVerseId).AsReadOnly(), ct);
+                        x => x
+                            .ToDictionary(g => g.BibleVerseId, g => g.BaseVerseId)
+                            .AsReadOnly(),
+                        ct);
 
                 return versifications.AsReadOnly();
-            });
+            })
+            ?? throw new InvalidOperationException($"\"{BaseVerseIdByBibleVerseIdMapsCacheKey}\" unexpectedly had a null value cached.");
     }
 
-    private async Task<ReadOnlyDictionary<int, ReadOnlyDictionary<int, int>>?> GetBibleVerseIdByBaseVerseIdMapsAsync(CancellationToken ct)
+    private async Task<ReadOnlyDictionary<int, ReadOnlyDictionary<int, int>>> GetBibleVerseIdByBaseVerseIdMapsAsync(CancellationToken ct)
     {
-        return await _memoryCache.GetOrCreateAsync(BibleVerseIdByBaseVerseIdMapsCacheKey,
+        return await _memoryCache.GetOrCreateAsync(
+            BibleVerseIdByBaseVerseIdMapsCacheKey,
             async cacheEntry =>
             {
                 cacheEntry.SlidingExpiration = s_cacheLifetime;
 
-                var baseVerseByBibleIdDictionaries = await GetBaseVerseIdByBibleVerseIdMapsAsync(ct);
-
-                var inverted = baseVerseByBibleIdDictionaries?.ToDictionary(
-                    x => x.Key,
-                    x => x.Value.ToDictionary(y => y.Value, y => y.Key).AsReadOnly());
-
-                return inverted?.AsReadOnly();
-            });
-    }
-
-    private async Task<ReadOnlyDictionary<int, ReadOnlySet<int>>?> GetExclusionListsFromCacheAsync(CancellationToken ct)
-    {
-        return await _memoryCache.GetOrCreateAsync(ExclusionDictionariesCacheKey,
-            async cacheEntry =>
-            {
-                cacheEntry.SlidingExpiration = s_cacheLifetime;
-
-                var exclusions = await _dbContext.VersificationExclusions
-                    .GroupBy(x => x.BibleId)
-                    .ToDictionaryAsync(
+                return (await GetBaseVerseIdByBibleVerseIdMapsAsync(ct))
+                    .ToDictionary(
                         x => x.Key,
-                        x => new ReadOnlySet<int>(x.Select(v => v.BibleVerseId).ToHashSet()), ct);
+                        x => x.Value
+                            .ToDictionary(y => y.Value, y => y.Key)
+                            .AsReadOnly())
+                    .AsReadOnly();
+            })
+            ?? throw new InvalidOperationException($"\"{BibleVerseIdByBaseVerseIdMapsCacheKey}\" unexpectedly had a null value cached.");
+    }
 
-                return exclusions.AsReadOnly();
-            });
+    private async Task<ReadOnlyDictionary<int, ReadOnlySet<int>>> GetExcludedVerseIdsByBibleIdMapAsync(CancellationToken ct)
+    {
+        return await _memoryCache.GetOrCreateAsync(
+            ExcludedVerseIdsByBibleIdMapCacheKey,
+            async cacheEntry =>
+            {
+                cacheEntry.SlidingExpiration = s_cacheLifetime;
+
+                return (await _dbContext.VersificationExclusions
+                        .GroupBy(x => x.BibleId)
+                        .ToDictionaryAsync(
+                            x => x.Key,
+                            x => new ReadOnlySet<int>(
+                                x.Select(v => v.BibleVerseId).ToHashSet()),
+                            ct))
+                    .AsReadOnly();
+            })
+            ?? throw new InvalidOperationException($"\"{ExcludedVerseIdsByBibleIdMapCacheKey}\" unexpectedly had a null value cached.");
     }
 }

--- a/src/Aquifer.Common/Utilities/BibleUtilities.cs
+++ b/src/Aquifer.Common/Utilities/BibleUtilities.cs
@@ -101,6 +101,11 @@ public static class BibleUtilities
         return value.ToString().PadLeft(3, '0');
     }
 
+    public static int GetVerseId(BookId bookId, int chapterNumber, int verseNumber)
+    {
+        return GetVerseId((int)bookId, chapterNumber, verseNumber);
+    }
+
     public static int GetVerseId(int bookNumber, int chapterNumber, int verseNumber)
     {
         return int.Parse($"1{PadVerseId(bookNumber)}{PadVerseId(chapterNumber)}{PadVerseId(verseNumber)}");

--- a/src/Aquifer.Common/Utilities/DictionaryExtensions.cs
+++ b/src/Aquifer.Common/Utilities/DictionaryExtensions.cs
@@ -1,0 +1,12 @@
+﻿namespace Aquifer.Common.Utilities;
+
+public static class DictionaryExtensions
+{
+    public static TValue? GetValueOrNull<TKey, TValue>(this IDictionary<TKey, TValue> source, TKey key)
+        where TValue : struct
+    {
+        return source.TryGetValue(key, out var value)
+            ? value
+            : null;
+    }
+}

--- a/src/Aquifer.Common/Utilities/VersificationUtilities.cs
+++ b/src/Aquifer.Common/Utilities/VersificationUtilities.cs
@@ -1,19 +1,236 @@
+using System.Collections.ObjectModel;
 using Aquifer.Common.Services.Caching;
+using Aquifer.Data.Enums;
 
 namespace Aquifer.Common.Utilities;
 
 public static class VersificationUtilities
 {
-    public static async Task<int> GetVersificationAsync(int sourceBibleVerseId, int sourceBibleId, int targetBibleId,
-        ICachingVersificationService versificationService, CancellationToken ct)
+    /// <summary>
+    /// Returns <c>true</c> if the given verse ID is valid and is contained in the given Bible, <c>false</c> otherwise.
+    /// </summary>
+    public static async Task<bool> IsValidVerseIdAsync(
+        int bibleId,
+        int verseId,
+        ICachingVersificationService versificationService,
+        CancellationToken ct)
     {
-        var baseVerseIdBySourceBibleVerseIdMapping = await versificationService.GetBaseVerseIdByBibleVerseIdMapAsync(sourceBibleId, ct);
-        var targetBibleVerseIdByBaseVerseIdMapping = await versificationService.GetBibleVerseIdByBaseVerseIdMapAsync(targetBibleId, ct);
+        var verse = BibleUtilities.TranslateVerseId(verseId);
 
+        if (verse.bookId == BookId.None || verse.chapter == 0 || verse.verse == 0)
+        {
+            return false;
+        }
+
+        // Some Bibles are missing specific verses.
+        var excludedVerseIds = await versificationService.GetExcludedVerseIdsAsync(bibleId, ct);
+        if (excludedVerseIds.Contains(verseId))
+        {
+            return false;
+        }
+
+        var maxChapterNumberAndVerseNumbersByBookIdMap =
+            await versificationService.GetMaxChapterNumberAndVerseNumbersByBookIdMapAsync(bibleId, ct);
+
+        // Bibles often don't include every possible book.
+        if (!maxChapterNumberAndVerseNumbersByBookIdMap.TryGetValue(verse.bookId, out var maxChapterNumberAndVerseNumbers))
+        {
+            return false;
+        }
+
+        if (verse.chapter > maxChapterNumberAndVerseNumbers.MaxChapterNumber)
+        {
+            return false;
+        }
+
+        // Edge Case: It's theoretically possible that a Bible could be missing an entire chapter.
+        if (!maxChapterNumberAndVerseNumbers.MaxVerseNumberByChapterNumberMap
+                .TryGetValue(verse.chapter, out var maxVerseNumber))
+        {
+            return false;
+        }
+
+        return verse.verse <= maxVerseNumber;
+    }
+
+    /// <summary>
+    /// Returns an ordered list of verse IDs for any valid start and end verse IDs, even if the range spans across chapters or books.
+    /// Only verse IDs present for the given <see paramref="bibleId"/> will be included.
+    /// If the range spans across books then the standard <see cref="BookId"/> ordering will be used, even if that's different from
+    /// the given Bible's book ordering.
+    /// </summary>
+    public static async Task<IReadOnlyList<int>> ExpandVerseIdRangeAsync(
+        int bibleId,
+        int startVerseId,
+        int endVerseId,
+        ICachingVersificationService versificationService,
+        CancellationToken ct)
+    {
+        if (endVerseId < startVerseId)
+        {
+            throw new ArgumentException(
+                $"{nameof(endVerseId)} ({endVerseId}) must be greater than or equal to {nameof(startVerseId)} ({startVerseId}).",
+                nameof(endVerseId));
+        }
+
+        if (!await IsValidVerseIdAsync(bibleId, startVerseId, versificationService, ct))
+        {
+            throw new ArgumentException(
+                $"{nameof(startVerseId)} {startVerseId} is invalid for {nameof(bibleId)} {bibleId}.",
+                nameof(startVerseId));
+        }
+
+        if (!await IsValidVerseIdAsync(bibleId, endVerseId, versificationService, ct))
+        {
+            throw new ArgumentException(
+                $"{nameof(endVerseId)} {endVerseId} is invalid for {nameof(bibleId)} {bibleId}.",
+                nameof(endVerseId));
+        }
+
+        if (startVerseId == endVerseId)
+        {
+            return [startVerseId];
+        }
+
+        var startVerse = BibleUtilities.TranslateVerseId(startVerseId);
+        var endVerse = BibleUtilities.TranslateVerseId(endVerseId);
+
+        var maxChapterNumberAndVerseNumbersByBookIdMap =
+            await versificationService.GetMaxChapterNumberAndVerseNumbersByBookIdMapAsync(bibleId, ct);
+
+        var excludedVerseIds = await versificationService.GetExcludedVerseIdsAsync(bibleId, ct);
+
+        var expandedVerseIds = new List<int>();
+        for (var bookId = startVerse.bookId; bookId <= endVerse.bookId; bookId++)
+        {
+            // Bibles often don't include every possible book.
+            if (!maxChapterNumberAndVerseNumbersByBookIdMap.TryGetValue(bookId, out var maxChapterNumberAndVerseNumbers))
+            {
+                continue;
+            }
+
+            var startChapterNumber = bookId == startVerse.bookId
+                ? startVerse.chapter
+                : 1;
+            var endChapterNumber = bookId == endVerse.bookId
+                ? endVerse.chapter
+                : maxChapterNumberAndVerseNumbers.MaxChapterNumber;
+
+            for (var chapterNumber = startChapterNumber; chapterNumber <= endChapterNumber; chapterNumber++)
+            {
+                // Edge Case: It's theoretically possible that a Bible could be missing an entire chapter.
+                if (!maxChapterNumberAndVerseNumbers.MaxVerseNumberByChapterNumberMap
+                        .TryGetValue(chapterNumber, out var maxVerseNumber))
+                {
+                    continue;
+                }
+
+                var startVerseNumber = bookId == startVerse.bookId && chapterNumber == startVerse.chapter
+                    ? startVerse.verse
+                    : 1;
+                var endVerseNumber = bookId == endVerse.bookId && chapterNumber == endVerse.chapter
+                    ? endVerse.verse
+                    : maxVerseNumber;
+
+                for (var verseNumber = startVerseNumber; verseNumber <= endVerseNumber; verseNumber++)
+                {
+                    var verseId = BibleUtilities.GetVerseId(bookId, chapterNumber, verseNumber);
+
+                    // Some Bibles are missing specific verses.
+                    if (!excludedVerseIds.Contains(verseId))
+                    {
+                        expandedVerseIds.Add(verseId);
+                    }
+                }
+            }
+        }
+
+        return expandedVerseIds;
+    }
+
+    /// <summary>
+    /// Returns the verse ID in the target Bible that corresponds to the given verse ID in the source Bible.
+    /// <c>null</c> will be returned if it's not possible to map between the versification schemes.
+    /// </summary>
+    public static async Task<int?> ConvertVersificationAsync(
+        int sourceBibleId,
+        int sourceVerseId,
+        int targetBibleId,
+        ICachingVersificationService versificationService,
+        CancellationToken ct)
+    {
+        if (!await IsValidVerseIdAsync(sourceBibleId, sourceVerseId, versificationService, ct))
+        {
+            throw new ArgumentException(
+                $"{nameof(sourceVerseId)} {sourceVerseId} is invalid for {nameof(sourceBibleId)} {sourceBibleId}.",
+                nameof(sourceVerseId));
+        }
+
+        var baseVerseIdBySourceBibleVerseIdMap = await versificationService.GetBaseVerseIdByBibleVerseIdMapAsync(sourceBibleId, ct);
+        var targetBibleVerseIdByBaseVerseIdMap = await versificationService.GetBibleVerseIdByBaseVerseIdMapAsync(targetBibleId, ct);
+        var targetBibleExcludedVerseIds = await versificationService.GetExcludedVerseIdsAsync(targetBibleId, ct);
+
+        return ConvertVersificationCore(
+            sourceVerseId,
+            baseVerseIdBySourceBibleVerseIdMap,
+            targetBibleVerseIdByBaseVerseIdMap,
+            targetBibleExcludedVerseIds);
+    }
+
+    /// <summary>
+    /// This method assumes that the <paramref name="sourceVerseId"/> is valid for the given maps and exclusions.
+    /// </summary>
+    /// <returns>The converted verse ID or <c>null</c> if conversion is not possible.</returns>
+    private static int? ConvertVersificationCore(
+        int sourceVerseId,
+        ReadOnlyDictionary<int, int> baseVerseIdBySourceBibleVerseIdMap,
+        ReadOnlyDictionary<int, int> targetBibleVerseIdByBaseVerseIdMap,
+        ReadOnlySet<int> targetBibleExcludedVerseIds)
+    {
         // The dictionary only contains mappings where the key is different from the value.
         // If the key verse ID is not present in the mapping (and is not in the exclusions list) then the value matches the key.
-        var baseVerseId = baseVerseIdBySourceBibleVerseIdMapping.GetValueOrDefault(sourceBibleVerseId, sourceBibleVerseId);
+        var baseVerseId = baseVerseIdBySourceBibleVerseIdMap.GetValueOrDefault(sourceVerseId, sourceVerseId);
+        var targetVerseId = targetBibleVerseIdByBaseVerseIdMap.GetValueOrDefault(baseVerseId, baseVerseId);
 
-        return targetBibleVerseIdByBaseVerseIdMapping.GetValueOrDefault(baseVerseId, baseVerseId);
+        return targetBibleExcludedVerseIds.Contains(targetVerseId)
+            ? null
+            : targetVerseId;
+    }
+
+    /// <summary>
+    /// Returns the verse IDs in the target Bible that corresponds to the given verse IDs in the source Bible.
+    /// Ranges will be expanded to their component verse IDs.
+    /// The source verse ID is the dictionary key and the target verse ID is the dictionary value.
+    /// <c>null</c> will be returned for the target verse ID if it's not possible to map between the versification schemes.
+    /// </summary>
+    public static async Task<ReadOnlyDictionary<int, int?>> ConvertVersificationRangeAsync(
+        int sourceBibleId,
+        int sourceStartVerseId,
+        int sourceEndVerseId,
+        int targetBibleId,
+        ICachingVersificationService versificationService,
+        CancellationToken ct)
+    {
+        // expanding will throw exceptions if the given start/end verse IDs are invalid
+        var expandedSourceVerseIds = await ExpandVerseIdRangeAsync(
+            sourceBibleId,
+            sourceStartVerseId,
+            sourceEndVerseId,
+            versificationService,
+            ct);
+
+        var baseVerseIdBySourceBibleVerseIdMap = await versificationService.GetBaseVerseIdByBibleVerseIdMapAsync(sourceBibleId, ct);
+        var targetBibleVerseIdByBaseVerseIdMap = await versificationService.GetBibleVerseIdByBaseVerseIdMapAsync(targetBibleId, ct);
+        var targetBibleExcludedVerseIds = await versificationService.GetExcludedVerseIdsAsync(targetBibleId, ct);
+
+        return expandedSourceVerseIds
+            .ToDictionary(
+                sourceVerseId => sourceVerseId,
+                sourceVerseId => ConvertVersificationCore(
+                    sourceVerseId,
+                    baseVerseIdBySourceBibleVerseIdMap,
+                    targetBibleVerseIdByBaseVerseIdMap,
+                    targetBibleExcludedVerseIds))
+            .AsReadOnly();
     }
 }

--- a/src/Aquifer.Jobs/Program.cs
+++ b/src/Aquifer.Jobs/Program.cs
@@ -30,7 +30,7 @@ var host = new HostBuilder()
     .ConfigureServices((context, services) =>
     {
         // This requires setting env var name AZURE_FUNCTIONS_ENVIRONMENT in Dev/QA and Prod
-        var isDevelopment = context.HostingEnvironment.EnvironmentName == "Development";
+        var isDevelopment = context.HostingEnvironment.EnvironmentName == Environments.Development;
 
         services.AddOptions<ConfigurationOptions>().Bind(context.Configuration);
         services.AddSingleton(cfg => cfg.GetService<IOptions<ConfigurationOptions>>()!.Value.OpenAi);

--- a/tests/Aquifer.Common.IntegrationTests/App.cs
+++ b/tests/Aquifer.Common.IntegrationTests/App.cs
@@ -1,0 +1,80 @@
+﻿using Aquifer.Common.Clients;
+using Aquifer.Common.Services;
+using Aquifer.Common.Services.Caching;
+using Aquifer.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Aquifer.Common.IntegrationTests;
+
+/// <summary>
+/// This class essentially acts as the Program.cs file for configuring the integration tests project's app config and services.
+/// XUnit will automatically run the <see cref="InitializeAsync"/> and <see cref="DisposeAsync"/> methods when used in conjunction with
+/// <see cref="TestBase{TAppFixture}"/> and will only do it only once per test class, not per test method, due to
+/// the base class using <see cref="IClassFixture{TFixture}"/>.
+/// </summary>
+public sealed class App : IAsyncLifetime
+{
+    private IHost Host { get; set; } = null!;
+
+    private IServiceScope AppServiceScope { get; set; } = null!;
+
+    public Task InitializeAsync()
+    {
+        Host = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
+            .UseEnvironment(Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") ?? Environments.Development)
+            .ConfigureServices((context, services) =>
+            {
+                var isDevelopment = context.HostingEnvironment.EnvironmentName == Environments.Development;
+
+                services.AddOptions<ConfigurationOptions>().Bind(context.Configuration);
+
+                var configuration = context.Configuration.Get<ConfigurationOptions>() ??
+                    throw new InvalidOperationException($"Unable to bind {nameof(ConfigurationOptions)}.");
+
+                services
+                    .AddMemoryCache()
+                    .AddDbContext<AquiferDbContext>(options => options
+                        .UseAzureSql(configuration.ConnectionStrings.BiblioNexusDb,
+                            providerOptions => providerOptions.EnableRetryOnFailure(3))
+                        .EnableSensitiveDataLogging(isDevelopment)
+                        .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking))
+                    .AddAzureClient(useCliCredential: true)
+                    .AddSingleton<IAzureKeyVaultClient, AzureKeyVaultClient>()
+                    .AddScoped<ICachingVersificationService, CachingVersificationService>();
+            })
+            .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole())
+            .Build();
+
+        StaticLoggerFactory.LoggerFactory = Host.Services.GetRequiredService<ILoggerFactory>();
+
+        // Tests really only need a Singleton scope, but then we can't share the same common service registration methods
+        // for use by Web APIs that use Scoped registrations. This allows using them within a single Scope per test fixture.
+        // If a scope per test method is needed then it will need to be done manually.
+        var scopeFactory = Host.Services.GetRequiredService<IServiceScopeFactory>();
+        AppServiceScope = scopeFactory.CreateScope();
+
+        // There's no need to start/stop the host; we're only using it to build configuration and services.
+        //await Host.StartAsync();
+
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        // There's no need to start/stop the host; we're only using it to build configuration and services.
+        //await Host.StopAsync();
+
+        AppServiceScope.Dispose();
+        Host.Dispose();
+        return Task.CompletedTask;
+    }
+
+    public T GetRequiredService<T>() where T : notnull
+    {
+        return AppServiceScope.ServiceProvider.GetRequiredService<T>();
+    }
+}

--- a/tests/Aquifer.Common.IntegrationTests/Aquifer.Common.IntegrationTests.csproj
+++ b/tests/Aquifer.Common.IntegrationTests/Aquifer.Common.IntegrationTests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Content Include="appsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="appsettings.Development.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <None Update="appsettings.example.json">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Aquifer.Common\Aquifer.Common.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Aquifer.Common.IntegrationTests/ConfigurationOptions.cs
+++ b/tests/Aquifer.Common.IntegrationTests/ConfigurationOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace Aquifer.Common.IntegrationTests;
+
+public sealed class ConfigurationOptions
+{
+    public required ConnectionStringOptions ConnectionStrings { get; init; }
+    public required string KeyVaultUri { get; init; }
+}
+
+public sealed class ConnectionStringOptions
+{
+    public required string BiblioNexusDb { get; init; }
+    public required string AzureStorageAccount { get; init; }
+}

--- a/tests/Aquifer.Common.IntegrationTests/TestBase.cs
+++ b/tests/Aquifer.Common.IntegrationTests/TestBase.cs
@@ -1,0 +1,16 @@
+﻿namespace Aquifer.Common.IntegrationTests;
+
+/// <summary>
+/// This class allows for injecting a <typeparamref name="TAppFixture"/> into the constructor of a test class by inheriting from
+/// this base class.
+/// Example:
+/// <example>
+/// <code>
+/// public sealed class FooTests(App _app) : TestBase&lt;App&gt; { }
+/// </code>
+/// </example>
+/// </summary>
+/// <typeparam name="TAppFixture"></typeparam>
+public abstract class TestBase<TAppFixture> : IClassFixture<TAppFixture> where TAppFixture : class
+{
+}

--- a/tests/Aquifer.Common.IntegrationTests/Utilities/VersificationUtilitiesTests.cs
+++ b/tests/Aquifer.Common.IntegrationTests/Utilities/VersificationUtilitiesTests.cs
@@ -1,0 +1,120 @@
+﻿using Aquifer.Common.Services.Caching;
+using Aquifer.Common.Utilities;
+
+namespace Aquifer.Common.IntegrationTests.Utilities;
+
+public sealed class VersificationUtilitiesTests(App _app) : TestBase<App>
+{
+    private readonly ICachingVersificationService _versificationService = _app.GetRequiredService<ICachingVersificationService>();
+
+    private const int _engVersificationSchemeBibleId = 0;
+    private const int _bsbBibleId = 1;
+    private const int _rsbBibleId = 9;
+    private const int _gltBibleId = 9;
+
+    [Theory]
+    [InlineData(_bsbBibleId, 1001001001, true,
+        "the BSB contains the given verse")]
+    [InlineData(_bsbBibleId, 1041017021, false,
+        "the BSB does not have the given verse")]
+    [InlineData(_bsbBibleId, 1072001001, false,
+        "the BSB does not have the given book")]
+    [InlineData(_engVersificationSchemeBibleId, 1001001001, true,
+        "ENG contains the given verse")]
+    [InlineData(_engVersificationSchemeBibleId, 1041017021, true,
+        "the BSB does not have the given verse")]
+    [InlineData(_engVersificationSchemeBibleId, 1072001001, true,
+        "ENG contains the given verse")]
+    public async Task IsValidVerseId_ValidArguments_Success(
+        int bibleId,
+        int verseId,
+        bool expected,
+        string because)
+    {
+        var result = await VersificationUtilities.IsValidVerseIdAsync(
+            bibleId,
+            verseId,
+            _versificationService,
+            CancellationToken.None);
+
+        result.Should().Be(expected, because);
+    }
+
+    [Theory]
+    [InlineData(_bsbBibleId, 1001001001, 1001001001, new[] { 1001001001 },
+        "a range of a single verse should return that verse")]
+    [InlineData(_bsbBibleId, 1001001001, 1001001003, new[] { 1001001001, 1001001002, 1001001003 },
+        "a simple range within a single chapter should be correctly returned")]
+    [InlineData(_bsbBibleId, 1041017020, 1041017022, new[] { 1041017020, 1041017022 },
+        "a range should not include excluded verse IDs for the given Bible")]
+    [InlineData(_bsbBibleId, 1041017027, 1041018002, new[] { 1041017027, 1041018001, 1041018002 },
+        "a range spanning two chapters should be correctly returned")]
+    [InlineData(_bsbBibleId, 1041028019, 1042001002, new[] { 1041028019, 1041028020, 1042001001, 1042001002 },
+        "a range spanning two books should be correctly returned")]
+    public async Task ExpandVerseIdRangeAsync_ValidArguments_Success(
+        int bibleId,
+        int startVerseId,
+        int endVerseId,
+        IReadOnlyList<int> expectedVerseIds,
+        string because)
+    {
+        var results = await VersificationUtilities.ExpandVerseIdRangeAsync(
+            bibleId,
+            startVerseId,
+            endVerseId,
+            _versificationService,
+            CancellationToken.None);
+
+        results.Should().Equal(expectedVerseIds, because);
+    }
+
+    [Theory]
+    [InlineData(_bsbBibleId, _bsbBibleId, 1001001001, 1001001001,
+        "the source and target Bibles are the same (with versification mappings) so the source and target verse IDs should be the same")]
+    [InlineData(_engVersificationSchemeBibleId, _bsbBibleId, 1041017021, null,
+        "the target (BSB) does not have the given verse")]
+    [InlineData(_bsbBibleId, _rsbBibleId, 1001003002, 1001003003,
+        "the RSB has a different versification than the BSB for the given verse")]
+    [InlineData(_rsbBibleId, _bsbBibleId, 1001003003, 1001003002,
+        "the RSB has a different versification than the BSB for the given verse")]
+    public async Task ConvertVersification_ValidArguments_Success(
+        int sourceBibleId,
+        int targetBibleId,
+        int sourceVerseId,
+        int? expectedTargetVerseId,
+        string because)
+    {
+        var result = await VersificationUtilities.ConvertVersificationAsync(
+            sourceBibleId,
+            sourceVerseId,
+            targetBibleId,
+            _versificationService,
+            CancellationToken.None);
+
+        result.Should().Be(expectedTargetVerseId, because);
+    }
+
+    [Fact]
+    public async Task ConvertVersificationRange_ValidArgumentsWithExclusionInSourceAndTarget_Success()
+    {
+        var results = await VersificationUtilities.ConvertVersificationRangeAsync(
+            sourceBibleId: _bsbBibleId,
+            1046016023,
+            1046016027,
+            targetBibleId: _gltBibleId,
+            _versificationService,
+            CancellationToken.None);
+
+        var expectedResults = new Dictionary<int, int?>
+            {
+                [1046016023] = 1046016023,
+                //[1046016024] = 1046016024, // The BSB doesn't have Rom. 16:24
+                [1046016025] = 1046016025,
+                [1046016026] = null, // The GLT doesn't have Rom. 16:26 or 16:27
+                [1046016027] = null,
+            }
+            .AsReadOnly();
+
+        results.Should().Equal(expectedResults, "source and target both have exclusions");
+    }
+}

--- a/tests/Aquifer.Common.IntegrationTests/Utilities/VersificationUtilitiesTests.cs
+++ b/tests/Aquifer.Common.IntegrationTests/Utilities/VersificationUtilitiesTests.cs
@@ -9,8 +9,9 @@ public sealed class VersificationUtilitiesTests(App _app) : TestBase<App>
 
     private const int _engVersificationSchemeBibleId = 0;
     private const int _bsbBibleId = 1;
+    private const int _ls1910BibleId = 6;
     private const int _rsbBibleId = 9;
-    private const int _gltBibleId = 9;
+    private const int _gltBibleId = 10;
 
     [Theory]
     [InlineData(_bsbBibleId, 1001001001, true,
@@ -73,10 +74,22 @@ public sealed class VersificationUtilitiesTests(App _app) : TestBase<App>
         "the source and target Bibles are the same (with versification mappings) so the source and target verse IDs should be the same")]
     [InlineData(_engVersificationSchemeBibleId, _bsbBibleId, 1041017021, null,
         "the target (BSB) does not have the given verse")]
-    [InlineData(_bsbBibleId, _rsbBibleId, 1001003002, 1001003003,
+    [InlineData(_bsbBibleId, _rsbBibleId, 1001003001, 1001003003,
         "the RSB has a different versification than the BSB for the given verse")]
-    [InlineData(_rsbBibleId, _bsbBibleId, 1001003003, 1001003002,
+    [InlineData(_rsbBibleId, _bsbBibleId, 1001003003, 1001003001,
         "the RSB has a different versification than the BSB for the given verse")]
+    [InlineData(_bsbBibleId, _rsbBibleId, 1016007067, 1016007068,
+        "the RSB has a different versification than the BSB for the given verse with an ignored optional base verse part")]
+    [InlineData(_rsbBibleId, _bsbBibleId, 1016007068, 1016007067,
+        "the RSB has a different versification than the BSB for the given verse with a non-matching base verse part")]
+    [InlineData(_engVersificationSchemeBibleId, _ls1910BibleId, 1004026001, 1004026001,
+        "the ENG and LS1910 have the same versification with matching base verse parts")]
+    [InlineData(_ls1910BibleId, _engVersificationSchemeBibleId, 1004026001, 1004026001,
+        "the ENG and LS1910 have the same versification with matching base verse parts")]
+    [InlineData(_bsbBibleId, _engVersificationSchemeBibleId, 1004026001, 1004026001,
+        "the ENG has a different versification than the BSB, the Bible verse part of 'b' is not loaded, and the base verse part of 'b' is ignored which results in mapping back to the same verse ID")]
+    [InlineData(_engVersificationSchemeBibleId, _bsbBibleId, 1004026001, 1004026001,
+        "the ENG has a different versification than the BSB and the base verse part of 'b' is ignored which results in mapping to the same verse ID")]
     public async Task ConvertVersification_ValidArguments_Success(
         int sourceBibleId,
         int targetBibleId,

--- a/tests/Aquifer.Common.IntegrationTests/appsettings.example.json
+++ b/tests/Aquifer.Common.IntegrationTests/appsettings.example.json
@@ -1,0 +1,7 @@
+{
+    "ConnectionStrings": {
+        "BiblioNexusDb": "Database connection string using Azure identity. Either get local or grab from dev app service config",
+        "AzureStorageAccount": "Connection string for the Azure Storage Account that is used for job queues."
+    },
+    "KeyVaultUri": "Azure Key Vault URI"
+}

--- a/tests/Aquifer.Common.IntegrationTests/appsettings.json
+++ b/tests/Aquifer.Common.IntegrationTests/appsettings.json
@@ -1,0 +1,7 @@
+{
+    "ConnectionStrings": {
+        "BiblioNexusDb": "",
+        "AzureStorageAccount": ""
+    },
+    "KeyVaultUri": ""
+}

--- a/tests/Aquifer.Common.UnitTests/Utilities/VersificationUtilitiesTests.cs
+++ b/tests/Aquifer.Common.UnitTests/Utilities/VersificationUtilitiesTests.cs
@@ -11,47 +11,47 @@ public sealed class VersificationUtilitiesTests
 
     [Theory]
     [InlineData(1, 0, false,
-        "Invalid source verse ID.")]
+        "the source verse ID is invalid")]
     [InlineData(1, int.MaxValue, false,
-        "Invalid source verse ID.")]
+        "the source verse ID is invalid")]
     [InlineData(1, 1001004002, false,
-        "Source Bible does not have the given verse due to exclusion.")]
+        "the source Bible does not have the given verse due to exclusion")]
     [InlineData(1, 1072001001, false,
-        "Source Bible does not have the given book.")]
+        "the source Bible does not have the given book")]
     [InlineData(1, 1001006001, false,
-        "Source Bible does not have the given chapter (greater than max chapter in book).")]
+        "the source Bible does not have the given chapter (greater than max chapter in book)")]
     [InlineData(1, 1001001032, false,
-        "Source Bible does not have the given verse (greater than max verse in chapter).")]
+        "the source Bible does not have the given verse (greater than max verse in chapter)")]
     [InlineData(99, 1001001001, false,
-        "Source Bible ID doesn't exist.")]
+        "the source Bible ID doesn't exist.")]
     [InlineData(1, 1001001001, true,
-        "Source Bible contains the given verse.")]
+        "the source Bible contains the given verse.")]
     public async Task IsValidVerseId_ValidArguments_Success(
         int bibleId,
         int verseId,
         bool expected,
         string because)
     {
-        (await VersificationUtilities.IsValidVerseIdAsync(
-                bibleId,
-                verseId,
-                _versificationService,
-                CancellationToken.None))
-            .Should()
-            .Be(expected, because);
+        var result = await VersificationUtilities.IsValidVerseIdAsync(
+            bibleId,
+            verseId,
+            _versificationService,
+            CancellationToken.None);
+
+        result.Should().Be(expected, because);
     }
 
     [Theory]
     [InlineData(1, 1001001001, 1001001001, new[] { 1001001001},
-        "A range of a single verse should return that verse.")]
+        "a range of a single verse should return that verse")]
     [InlineData(1, 1001001001, 1001001003, new[] { 1001001001, 1001001002, 1001001003 },
-        "A simple range within a single chapter should be correctly returned.")]
+        "a simple range within a single chapter should be correctly returned")]
     [InlineData(1, 1002001002, 1002001004, new[] { 1002001002, 1002001004 },
-        "A range should not include excluded verse IDs for the given Bible.")]
+        "a range should not include excluded verse IDs for the given Bible")]
     [InlineData(1, 1001001030, 1001002001, new[] { 1001001030, 1001001031, 1001002001 },
-        "A range spanning two chapters should be correctly returned.")]
+        "a range spanning two chapters should be correctly returned")]
     [InlineData(1, 1001005032, 1002001002, new[] { 1001005032, 1002001001, 1002001002 },
-        "A range spanning two books should be correctly returned.")]
+        "a range spanning two books should be correctly returned")]
     public async Task ExpandVerseIdRangeAsync_ValidArguments_Success(
         int bibleId,
         int startVerseId,
@@ -59,19 +59,19 @@ public sealed class VersificationUtilitiesTests
         IReadOnlyList<int> expectedVerseIds,
         string because)
     {
-        (await VersificationUtilities.ExpandVerseIdRangeAsync(
-                bibleId,
-                startVerseId,
-                endVerseId,
-                _versificationService,
-                CancellationToken.None))
-            .Should()
-            .Equal(expectedVerseIds, because);
+        var result = await VersificationUtilities.ExpandVerseIdRangeAsync(
+            bibleId,
+            startVerseId,
+            endVerseId,
+            _versificationService,
+            CancellationToken.None);
+
+        result.Should().Equal(expectedVerseIds, because);
     }
 
     [Theory]
     [InlineData(1, 1001003005, 1001003002,
-        "Start verse ID must be less than end verse ID.")]
+        "the start verse ID must be less than end verse ID")]
     public async Task ExpandVerseIdRange_InvalidArguments_ThrowsArgumentException(
         int bibleId,
         int startVerseId,
@@ -91,21 +91,21 @@ public sealed class VersificationUtilitiesTests
 
     [Theory]
     [InlineData(1, 1, 1001003001, 1001003001,
-        "The source and target Bibles are the same (with versification mappings) so the source and target verse IDs should be the same.")]
+        "the source and target Bibles are the same (with versification mappings) so the source and target verse IDs should be the same")]
     [InlineData(3, 3, 1001003001, 1001003001,
-        "The source and target Bibles are the same (without versification mappings) so the source and target verse IDs should be the same.")]
+        "the source and target Bibles are the same (without versification mappings) so the source and target verse IDs should be the same")]
     [InlineData(1, 2, 1001003001, 1001003003,
-        "Source verse ID from Bible 1 has a different versification in Bible 2.")]
+        "the source verse ID from Bible 1 has a different versification in Bible 2.")]
     [InlineData(1, 2, 1001002029, 1001002029,
-        "Verse ID does not have an explicit versification map for either source or target and so should map to itself.")]
+        "the verse ID does not have an explicit versification map for either source or target and so should map to itself")]
     [InlineData(1, 3, 1001002029, 1001002029,
-        "Target verse ID should match source verse ID because there is no explicit versification mapping for the source verse ID and the target Bible doesn't have a versification map.")]
+        "the target verse ID should match source verse ID because there is no explicit versification mapping for the source verse ID and the target Bible doesn't have a versification map")]
     [InlineData(1, 2, 1001003004, 1001003005,
-        "Target verse ID should match the mapped base verse ID if there is no versification from the target Bible to Base.")]
+        "the target verse ID should match the mapped base verse ID if there is no versification from the target Bible to Base")]
     [InlineData(3, 4, 1001003004, 1001003004,
-        "Neither Bible has a versification map so target verse ID should match source verse ID.")]
+        "neither Bible has a versification map so the target verse ID should match the source verse ID")]
     [InlineData(1, 2, 1001004003, null,
-        "Target Bible does not have the given verse so the conversion is not possible.")]
+        "the target Bible does not have the given verse so the conversion is not possible")]
     public async Task ConvertVersification_ValidArguments_Success(
         int sourceBibleId,
         int targetBibleId,
@@ -125,9 +125,9 @@ public sealed class VersificationUtilitiesTests
 
     [Theory]
     [InlineData(1, 1001002001, 1001002001, 2, new[] { 1001002001 },
-        "Single verse ID conversion should be successful.")]
+        "a single verse ID conversion should be successful")]
     [InlineData(1, 1001003001, 1001003005, 2, new [] { 1001003003, 1001003004, 1001003005, 1001003005, 1001003005 },
-        "Range conversion should be successful.")]
+        "a range conversion should be successful")]
     public async Task ConvertVersificationRange_ValidArguments_Success(
         int sourceBibleId,
         int sourceStartVerseId,

--- a/tests/Aquifer.Common.UnitTests/Utilities/VersificationUtilitiesTests.cs
+++ b/tests/Aquifer.Common.UnitTests/Utilities/VersificationUtilitiesTests.cs
@@ -1,89 +1,287 @@
 using System.Collections.ObjectModel;
 using Aquifer.Common.Services.Caching;
 using Aquifer.Common.Utilities;
+using Aquifer.Data.Enums;
 
 namespace Aquifer.Common.UnitTests.Utilities;
 
-public class VersificationUtilitiesTests
+public sealed class VersificationUtilitiesTests
 {
-    [Theory]
-    [InlineData(1, 9, 1001003001, 1001003003, "Verse from Bible 1 has a different versification in Bible 9")]
-    [InlineData(1, 9, 1001002029, 1001002029, "Verse from Bible 1 does not have a versification at all, so should be itself")]
-    [InlineData(1, 8, 1001002029, 1001002029,
-        "Verses should be the same because there are no versification mappings at all from English to target Bible")]
-    [InlineData(1, 9, 1001003004, 1001003005,
-        "Mapped verse should be base verse if there is no versification from the foreign Bible to Base")]
-    [InlineData(2, 10, 1001003004, 1001003004,
-        "Mapped verse from and To Bibles should be the same when both Bibles that are not found in versification")]
-    public async Task GetVersificationStartAndEnd(int fromBible, int toBible, int verse, int expected, string because)
-    {
-        var result = await VersificationUtilities.GetVersificationAsync(verse,
-            fromBible, toBible, new MockCachingVersificationService(), CancellationToken.None);
+    private readonly ICachingVersificationService _versificationService = new MockCachingVersificationService();
 
-        result.Should().Be(expected, because);
+    [Theory]
+    [InlineData(1, 0, false,
+        "Invalid source verse ID.")]
+    [InlineData(1, int.MaxValue, false,
+        "Invalid source verse ID.")]
+    [InlineData(1, 1001004002, false,
+        "Source Bible does not have the given verse due to exclusion.")]
+    [InlineData(1, 1072001001, false,
+        "Source Bible does not have the given book.")]
+    [InlineData(1, 1001006001, false,
+        "Source Bible does not have the given chapter (greater than max chapter in book).")]
+    [InlineData(1, 1001001032, false,
+        "Source Bible does not have the given verse (greater than max verse in chapter).")]
+    [InlineData(99, 1001001001, false,
+        "Source Bible ID doesn't exist.")]
+    [InlineData(1, 1001001001, true,
+        "Source Bible contains the given verse.")]
+    public async Task IsValidVerseId_ValidArguments_Success(
+        int bibleId,
+        int verseId,
+        bool expected,
+        string because)
+    {
+        (await VersificationUtilities.IsValidVerseIdAsync(
+                bibleId,
+                verseId,
+                _versificationService,
+                CancellationToken.None))
+            .Should()
+            .Be(expected, because);
+    }
+
+    [Theory]
+    [InlineData(1, 1001001001, 1001001001, new[] { 1001001001},
+        "A range of a single verse should return that verse.")]
+    [InlineData(1, 1001001001, 1001001003, new[] { 1001001001, 1001001002, 1001001003 },
+        "A simple range within a single chapter should be correctly returned.")]
+    [InlineData(1, 1002001002, 1002001004, new[] { 1002001002, 1002001004 },
+        "A range should not include excluded verse IDs for the given Bible.")]
+    [InlineData(1, 1001001030, 1001002001, new[] { 1001001030, 1001001031, 1001002001 },
+        "A range spanning two chapters should be correctly returned.")]
+    [InlineData(1, 1001005032, 1002001002, new[] { 1001005032, 1002001001, 1002001002 },
+        "A range spanning two books should be correctly returned.")]
+    public async Task ExpandVerseIdRangeAsync_ValidArguments_Success(
+        int bibleId,
+        int startVerseId,
+        int endVerseId,
+        IReadOnlyList<int> expectedVerseIds,
+        string because)
+    {
+        (await VersificationUtilities.ExpandVerseIdRangeAsync(
+                bibleId,
+                startVerseId,
+                endVerseId,
+                _versificationService,
+                CancellationToken.None))
+            .Should()
+            .Equal(expectedVerseIds, because);
+    }
+
+    [Theory]
+    [InlineData(1, 1001003005, 1001003002,
+        "Start verse ID must be less than end verse ID.")]
+    public async Task ExpandVerseIdRange_InvalidArguments_ThrowsArgumentException(
+        int bibleId,
+        int startVerseId,
+        int endVerseId,
+        string because)
+    {
+        await FluentActions.Invoking(
+                async () => await VersificationUtilities.ExpandVerseIdRangeAsync(
+                    bibleId,
+                    startVerseId,
+                    endVerseId,
+                    _versificationService,
+                    CancellationToken.None))
+            .Should()
+            .ThrowAsync<ArgumentException>(because);
+    }
+
+    [Theory]
+    [InlineData(1, 1, 1001003001, 1001003001,
+        "The source and target Bibles are the same (with versification mappings) so the source and target verse IDs should be the same.")]
+    [InlineData(3, 3, 1001003001, 1001003001,
+        "The source and target Bibles are the same (without versification mappings) so the source and target verse IDs should be the same.")]
+    [InlineData(1, 2, 1001003001, 1001003003,
+        "Source verse ID from Bible 1 has a different versification in Bible 2.")]
+    [InlineData(1, 2, 1001002029, 1001002029,
+        "Verse ID does not have an explicit versification map for either source or target and so should map to itself.")]
+    [InlineData(1, 3, 1001002029, 1001002029,
+        "Target verse ID should match source verse ID because there is no explicit versification mapping for the source verse ID and the target Bible doesn't have a versification map.")]
+    [InlineData(1, 2, 1001003004, 1001003005,
+        "Target verse ID should match the mapped base verse ID if there is no versification from the target Bible to Base.")]
+    [InlineData(3, 4, 1001003004, 1001003004,
+        "Neither Bible has a versification map so target verse ID should match source verse ID.")]
+    [InlineData(1, 2, 1001004003, null,
+        "Target Bible does not have the given verse so the conversion is not possible.")]
+    public async Task ConvertVersification_ValidArguments_Success(
+        int sourceBibleId,
+        int targetBibleId,
+        int sourceVerseId,
+        int? expectedTargetVerseId,
+        string because)
+    {
+        var result = await VersificationUtilities.ConvertVersificationAsync(
+            sourceBibleId,
+            sourceVerseId,
+            targetBibleId,
+            _versificationService,
+            CancellationToken.None);
+
+        result.Should().Be(expectedTargetVerseId, because);
+    }
+
+    [Theory]
+    [InlineData(1, 1001002001, 1001002001, 2, new[] { 1001002001 },
+        "Single verse ID conversion should be successful.")]
+    [InlineData(1, 1001003001, 1001003005, 2, new [] { 1001003003, 1001003004, 1001003005, 1001003005, 1001003005 },
+        "Range conversion should be successful.")]
+    public async Task ConvertVersificationRange_ValidArguments_Success(
+        int sourceBibleId,
+        int sourceStartVerseId,
+        int sourceEndVerseId,
+        int targetBibleId,
+        IReadOnlyList<int> expectedTargetVerseIds,
+        string because)
+    {
+        var result = await VersificationUtilities.ConvertVersificationRangeAsync(
+            sourceBibleId,
+            sourceStartVerseId,
+            sourceEndVerseId,
+            targetBibleId,
+            _versificationService,
+            CancellationToken.None);
+
+        result
+            .OrderBy(kvp => kvp.Key)
+            .Select(kvp => kvp.Value)
+            .Should()
+            .Equal(expectedTargetVerseIds.Cast<int?>(), because);
     }
 }
 
 public class MockCachingVersificationService : ICachingVersificationService
 {
-    private static readonly Dictionary<int, Dictionary<int, int>>
-        BaseVerseByBibleIdMappings = new()
+    private static readonly ReadOnlyDictionary<int, ReadOnlyDictionary<int, int>> s_baseVerseIdByBibleVerseIdMapByBibleIdMap =
+        new Dictionary<int, ReadOnlyDictionary<int, int>>
         {
-            {
-                1, new Dictionary<int, int>
+            // All mappings are in GEN 3.
+            [1] = new Dictionary<int, int>
                 {
                     [1001003001] = 1001003002,
                     [1001003002] = 1001003003,
                     [1001003003] = 1001003004,
                     [1001003004] = 1001003005,
                 }
-            },
-            {
-                9, new Dictionary<int, int>
+                .AsReadOnly(),
+            [2] = new Dictionary<int, int>
                 {
                     [1001003003] = 1001003002,
                     [1001003004] = 1001003003,
-                    [1001003005] = 1001003004
+                    [1001003005] = 1001003004,
                 }
-            }
-        };
+                .AsReadOnly(),
+        }
+        .AsReadOnly();
 
-    private static readonly Dictionary<int, ReadOnlySet<int>>
-        ExclusionMappings = new()
+    private static readonly ReadOnlyDictionary<int, ReadOnlySet<int>> s_excludedVerseIdsByBibleIdMap =
+        new Dictionary<int, ReadOnlySet<int>>
         {
+            [1] = new(new HashSet<int>(
+                [
+                    1001004001, // GEN 4:1
+                    1001004002, // GEN 4:2
+                    1002001003, // EXO 1:3
+                ])
+            ),
+            [2] = new(new HashSet<int>(
+                [
+                    1001004002, // GEN 4:2
+                    1001004003, // GEN 4:3
+                    1072001003, // SIR 1:3
+                ])),
+        }
+        .AsReadOnly();
+
+    private static readonly
+        ReadOnlyDictionary<BookId, (int MaxChapterNumber, ReadOnlyDictionary<int, int> MaxVerseNumberByChapterNumberMap)>
+        s_baseMaxChapterNumberAndVerseNumbersByBookIdMap =
+            new Dictionary<BookId, (int MaxChapterNumber, ReadOnlyDictionary<int, int> MaxVerseNumberByChapterNumberMap)>
             {
-                1, new ReadOnlySet<int>(
-                    new HashSet<int>([
-                        1001004001,
-                        1001004002
-                    ])
-                )
-            },
-            {
-                9, new ReadOnlySet<int>(
-                    new HashSet<int>([
-                        1001004001,
-                        1001004002
-                    ]))
+                [BookId.BookGEN] =
+                (
+                    5,
+                    new Dictionary<int, int>
+                    {
+                        [1] = 31,
+                        [2] = 29,
+                        [3] = 24,
+                        [4] = 26,
+                        [5] = 32,
+                    }
+                    .AsReadOnly()
+                ),
+                [BookId.BookEXO] =
+                (
+                    4,
+                    new Dictionary<int, int>
+                    {
+                        [1] = 5,
+                        [2] = 9,
+                        [3] = 24,
+                        [4] = 11,
+                    }
+                    .AsReadOnly()
+                ),
             }
-        };
+            .AsReadOnly();
+
+    private static readonly
+        ReadOnlyDictionary<BookId, (int MaxChapterNumber, ReadOnlyDictionary<int, int> MaxVerseNumberByChapterNumberMap)>
+            s_additionalMaxChapterNumberAndVerseNumbersByBookIdMap =
+                new Dictionary<BookId, (int MaxChapterNumber, ReadOnlyDictionary<int, int> MaxVerseNumberByChapterNumberMap)>
+                    {
+                        [BookId.BookSIR] =
+                        (
+                            3,
+                            new Dictionary<int, int>
+                                {
+                                    [1] = 4,
+                                    [2] = 5,
+                                    [3] = 6,
+                                }
+                                .AsReadOnly()
+                        ),
+                    }
+                    .AsReadOnly();
 
     public Task<ReadOnlyDictionary<int, int>>
         GetBaseVerseIdByBibleVerseIdMapAsync(int bibleId, CancellationToken cancellationToken)
     {
-        return Task.FromResult(BaseVerseByBibleIdMappings.GetValueOrDefault(bibleId)?.AsReadOnly() ??
-                               new Dictionary<int, int>().AsReadOnly());
+        return Task.FromResult(s_baseVerseIdByBibleVerseIdMapByBibleIdMap.GetValueOrDefault(bibleId) ?? new Dictionary<int, int>().AsReadOnly());
     }
 
     public async Task<ReadOnlyDictionary<int, int>> GetBibleVerseIdByBaseVerseIdMapAsync(int bibleId, CancellationToken cancellationToken)
     {
-        var map = await GetBaseVerseIdByBibleVerseIdMapAsync(bibleId, cancellationToken);
-        var invertedMap = map.ToDictionary(x => x.Value, x => x.Key).AsReadOnly();
-        return invertedMap;
+        return (await GetBaseVerseIdByBibleVerseIdMapAsync(bibleId, cancellationToken))
+            .ToDictionary(x => x.Value, x => x.Key)
+            .AsReadOnly();
     }
 
-    Task<ReadOnlySet<int>> ICachingVersificationService.GetExclusionsByBibleIdAsync(int bibleId, CancellationToken cancellationToken)
+    public Task<ReadOnlySet<int>> GetExcludedVerseIdsAsync(int bibleId, CancellationToken cancellationToken)
     {
-        return Task.FromResult(ExclusionMappings.GetValueOrDefault(bibleId, new ReadOnlySet<int>(new HashSet<int>())));
+        return Task.FromResult(s_excludedVerseIdsByBibleIdMap.GetValueOrDefault(bibleId, new ReadOnlySet<int>(new HashSet<int>())));
+    }
+
+    public Task<ReadOnlyDictionary<BookId, (int MaxChapterNumber, ReadOnlyDictionary<int, int> MaxVerseNumberByChapterNumberMap)>>
+        GetMaxChapterNumberAndVerseNumbersByBookIdMapAsync(int bibleId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(bibleId switch
+        {
+            // Bible 99 doesn't exist.
+            99 => new Dictionary<BookId, (int MaxChapterNumber, ReadOnlyDictionary<int, int> MaxVerseNumberByChapterNumberMap)>()
+                .AsReadOnly(),
+
+            //  Bible 2 gets an additional book.
+            2 => s_baseMaxChapterNumberAndVerseNumbersByBookIdMap
+                .Concat(s_additionalMaxChapterNumberAndVerseNumbersByBookIdMap)
+                .ToDictionary()
+                .AsReadOnly(),
+
+            // Return the same max chapters/verses for all other Bibles.
+            _ => s_baseMaxChapterNumberAndVerseNumbersByBookIdMap,
+        });
     }
 }


### PR DESCRIPTION
This PR includes the addition of integration tests for Aquifer.Common with `appsettings.json` and DI support (the required environment variables for GHA are already present).  There's an available NuGet package to provide full test class constructor DI with XUnit but it also provided a lot of other functionality I didn't want, had some abstractions that made you learn its specific strategies instead of standard `Builder` extension methods, and didn't do exactly what I wanted for DI, so I rolled my own app fixture which requires manually getting a required service.  I think it's pretty clean for what it does but welcome other opinions.