### PR TITLE
Add Microsoft.VisualStudio.Threading.Analyzers and fix async analyzer warnings.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,4 +18,11 @@
         <IsTestProject>false</IsTestProject>
     </PropertyGroup>
 
+    <ItemGroup>
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,6 +41,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="OpenAI" Version="2.0.0" />

--- a/src/Aquifer.AI/OpenAiTranslationService.cs
+++ b/src/Aquifer.AI/OpenAiTranslationService.cs
@@ -69,9 +69,12 @@ public sealed partial class OpenAiTranslationService : ITranslationService
     {
         _options = openAiTranslationOptions;
 
-        // TODO Inject a ChatClient instead of building one here. This will require changing how we fetch key vault secrets.
         const string openAiApiKeySecretName = "OpenAiApiKey";
+
+        // TODO Inject a ChatClient instead of building one here. This will require changing how we fetch key vault secrets.
+#pragma warning disable VSTHRD002
         var openApiKey = keyVaultClient.GetSecretAsync(openAiApiKeySecretName).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
 
         _chatClient = new ChatClient(
             openAiOptions.Model,
@@ -151,7 +154,7 @@ public sealed partial class OpenAiTranslationService : ITranslationService
 
             foreach (var paragraphTranslationTask in paragraphTranslationTasks)
             {
-                translatedHtml.Append(paragraphTranslationTask.Result);
+                translatedHtml.Append(await paragraphTranslationTask);
             }
         }
 

--- a/src/Aquifer.API/Clients/Http/Auth0/Auth0HttpClient.cs
+++ b/src/Aquifer.API/Clients/Http/Auth0/Auth0HttpClient.cs
@@ -11,12 +11,12 @@ namespace Aquifer.API.Clients.Http.Auth0;
 
 public interface IAuth0HttpClient
 {
-    Task<HttpResponseMessage> CreateUser(string name, string email, string authToken, CancellationToken cancellationToken);
-    Task<HttpResponseMessage> GetAuth0Token(CancellationToken cancellationToken);
-    Task<HttpResponseMessage> GetUserRoles(string auth0Token, CancellationToken cancellationToken);
-    Task<HttpResponseMessage> AssignUserToRole(string roleId, string userId, string auth0Token, CancellationToken cancellationToken);
-    Task<HttpResponseMessage> ResetPassword(string email, string authToken, CancellationToken cancellationToken);
-    Task<HttpResponseMessage> BlockUser(string auth0Id, string authToken, CancellationToken cancellationToken);
+    Task<HttpResponseMessage> CreateUserAsync(string name, string email, string authToken, CancellationToken cancellationToken);
+    Task<HttpResponseMessage> GetAuth0TokenAsync(CancellationToken cancellationToken);
+    Task<HttpResponseMessage> GetUserRolesAsync(string auth0Token, CancellationToken cancellationToken);
+    Task<HttpResponseMessage> AssignUserToRoleAsync(string roleId, string userId, string auth0Token, CancellationToken cancellationToken);
+    Task<HttpResponseMessage> ResetPasswordAsync(string email, string authToken, CancellationToken cancellationToken);
+    Task<HttpResponseMessage> BlockUserAsync(string auth0Id, string authToken, CancellationToken cancellationToken);
 }
 
 public class Auth0HttpClient : IAuth0HttpClient
@@ -35,14 +35,14 @@ public class Auth0HttpClient : IAuth0HttpClient
         _httpClient.BaseAddress = new Uri(_authSettings.BaseUri);
     }
 
-    public async Task<HttpResponseMessage> GetUserRoles(string auth0Token, CancellationToken cancellationToken)
+    public async Task<HttpResponseMessage> GetUserRolesAsync(string auth0Token, CancellationToken cancellationToken)
     {
         SetAuthHeader(auth0Token);
 
         return await _httpClient.GetAsync("/api/v2/roles", cancellationToken);
     }
 
