### PR TITLE
Add support for authenticated integration tests.

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -40,7 +40,11 @@ jobs:
                       -e KeyVaultUri="${{ secrets.KEY_VAULT_URI }}" \
                       -e JwtSettings__Authority="${{ secrets.JWT_SETTINGS_AUTHORITY }}" \
                       -e JwtSettings__Audience="${{ secrets.JWT_SETTINGS_AUDIENCE }}" \
-                      -e Auth0Settings__ApiClientId="${{ secrets.AUTH0SETTINGS_API_CLIENT_ID }}" \
-                      -e Auth0Settings__ApplicationClientId="${{ secrets.AUTH0SETTINGS_APPLICATION_CLIENT_ID }}" \
+                      -e Auth0Settings__ApiClientId="${{ secrets.AUTH0_SETTINGS_API_CLIENT_ID }}" \
+                      -e Auth0Settings__ApplicationClientId="${{ secrets.AUTH0_SETTINGS_APPLICATION_CLIENT_ID }}" \
                       -e Auth0Settings__Audience="${{ secrets.AUTH0_SETTINGS_AUDIENCE }}" \
-                      -e Auth0Settings__BaseUri="${{ secrets.AUTH0_SETTINGS_BASE_URI }}"
+                      -e Auth0Settings__BaseUri="${{ secrets.AUTH0_SETTINGS_BASE_URI }}" \
+                      -e IntegrationTestAuth0Settings__ApplicationClientId="${{ secrets.INTEGRATION_TEST_AUTH0_SETTINGS_APPLICATION_CLIENT_ID }}" \
+                      -e IntegrationTestAuth0Settings__Audience="${{ secrets.INTEGRATION_TEST_AUTH0_SETTINGS_AUDIENCE }}" \
+                      -e IntegrationTestAuth0Settings__BaseUri="${{ secrets.INTEGRATION_TEST_AUTH0_SETTINGS_BASE_URI }}" \
+                      -e IntegrationTestUserSettings__TestUserPassword="${{ secrets.INTEGRATION_TEST_USER_SETTINGS_TEST_USER_PASSWORD }}"

--- a/src/Aquifer.API/Common/Permissions.cs
+++ b/src/Aquifer.API/Common/Permissions.cs
@@ -45,5 +45,13 @@ public static class PermissionName
 
 public static class KeyVaultSecretName
 {
-    public const string Auth0ClientSecret = "Auth0ClientSecret", OpenAiApiKey = "OpenAiApiKey";
+    public const string Auth0ClientSecret = "Auth0ClientSecret";
+
+    /// <summary>
+    /// This secret purposefully only exists in the "biblionexus-kv-dev" key vault and should only be used for integration testing.
+    /// DO NOT add this secret to the production key vault!!!
+    /// </summary>
+    public const string ResourceOwnerAuth0ClientSecret = "ResourceOwnerAuth0ClientSecret";
+
+    public const string OpenAiApiKey = "OpenAiApiKey";
 }

--- a/src/Aquifer.API/Endpoints/Users/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Users/List/Endpoint.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Aquifer.API.Endpoints.Users.List;
 
