### PR TITLE
Limit the number of concurrent queue processing operations.

### DIFF
--- a/src/Aquifer.Jobs/host.json
+++ b/src/Aquifer.Jobs/host.json
@@ -52,11 +52,11 @@
             // default is 0; wait ten seconds before retrying failed operations
             "visibilityTimeout": "00:00:10",
             // default; maximum number of queue messages to process in parallel
-            "batchSize": 16,
+            "batchSize": 4,
             // default; maximum number of retries for failed operations
             "maxDequeueCount": 5,
             // default; the maximum number of in-process operations allowed before pulling a new batch
-            "newBatchThreshold": 8,
+            "newBatchThreshold": 2,
             // default
             "messageEncoding": "base64"
         }


### PR DESCRIPTION
See [documentation](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue?tabs=isolated-process%2Cextensionv5%2Cextensionv3&pivots=programming-language-csharp#host-json).

Note that this impacts _all_ queues, not just the similarity scoring queue.  The translation processing also had some errors when there were many messages so this change seems like an overall improvement.  If we want to only change values for a single queue then we'll either need (a) multiple function apps, each with a unique `host.json` file, or (b) [implement a custom factory](https://stackoverflow.com/a/52638472) to inject our own settings per queue. 