-    public async Task<HttpResponseMessage> GetAuth0Token(CancellationToken cancellationToken)
+    public async Task<HttpResponseMessage> GetAuth0TokenAsync(CancellationToken cancellationToken)
     {
         var tokenRequest = new Auth0TokenRequest
         {
@@ -57,7 +57,7 @@ public class Auth0HttpClient : IAuth0HttpClient
         return await _httpClient.PostAsync("/oauth/token", request, cancellationToken);
     }
 
-    public async Task<HttpResponseMessage> AssignUserToRole(string roleId,
+    public async Task<HttpResponseMessage> AssignUserToRoleAsync(string roleId,
         string userId,
         string auth0Token,
         CancellationToken cancellationToken)
@@ -72,7 +72,7 @@ public class Auth0HttpClient : IAuth0HttpClient
         return await _httpClient.PostAsync(postUri, request, cancellationToken);
     }
 
-    public async Task<HttpResponseMessage> CreateUser(string name, string email, string authToken, CancellationToken cancellationToken)
+    public async Task<HttpResponseMessage> CreateUserAsync(string name, string email, string authToken, CancellationToken cancellationToken)
     {
         SetAuthHeader(authToken);
 
@@ -89,7 +89,7 @@ public class Auth0HttpClient : IAuth0HttpClient
         return await _httpClient.PostAsync("/api/v2/users", request, cancellationToken);
     }
 
-    public async Task<HttpResponseMessage> ResetPassword(string email, string authToken, CancellationToken cancellationToken)
+    public async Task<HttpResponseMessage> ResetPasswordAsync(string email, string authToken, CancellationToken cancellationToken)
     {
         const string endpointPath = "/dbconnections/change_password";
         SetAuthHeader(authToken);
@@ -104,7 +104,7 @@ public class Auth0HttpClient : IAuth0HttpClient
         return await _httpClient.PostAsync(endpointPath, request, cancellationToken);
     }
 
-    public async Task<HttpResponseMessage> BlockUser(string auth0Id, string authToken, CancellationToken cancellationToken)
+    public async Task<HttpResponseMessage> BlockUserAsync(string auth0Id, string authToken, CancellationToken cancellationToken)
     {
         var endpointPath = $"/api/v2/users/{auth0Id}";
         SetAuthHeader(authToken);

--- a/src/Aquifer.API/Endpoints/Projects/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Projects/Create/Endpoint.cs
@@ -19,7 +19,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
 
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
-        var newProject = await BuildProjectFromRequest(request, ct);
+        var newProject = await BuildProjectFromRequestAsync(request, ct);
 
         await dbContext.Projects.AddAsync(newProject, ct);
 
@@ -28,7 +28,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
         await SendOkAsync(new Response { Id = newProject.Id }, ct);
     }
 
-    private async Task<ProjectEntity> BuildProjectFromRequest(Request request, CancellationToken ct)
+    private async Task<ProjectEntity> BuildProjectFromRequestAsync(Request request, CancellationToken ct)
     {
         var user = await userService.GetUserFromJwtAsync(ct);
 
@@ -68,9 +68,9 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
             ThrowError(r => r.Title, "A project with this title already exists.");
         }
 
-        var companyLeadUser = await MaybeGetCompanyLeadUser(projectPlatform, request, ct);
+        var companyLeadUser = await MaybeGetCompanyLeadUserAsync(projectPlatform, request, ct);
 
-        var resourceContents = await CreateOrFindResourceContentFromResourceIds(language.Id, request, user, ct);
+        var resourceContents = await CreateOrFindResourceContentFromResourceIdsAsync(language.Id, request, user, ct);
 
         var wordCount = await dbContext.ResourceContentVersions
             .AsTracking()
@@ -95,7 +95,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
         };
     }
 