-public class Endpoint(AquiferDbContext dbContext, IUserService userService) : EndpointWithoutRequest<List<Response>>
+public class Endpoint(AquiferDbContext dbContext, IUserService userService) : EndpointWithoutRequest<IReadOnlyList<Response>>
 {
     public override void Configure()
     {

--- a/tests/Aquifer.API.IntegrationTests/Aquifer.API.IntegrationTests.csproj
+++ b/tests/Aquifer.API.IntegrationTests/Aquifer.API.IntegrationTests.csproj
@@ -5,6 +5,18 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <None Update="appsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="appsettings.Development.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="appsettings.example.json">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="FastEndpoints.Testing" />
     </ItemGroup>
 

--- a/tests/Aquifer.API.IntegrationTests/ConfigurationOptions.cs
+++ b/tests/Aquifer.API.IntegrationTests/ConfigurationOptions.cs
@@ -1,0 +1,21 @@
+﻿using Aquifer.API.Configuration;
+
+namespace Aquifer.API.IntegrationTests;
+
+public sealed class ConfigurationOptions
+{
+    public required ConnectionStringOptions ConnectionStrings { get; init; }
+    public required Auth0Settings IntegrationTestAuth0Settings { get; init; }
+    public required UserSettings IntegrationTestUserSettings { get; init; }
+    public required string KeyVaultUri { get; init; }
+
+    public sealed class ConnectionStringOptions
+    {
+        public required string BiblioNexusDb { get; init; }
+    }
+
+    public sealed class UserSettings
+    {
+        public required string TestUserPassword { get; init; }
+    }
+}

--- a/tests/Aquifer.API.IntegrationTests/Endpoints/Resources/Content/Get/EndpointTests.cs
+++ b/tests/Aquifer.API.IntegrationTests/Endpoints/Resources/Content/Get/EndpointTests.cs
@@ -18,4 +18,18 @@ public sealed class EndpointTests(App _app) : TestBase<App>
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
+
+    [Fact]
+    public async Task AuthenticatedRequest_ShouldReturnOK()
+    {
+        var response = await _app.EditorClient.GETAsync<Endpoint, Request, Response>(
+            new Request
+            {
+                Id = 1890,
+            });
+
+        response.Response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        response.Result.ResourceContentId.Should().Be(1890);
+    }
 }

--- a/tests/Aquifer.API.IntegrationTests/appsettings.example.json
+++ b/tests/Aquifer.API.IntegrationTests/appsettings.example.json
@@ -1,0 +1,15 @@
+{
+    "ConnectionStrings": {
+        "BiblioNexusDb": "Database connection string using Azure identity. Either get local or grab from dev app service config"
+    },
+    "IntegrationTestAuth0Settings": {
+        "ApiClientId": "Unused for integration testing",
+        "ApplicationClientId": "This is the Integration Test App's client id on Auth0",
+        "Audience": "Use the same audience as the Admin CMS",
+        "BaseUri": "The domain of the Integration Test App"
+    },
+    "IntegrationTestUserSettings": {
+        "TestUserPassword": "The password to use for all integration test users"
+    },
+    "KeyVaultUri": "Azure Key Vault URI"
+}

--- a/tests/Aquifer.API.IntegrationTests/appsettings.json
+++ b/tests/Aquifer.API.IntegrationTests/appsettings.json
@@ -1,0 +1,15 @@
+{
+    "ConnectionStrings": {
+        "BiblioNexusDb": ""
+    },
+    "IntegrationTestAuth0Settings": {
+        "ApiClientId": "",
+        "ApplicationClientId": "",
+        "Audience": "",
+        "BaseUri": ""
+    },
+    "IntegrationTestUserSettings": {
+        "TestUserPassword": ""
+    },
+    "KeyVaultUri": ""
+}


### PR DESCRIPTION
Notes:
* I created a client for each of the CMS roles (leaving out a couple less used roles).  If we want additional roles represented in the future it's easy to add them.
* I wrote code that can create the test users, one per role.  This code will only be run once (I already ran it locally); if a test user exists already (by email lookup) then the existing user will be used for the tests instead of making a new user every test run.
* All test users share the same password.
* In order to create the test users with a known password I used the existing Create User endpoint and then manually updated the password.
* In order to get a bearer token for the test users I created a new Auth0 application which allows authenticated directly with username/password via the [Resource Owner Password Flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/resource-owner-password-flow).  This integration test application only exists in the Dev/QA environment for security reasons.  Only the integration test project currently has the needed configuration to invoke fetching a bearer token via username/password and only it should ever use this functionality.
* The Aquifer.API.IntegrationTests project now has configuration for both Aquifer.API (to set up the API under test) and for its own purposes in order to authenticate users.  I made this distinction clear via comments because I use the API's configuration for accessing the management API and the integration test configuration for authenticating via username/password.
* Necessary environment variables have already been added to the GitHub Actions environment.
