### PR TITLE
Specify dotnet SDK version in global.json file.

### DIFF
--- a/.github/workflows/post-merge-internal-api.yml
+++ b/.github/workflows/post-merge-internal-api.yml
@@ -58,7 +58,7 @@ jobs:
             - name: Setup .NET
               uses: actions/setup-dotnet@v4.0.1
               with:
-                  dotnet-version: '9.x'
+                  global-json-file: "./global.json"
             - name: Install NuGet packages (linux)
               run: dotnet restore --runtime linux-x64
             - name: Restore CLI tools

--- a/.github/workflows/post-merge-jobs.yml
+++ b/.github/workflows/post-merge-jobs.yml
@@ -55,7 +55,7 @@ jobs:
             - name: Setup .NET
               uses: actions/setup-dotnet@v4.0.1
               with:
-                  dotnet-version: '9.x'
+                  global-json-file: "./global.json"
             - name: Restore .net tools
               run: dotnet tool restore
             - name: Make build directory

--- a/.github/workflows/post-merge-public-api.yml
+++ b/.github/workflows/post-merge-public-api.yml
@@ -58,7 +58,7 @@ jobs:
             - name: Setup .NET
               uses: actions/setup-dotnet@v4.0.1
               with:
-                  dotnet-version: '9.x'
+                  global-json-file: "./global.json"
             - name: Install NuGet packages (linux)
               run: dotnet restore --runtime linux-x64
             - name: Restore CLI tools

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -22,7 +22,7 @@ jobs:
             - name: Setup .NET
               uses: actions/setup-dotnet@v4.0.1
               with:
-                  dotnet-version: '9.x'
+                  global-json-file: "./global.json"
             - name: Build
               run: dotnet build --no-incremental -m:1 --configuration Release /p:WarningsAsErrors=true /warnaserror
             - name: Login to Azure

--- a/Aquifer.sln
+++ b/Aquifer.sln
@@ -34,6 +34,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
 		Directory.Solution.props = Directory.Solution.props
+		global.json = global.json
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "rollForward": "latestPatch",
+    "version": "9.0.100"
+  }
+}


### PR DESCRIPTION
This prevents the build server from using a .net new SDK version without us realizing it while also enforcing that devs are using the same SDK version locally, all from one configuration file.

Note that I allowed patch updates (which seems safe) but we could lock it down to a specific patch version if desired.