-    private async Task<UserEntity?> MaybeGetCompanyLeadUser(ProjectPlatformEntity projectPlatform, Request request, CancellationToken ct)
+    private async Task<UserEntity?> MaybeGetCompanyLeadUserAsync(ProjectPlatformEntity projectPlatform, Request request, CancellationToken ct)
     {
         if (projectPlatform?.Name == "Aquifer")
         {
@@ -118,20 +118,20 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
         return null;
     }
 
-    private async Task<List<ResourceContentEntity>> CreateOrFindResourceContentFromResourceIds(int languageId,
+    private async Task<List<ResourceContentEntity>> CreateOrFindResourceContentFromResourceIdsAsync(int languageId,
         Request request,
         UserEntity user,
         CancellationToken ct)
     {
         if (languageId == Constants.EnglishLanguageId)
         {
-            return await CreateOrFindAquiferizationResourceContent(languageId, request, ct);
+            return await CreateOrFindAquiferizationResourceContentAsync(languageId, request, ct);
         }
 
-        return await CreateOrFindTranslationResourceContent(languageId, request, user, ct);
+        return await CreateOrFindTranslationResourceContentAsync(languageId, request, user, ct);
     }
 
-    private async Task<List<ResourceContentEntity>> CreateOrFindAquiferizationResourceContent(int languageId,
+    private async Task<List<ResourceContentEntity>> CreateOrFindAquiferizationResourceContentAsync(int languageId,
         Request request,
         CancellationToken ct)
     {
@@ -186,7 +186,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
         return resourceContents;
     }
 
-    private async Task<List<ResourceContentEntity>> CreateOrFindTranslationResourceContent(int languageId,
+    private async Task<List<ResourceContentEntity>> CreateOrFindTranslationResourceContentAsync(int languageId,
         Request request,
         UserEntity user,
         CancellationToken ct)

--- a/src/Aquifer.API/Endpoints/Projects/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Projects/Get/Endpoint.cs
@@ -17,7 +17,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
 
     public override async Task HandleAsync(Request req, CancellationToken ct)
     {
-        if (!userService.HasPermission(PermissionName.ReadProject) && !await HasSameCompanyAsProject(req.ProjectId, ct))
+        if (!userService.HasPermission(PermissionName.ReadProject) && !await HasSameCompanyAsProjectAsync(req.ProjectId, ct))
         {
             await SendForbiddenAsync(ct);
             return;
@@ -30,7 +30,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
             return;
         }
 
-        var items = await GetProjectItems(req.ProjectId, ct);
+        var items = await GetProjectItemsAsync(req.ProjectId, ct);
 
         project.Items = items.OrderBy(x => x.SortOrder).ThenBy(x => x.EnglishLabel);
         await SendOkAsync(project, ct);
@@ -83,13 +83,13 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
         }).SingleOrDefaultAsync(ct);
     }
 
-    private async Task<bool> HasSameCompanyAsProject(int projectId, CancellationToken ct)
+    private async Task<bool> HasSameCompanyAsProjectAsync(int projectId, CancellationToken ct)
     {
         var self = await userService.GetUserWithCompanyFromJwtAsync(ct);
         return dbContext.Projects.Any(x => x.Id == projectId && self.CompanyId == x.CompanyId);
     }
 
-    private async Task<List<ProjectResourceItem>> GetProjectItems(int projectId, CancellationToken ct)
+    private async Task<List<ProjectResourceItem>> GetProjectItemsAsync(int projectId, CancellationToken ct)
     {
         const string query = """
                              SELECT

--- a/src/Aquifer.API/Endpoints/Projects/Update/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Projects/Update/Endpoint.cs
@@ -28,7 +28,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
             return;
         }
 
-        await ValidateRequest(project, request, ct);
+        await ValidateRequestAsync(project, request, ct);
         UpdateProject(request, project);
 
         await dbContext.SaveChangesAsync(ct);
@@ -68,7 +68,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request>
         }
     }
 
-    private async Task ValidateRequest(ProjectEntity project, Request request, CancellationToken ct)
+    private async Task ValidateRequestAsync(ProjectEntity project, Request request, CancellationToken ct)
     {
         if (project.Started is not null &&
             ((request.QuotedCost.HasValue && project.QuotedCost != request.QuotedCost) ||

--- a/src/Aquifer.API/Endpoints/Reports/Dynamic/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Reports/Dynamic/Get/Endpoint.cs
@@ -71,7 +71,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, Response>
             var item = new List<object?>();
             for (var i = 0; i < reader.FieldCount; i++)
             {
-                item.Add(reader.IsDBNull(i) ? null : reader[i]);
+                item.Add(await reader.IsDBNullAsync(i ,ct) ? null : reader[i]);
             }
 
             items.Add(item);

--- a/src/Aquifer.API/Endpoints/Resources/Content/Aquiferize/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Aquiferize/Endpoint.cs
@@ -23,7 +23,7 @@ public class Endpoint(AquiferDbContext dbContext, ITranslationMessagePublisher t
         }
 
         var (mostRecentContentVersion, _, currentDraftVersion) =
-            await Helpers.GetResourceContentVersions(request.ContentId,
+            await Helpers.GetResourceContentVersionsAsync(request.ContentId,
                 dbContext,
                 ct);
 
@@ -37,7 +37,7 @@ public class Endpoint(AquiferDbContext dbContext, ITranslationMessagePublisher t
             ThrowError(Helpers.DraftAlreadyExistsResponse);
         }
 
-        await Helpers.CreateNewDraft(dbContext,
+        await Helpers.CreateNewDraftAsync(dbContext,
             translationMessagePublisher,
             request.ContentId,
             request.AssignedUserId,

--- a/src/Aquifer.API/Endpoints/Resources/Content/AssignPublisherReview/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/AssignPublisherReview/Endpoint.cs
@@ -20,7 +20,7 @@ public class Endpoint(AquiferDbContext dbContext, IResourceHistoryService histor
 
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
-        await ValidateAssignedUser(request, ct);
+        await ValidateAssignedUserAsync(request, ct);
         var user = await userService.GetUserFromJwtAsync(ct);
 
         var contentIds = request.ContentId is not null ? [(int)request.ContentId] : request.ContentIds!;
@@ -69,7 +69,7 @@ public class Endpoint(AquiferDbContext dbContext, IResourceHistoryService histor
         await SendNoContentAsync(ct);
     }
 
-    private async Task ValidateAssignedUser(Request request, CancellationToken ct)
+    private async Task ValidateAssignedUserAsync(Request request, CancellationToken ct)
     {
         var assignedUser = await dbContext.Users
             .AsTracking()

--- a/src/Aquifer.API/Endpoints/Resources/Content/Helpers.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Helpers.cs
@@ -24,7 +24,7 @@ public static class Helpers
 
     public static async
         Task<(ResourceContentVersionEntity? latestVersion, ResourceContentVersionEntity? publishedVersion, ResourceContentVersionEntity?
-            draftVersion)> GetResourceContentVersions(int contentId, AquiferDbContext dbContext, CancellationToken cancellationToken)
+            draftVersion)> GetResourceContentVersionsAsync(int contentId, AquiferDbContext dbContext, CancellationToken cancellationToken)
     {
         var resourceContentVersions = await dbContext.ResourceContentVersions
             .AsTracking()
@@ -36,7 +36,7 @@ public static class Helpers
             resourceContentVersions.SingleOrDefault(x => x.IsDraft));
     }
 
-    public static async Task CreateNewDraft(
+    public static async Task CreateNewDraftAsync(
         AquiferDbContext dbContext,
         ITranslationMessagePublisher translationMessagePublisher,
         int contentId,

--- a/src/Aquifer.API/Endpoints/Resources/Content/Publish/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Publish/Endpoint.cs
@@ -29,7 +29,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, ITra
         foreach (var contentId in contentIds)
         {
             var (mostRecentContentVersion, currentlyPublishedVersion, currentDraftVersion) =
-                await Helpers.GetResourceContentVersions(contentId, dbContext, ct);
+                await Helpers.GetResourceContentVersionsAsync(contentId, dbContext, ct);
 
             if (mostRecentContentVersion is null)
             {
@@ -65,7 +65,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, ITra
             if (request.CreateDraft)
             {
                 // create draft of published version
-                await Helpers.CreateNewDraft(dbContext,
+                await Helpers.CreateNewDraftAsync(dbContext,
                     translationMessagePublisher,
                     contentId,
                     request.AssignedUserId,

--- a/src/Aquifer.API/Endpoints/Resources/Content/PullFromPublisherReview/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/PullFromPublisherReview/Endpoint.cs
@@ -26,12 +26,12 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
             .SingleOrDefaultAsync(u => u.Id == request.AssignedUserId && u.Enabled, ct);
         var permissions = ResourceStatusHelpers.GetAssignmentPermissions(userService);
 
-        await ResourceStatusHelpers.ValidateReviewerAndAssignedUser<Request>(request.AssignedUserId, null,
+        await ResourceStatusHelpers.ValidateReviewerAndAssignedUserAsync<Request>(request.AssignedUserId, null,
             dbContext, user, permissions, ct, userToAssign);
 
         var contentIds = request.ContentId is not null ? [(int)request.ContentId] : request.ContentIds!;
 
-        var draftVersions = await ResourceStatusHelpers.GetDraftVersions<Request>(contentIds,
+        var draftVersions = await ResourceStatusHelpers.GetDraftVersionsAsync<Request>(contentIds,
         [
             ResourceContentStatus.AquiferizePublisherReview, ResourceContentStatus.TranslationPublisherReview,
             ResourceContentStatus.TranslationNotApplicable
@@ -48,7 +48,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
 
             SetDraftVersionStatus(originalStatus, draftVersion);
 
-            await ResourceStatusHelpers.SaveHistory(request.AssignedUserId, historyService, draftVersion, originalStatus, user, ct);
+            await ResourceStatusHelpers.SaveHistoryAsync(request.AssignedUserId, historyService, draftVersion, originalStatus, user, ct);
         }
 
         await dbContext.SaveChangesAsync(ct);

--- a/src/Aquifer.API/Endpoints/Resources/Content/ResourceStatusHelpers.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/ResourceStatusHelpers.cs
@@ -10,8 +10,7 @@ namespace Aquifer.API.Endpoints.Resources.Content;
 
 public static class ResourceStatusHelpers
 {
-
-    public static async Task SaveHistory(int assignedUserId, IResourceHistoryService historyService,
+    public static async Task SaveHistoryAsync(int assignedUserId, IResourceHistoryService historyService,
         ResourceContentVersionEntity draftVersion, ResourceContentStatus originalStatus,
         UserEntity user, CancellationToken ct)
     {
@@ -57,7 +56,7 @@ public static class ResourceStatusHelpers
         }
     }
 
-    public static async Task<List<ResourceContentVersionEntity>> GetDraftVersions<TRequest>(int[] contentIds,
+    public static async Task<List<ResourceContentVersionEntity>> GetDraftVersionsAsync<TRequest>(int[] contentIds,
         List<ResourceContentStatus> allowedStatuses, AquiferDbContext dbContext,
         CancellationToken ct)
     {
@@ -76,7 +75,7 @@ public static class ResourceStatusHelpers
         return draftVersions;
     }
 
-    public static async Task ValidateReviewerAndAssignedUser<TRequest>(int assignedUserId, int? assignedReviewerUserId,
+    public static async Task ValidateReviewerAndAssignedUserAsync<TRequest>(int assignedUserId, int? assignedReviewerUserId,
         AquiferDbContext dbContext, UserEntity user, AssignmentPermissions permissions,
         CancellationToken ct,
         UserEntity? userToAssign = null)

--- a/src/Aquifer.API/Endpoints/Resources/Content/SendForCompanyReview/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/SendForCompanyReview/Endpoint.cs
@@ -61,7 +61,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
                 : ResourceContentStatus.AquiferizeCompanyReview;
 
             draftVersion.ResourceContent.Status = reviewPendingStatus;
-            await SetAssignedUserId(user,
+            await SetAssignedUserIdAsync(user,
                 draftVersion.ResourceContent.ProjectResourceContents.FirstOrDefault(x => x.Project.ActualPublishDate == null)?.Project,
                 managerIds,
                 draftVersion);
@@ -80,7 +80,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
             .ToList();
     }
 
-    private async Task SetAssignedUserId(UserEntity user,
+    private async Task SetAssignedUserIdAsync(UserEntity user,
         ProjectEntity? project,
         List<int> managers,
         ResourceContentVersionEntity draftVersion)

--- a/src/Aquifer.API/Endpoints/Resources/Content/SendForEditorReview/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/SendForEditorReview/Endpoint.cs
@@ -20,12 +20,12 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
         var user = await userService.GetUserFromJwtAsync(ct);
         var permissions = ResourceStatusHelpers.GetAssignmentPermissions(userService);
 
-        await ResourceStatusHelpers.ValidateReviewerAndAssignedUser<Request>(request.AssignedUserId, request.AssignedReviewerUserId,
+        await ResourceStatusHelpers.ValidateReviewerAndAssignedUserAsync<Request>(request.AssignedUserId, request.AssignedReviewerUserId,
             dbContext, user, permissions, ct);
 
         var contentIds = request.ContentId is not null ? [(int)request.ContentId] : request.ContentIds!;
 
-        var draftVersions = await ResourceStatusHelpers.GetDraftVersions<Request>(contentIds,
+        var draftVersions = await ResourceStatusHelpers.GetDraftVersionsAsync<Request>(contentIds,
         [
             ResourceContentStatus.TranslationEditorReview, ResourceContentStatus.TranslationAiDraftComplete,
             ResourceContentStatus.New, ResourceContentStatus.AquiferizeAiDraftComplete,
@@ -44,7 +44,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
 
             ResourceStatusHelpers.SetAssignedReviewerUserId(request.AssignedReviewerUserId, draftVersion);
 
-            await ResourceStatusHelpers.SaveHistory(request.AssignedUserId, historyService, draftVersion, originalStatus, user, ct);
+            await ResourceStatusHelpers.SaveHistoryAsync(request.AssignedUserId, historyService, draftVersion, originalStatus, user, ct);
         }
 
         await dbContext.SaveChangesAsync(ct);

--- a/src/Aquifer.API/Endpoints/Resources/Content/Unpublish/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Unpublish/Endpoint.cs
@@ -18,7 +18,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
         var (mostRecentResourceContentVersion, currentlyPublishedVersion, currentDraftVersion) =
-            await Helpers.GetResourceContentVersions(request.ContentId,
+            await Helpers.GetResourceContentVersionsAsync(request.ContentId,
                 dbContext,
                 ct);
 

--- a/src/Aquifer.API/Endpoints/Resources/Search/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Search/Endpoint.cs
@@ -17,12 +17,12 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, List<Respo
 
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
-        var resources = await GetResources(request, ct);
+        var resources = await GetResourcesAsync(request, ct);
 
         await SendOkAsync(resources, ct);
     }
 
-    private async Task<List<Response>> GetResources(Request req, CancellationToken ct)
+    private async Task<List<Response>> GetResourcesAsync(Request req, CancellationToken ct)
     {
         var (startVerseId, endVerseId) = req.BookCode is null
             ? ((int?)null, (int?)null)

--- a/src/Aquifer.API/Endpoints/Users/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Users/Create/Endpoint.cs
@@ -55,7 +55,7 @@ public class Endpoint(AquiferDbContext dbContext, IAuth0HttpClient authProviderS
 
     private async Task<string> GetAccessTokenAsync(CancellationToken ct)
     {
-        var response = await authProviderService.GetAuth0Token(ct);
+        var response = await authProviderService.GetAuth0TokenAsync(ct);
         var responseContent = await response.Content.ReadAsStringAsync(ct);
         if (!response.IsSuccessStatusCode)
         {
@@ -68,7 +68,7 @@ public class Endpoint(AquiferDbContext dbContext, IAuth0HttpClient authProviderS
 
     private async Task<string> GetRoleIdAsync(Request req, string accessToken, CancellationToken ct)
     {
-        var response = await authProviderService.GetUserRoles(accessToken, ct);
+        var response = await authProviderService.GetUserRolesAsync(accessToken, ct);
         var responseContent = await response.Content.ReadAsStringAsync(ct);
         if (!response.IsSuccessStatusCode)
         {
@@ -89,7 +89,7 @@ public class Endpoint(AquiferDbContext dbContext, IAuth0HttpClient authProviderS
 
     private async Task<string> CreateAuth0UserAsync(Request req, string accessToken, CancellationToken ct)
     {
-        var response = await authProviderService.CreateUser($"{req.FirstName} {req.LastName}", req.Email, accessToken, ct);
+        var response = await authProviderService.CreateUserAsync($"{req.FirstName} {req.LastName}", req.Email, accessToken, ct);
         var responseContent = await response.Content.ReadAsStringAsync(ct);
         if (!response.IsSuccessStatusCode)
         {
@@ -102,7 +102,7 @@ public class Endpoint(AquiferDbContext dbContext, IAuth0HttpClient authProviderS
 
     private async Task AssignAuth0RoleAsync(string accessToken, string userId, string roleId, CancellationToken ct)
     {
-        var response = await authProviderService.AssignUserToRole(roleId, userId, accessToken, ct);
+        var response = await authProviderService.AssignUserToRoleAsync(roleId, userId, accessToken, ct);
 
         var responseContent = await response.Content.ReadAsStringAsync(ct);
         if (!response.IsSuccessStatusCode)
@@ -126,7 +126,7 @@ public class Endpoint(AquiferDbContext dbContext, IAuth0HttpClient authProviderS
         // as part of creating their account, and then immediately send them the reset email
         // which will act as a creation / set password flow.
 
-        var response = await authProviderService.ResetPassword(email, accessToken, ct);
+        var response = await authProviderService.ResetPasswordAsync(email, accessToken, ct);
 
         var responseContent = await response.Content.ReadAsStringAsync(ct);
         if (!response.IsSuccessStatusCode)

--- a/src/Aquifer.API/Endpoints/Users/Disable/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Users/Disable/Endpoint.cs
@@ -50,27 +50,27 @@ public class Endpoint(
 
     private async Task BlockAuth0UserAsync(UserEntity userToDisable, string token, CancellationToken ct)
     {
-        var blockUserResponse = await auth0HttpClient.BlockUser(userToDisable.ProviderId, token, ct);
+        var blockUserResponse = await auth0HttpClient.BlockUserAsync(userToDisable.ProviderId, token, ct);
         var blockUserResponseContent = await blockUserResponse.Content.ReadAsStringAsync(ct);
         if (!blockUserResponse.IsSuccessStatusCode)
         {
-            HandleErrorAsync(blockUserResponse, blockUserResponseContent, "Error blocking user on Auth0");
+            HandleError(blockUserResponse, blockUserResponseContent, "Error blocking user on Auth0");
         }
     }
 
     private async Task<string> GetAuth0TokenAsync(CancellationToken ct)
     {
-        var authTokenResponse = await auth0HttpClient.GetAuth0Token(ct);
+        var authTokenResponse = await auth0HttpClient.GetAuth0TokenAsync(ct);
         var authTokenResponseContent = await authTokenResponse.Content.ReadAsStringAsync(ct);
         if (!authTokenResponse.IsSuccessStatusCode)
         {
-            HandleErrorAsync(authTokenResponse, authTokenResponseContent, "Error getting Auth0 access token");
+            HandleError(authTokenResponse, authTokenResponseContent, "Error getting Auth0 access token");
         }
 
         return JsonUtilities.DefaultDeserialize<Auth0TokenResponse>(authTokenResponseContent).AccessToken;
     }
 
-    private void HandleErrorAsync(HttpResponseMessage responseMessage, string responseMessageContent, string error)
+    private void HandleError(HttpResponseMessage responseMessage, string responseMessageContent, string error)
     {
         logger.LogError("{error} - {statusCode} - {responseMessageContent}",
             error,

--- a/src/Aquifer.API/Modules/Passages/PassagesModule.cs
+++ b/src/Aquifer.API/Modules/Passages/PassagesModule.cs
@@ -11,11 +11,11 @@ public class PassagesModule : IModule
     public IEndpointRouteBuilder MapEndpoints(IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup("passages").WithTags("Passages");
-        group.MapGet("language/{languageId:int}/resource/{parentResourceId:int}", GetPassagesByLanguageAndResource);
+        group.MapGet("language/{languageId:int}/resource/{parentResourceId:int}", GetPassagesByLanguageAndResourceAsync);
         return endpoints;
     }
 
-    private async Task<Results<Ok<List<PassagesByBookResponse>>, NotFound>> GetPassagesByLanguageAndResource(
+    private async Task<Results<Ok<List<PassagesByBookResponse>>, NotFound>> GetPassagesByLanguageAndResourceAsync(
         int languageId,
         int parentResourceId,
         AquiferDbContext dbContext,

--- a/src/Aquifer.API/Modules/Resources/LanguageResources/LanguageResourcesEndpoints.cs
+++ b/src/Aquifer.API/Modules/Resources/LanguageResources/LanguageResourcesEndpoints.cs
@@ -12,7 +12,7 @@ namespace Aquifer.API.Modules.Resources.LanguageResources;
 public static class LanguageResourcesEndpoints
 {
     public static async Task<Results<Ok<ResourceItemsByChapterResponse>, NotFound, BadRequest<string>>>
-        GetBookByLanguage(
+        GetBookByLanguageAsync(
             int languageId,
             string bookCode,
             AquiferDbContext dbContext,

--- a/src/Aquifer.API/Modules/Resources/ResourceContentItem/ResourceContentItemEndpoints.cs
+++ b/src/Aquifer.API/Modules/Resources/ResourceContentItem/ResourceContentItemEndpoints.cs
@@ -8,7 +8,7 @@ namespace Aquifer.API.Modules.Resources.ResourceContentItem;
 
 public static class ResourceContentItemEndpoints
 {
-    public static async Task<Results<RedirectHttpResult, NotFound>> GetResourceThumbnailById(int contentId,
+    public static async Task<Results<RedirectHttpResult, NotFound>> GetResourceThumbnailByIdAsync(int contentId,
         AquiferDbContext dbContext,
         CancellationToken cancellationToken)
     {

--- a/src/Aquifer.API/Modules/Resources/ResourcesModule.cs
+++ b/src/Aquifer.API/Modules/Resources/ResourcesModule.cs
@@ -8,8 +8,8 @@ public class ResourcesModule : IModule
     public IEndpointRouteBuilder MapEndpoints(IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup("resources").WithTags("Resources");
-        group.MapGet("{contentId:int}/thumbnail", ResourceContentItemEndpoints.GetResourceThumbnailById);
-        group.MapGet("language/{languageId:int}/book/{bookCode}", LanguageResourcesEndpoints.GetBookByLanguage);
+        group.MapGet("{contentId:int}/thumbnail", ResourceContentItemEndpoints.GetResourceThumbnailByIdAsync);
+        group.MapGet("language/{languageId:int}/book/{bookCode}", LanguageResourcesEndpoints.GetBookByLanguageAsync);
 
         return endpoints;
     }

--- a/src/Aquifer.Common/Messages/QueueClientFactory.cs
+++ b/src/Aquifer.Common/Messages/QueueClientFactory.cs
@@ -33,7 +33,9 @@ public sealed class QueueClientFactory(QueueConfigurationOptions _queueConfigura
         // and create the queue in Azure Storage (if it doesn't exist yet) only happens once.
         var queueClient = _queueClientByQueueNameMap.GetOrAdd(
             queueName,
+#pragma warning disable VSTHRD011 // Lazy<Task<T>> is fine here because we don't have a UI thread.
             qn => new Lazy<Task<QueueClient>>(() => GetQueueClientCoreAsync(qn, ct), LazyThreadSafetyMode.ExecutionAndPublication));
+#pragma warning restore VSTHRD011
 
         try
         {

--- a/src/Aquifer.Jobs/Clients/AquiferAppInsightsClient.cs
+++ b/src/Aquifer.Jobs/Clients/AquiferAppInsightsClient.cs
@@ -9,7 +9,7 @@ namespace Aquifer.Jobs.Clients;
 
 public interface IAquiferAppInsightsClient
 {
-    public Task<Response<IReadOnlyList<T>>> QueryAsyncSinceTimestamp<T>(string query, DateTime? timestamp, CancellationToken ct);
+    public Task<Response<IReadOnlyList<T>>> QueryAsyncSinceTimestampAsync<T>(string query, DateTime? timestamp, CancellationToken ct);
 }
 
 public class AquiferAppInsightsClient(IAzureClientService _azureClientService, IOptions<ConfigurationOptions> _options)
@@ -28,7 +28,7 @@ public class AquiferAppInsightsClient(IAzureClientService _azureClientService, I
 
     private readonly LogsQueryClient _logsClient = new(_azureClientService.GetCredential(), s_logsQueryClientOptions);
 
-    public async Task<Response<IReadOnlyList<T>>> QueryAsyncSinceTimestamp<T>(string query, DateTime? timestamp, CancellationToken ct)
+    public async Task<Response<IReadOnlyList<T>>> QueryAsyncSinceTimestampAsync<T>(string query, DateTime? timestamp, CancellationToken ct)
     {
         var appInsightsResourceId = new ResourceIdentifier(_options.Value.Analytics.AppInsightsResourceId);
         var endTime = DateTime.UtcNow;

--- a/src/Aquifer.Jobs/Services/SendGridEmailService.cs
+++ b/src/Aquifer.Jobs/Services/SendGridEmailService.cs
@@ -42,7 +42,12 @@ public class SendGridEmailService : IEmailService
     public SendGridEmailService(IAzureKeyVaultClient keyVaultClient)
     {
         const string apiKeySecretName = "SendGridMarketingApiKey";
+
+        // TODO Inject a SendGridClient instead of building one here. This will require changing how we fetch key vault secrets.
+#pragma warning disable VSTHRD002
         var apiToken = keyVaultClient.GetSecretAsync(apiKeySecretName).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+
         _sendGridClient = new SendGridClient(
             new SendGridClientOptions
             {

--- a/src/Aquifer.Jobs/Services/TranslationProcessors/FrenchTranslationProcessingService.cs
+++ b/src/Aquifer.Jobs/Services/TranslationProcessors/FrenchTranslationProcessingService.cs
@@ -39,7 +39,7 @@ public sealed partial class FrenchTranslationProcessingService : ILanguageSpecif
             async text =>
             {
                 text = await SetNarrowNonBreakingSpacesAsync(text);
-                text = await SetCorrectBibleBookAbbreviation(text);
+                text = await SetCorrectBibleBookAbbreviationAsync(text);
 
                 return text;
             });
@@ -62,7 +62,7 @@ public sealed partial class FrenchTranslationProcessingService : ILanguageSpecif
         return Task.FromResult(text);
     }
 
-    private static Task<string> SetCorrectBibleBookAbbreviation(string text)
+    private static Task<string> SetCorrectBibleBookAbbreviationAsync(string text)
     {
         text = BibleBookRegex()
             .Replace(text,

--- a/src/Aquifer.Jobs/Subscribers/EmailMessageSubscriber.cs
+++ b/src/Aquifer.Jobs/Subscribers/EmailMessageSubscriber.cs
@@ -16,15 +16,17 @@ public sealed class EmailMessageSubscriber(
     IOptions<ConfigurationOptions> _configurationOptions,
     ILogger<EmailMessageSubscriber> _logger)
 {
-    [Function(nameof(SendEmailMessageSubscriber))]
-    public async Task SendEmailMessageSubscriber(
+    private const string SendEmailFunctionName = "SendEmailMessageSubscriber";
+
+    [Function(SendEmailFunctionName)]
+    public async Task SendEmailAsync(
         [QueueTrigger(Queues.SendEmail)]
         QueueMessage queueMessage,
         CancellationToken ct)
     {
         await queueMessage.ProcessAsync<SendEmailMessage, EmailMessageSubscriber>(
             _logger,
-            nameof(SendEmailMessageSubscriber),
+            SendEmailFunctionName,
             ProcessAsync,
             ct);
     }
@@ -38,15 +40,17 @@ public sealed class EmailMessageSubscriber(
         _logger.LogInformation("Email sent: {SendEmailMessage}", queueMessage.MessageText);
     }
 
-    [Function(nameof(SendTemplatedEmailMessageSubscriber))]
-    public async Task SendTemplatedEmailMessageSubscriber(
+    private const string SendTemplatedEmailFunctionName = "SendTemplatedEmailMessageSubscriber";
+
+    [Function(SendTemplatedEmailFunctionName)]
+    public async Task SendTemplatedEmailAsync(
         [QueueTrigger(Queues.SendTemplatedEmail)]
         QueueMessage queueMessage,
         CancellationToken ct)
     {
         await queueMessage.ProcessAsync<SendTemplatedEmailMessage, EmailMessageSubscriber>(
             _logger,
-            nameof(SendTemplatedEmailMessageSubscriber),
+            SendTemplatedEmailFunctionName,
             ProcessAsync,
             ct);
     }

--- a/src/Aquifer.Jobs/Subscribers/NotificationMessageSubscriber.cs
+++ b/src/Aquifer.Jobs/Subscribers/NotificationMessageSubscriber.cs
@@ -20,14 +20,16 @@ public sealed class NotificationMessageSubscriber(
     IEmailMessagePublisher _emailMessagePublisher,
     ILogger<NotificationMessageSubscriber> _logger)
 {
-    [Function(nameof(SendProjectStartedNotificationMessageSubscriber))]
-    public async Task SendProjectStartedNotificationMessageSubscriber(
+    private const string SendProjectStartedNotificationMessageSubscriberFunctionName = "SendProjectStartedNotificationMessageSubscriber";
+
+    [Function(SendProjectStartedNotificationMessageSubscriberFunctionName)]
+    public async Task SendProjectStartedNotificationAsync(
         [QueueTrigger(Queues.SendProjectStartedNotification)] QueueMessage queueMessage,
         CancellationToken ct)
     {
         await queueMessage.ProcessAsync<SendProjectStartedNotificationMessage, NotificationMessageSubscriber>(
             _logger,
-            nameof(SendProjectStartedNotificationMessageSubscriber),
+            SendProjectStartedNotificationMessageSubscriberFunctionName,
             ProcessAsync,
             ct);
     }
@@ -75,14 +77,17 @@ public sealed class NotificationMessageSubscriber(
         }
     }
 
-    [Function(nameof(SendResourceCommentCreatedNotificationMessageSubscriber))]
-    public async Task SendResourceCommentCreatedNotificationMessageSubscriber(
+    private const string SendResourceCommentCreatedNotificationMessageSubscriberFunctionName =
+        "SendResourceCommentCreatedNotificationMessageSubscriber";
+
+    [Function(SendResourceCommentCreatedNotificationMessageSubscriberFunctionName)]
+    public async Task SendResourceCommentCreatedNotificationAsync(
         [QueueTrigger(Queues.SendResourceCommentCreatedNotification)] QueueMessage queueMessage,
         CancellationToken ct)
     {
         await queueMessage.ProcessAsync<SendResourceCommentCreatedNotificationMessage, NotificationMessageSubscriber>(
             _logger,
-            nameof(SendResourceCommentCreatedNotificationMessageSubscriber),
+            SendResourceCommentCreatedNotificationMessageSubscriberFunctionName,
             ProcessAsync,
             ct);
     }

--- a/src/Aquifer.Jobs/Subscribers/TrackResourceContentRequestMessageSubscriber.cs
+++ b/src/Aquifer.Jobs/Subscribers/TrackResourceContentRequestMessageSubscriber.cs
@@ -16,14 +16,16 @@ public class TrackResourceContentRequestMessageSubscriber(
     AquiferDbContext dbContext,
     IIpAddressLookupHttpClient ipAddressClient)
 {
-    [Function(nameof(TrackResourceContentRequestMessageSubscriber))]
-    public async Task Run(
+    private const string TrackResourceContentRequestMessageSubscriberFunctionName = "TrackResourceContentRequestMessageSubscriber";
+
+    [Function(TrackResourceContentRequestMessageSubscriberFunctionName)]
+    public async Task RunAsync(
         [QueueTrigger(Queues.TrackResourceContentRequest)] QueueMessage queueMessage,
         CancellationToken ct)
     {
         await queueMessage.ProcessAsync<TrackResourceContentRequestMessage, TrackResourceContentRequestMessageSubscriber>(
             logger,
-            nameof(TrackResourceContentRequestMessageSubscriber),
+            TrackResourceContentRequestMessageSubscriberFunctionName,
             ProcessAsync,
             ct);
     }

--- a/src/Aquifer.Tiptap/Directory.Build.props
+++ b/src/Aquifer.Tiptap/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+    <!-- Override the default Directory.Build.props with nothing because this project uses the JavaScript SDK. -->
+</Project>


### PR DESCRIPTION
This PR does the following:
* Add missing `Async` suffix on async methods.
* Remove erroneous `Async` suffix on non-async methods.
* For Jobs where the Azure Function name was the `nameof` the async method, add the `Async` suffix but use a different constant for the function name so as to not have `Async` in some function names in the Azure Portal.
* Use async overload where we weren't using it.
* Disable other warnings with a comment or TODO explaining why.