### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -81,6 +81,7 @@ dotnet_style_null_propagation = true:error
 dotnet_style_object_initializer = true
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
 dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_collection_expression.when_types_loosely_match = true:suggestion
 dotnet_style_prefer_compound_assignment = true:error
 dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
 dotnet_style_prefer_conditional_expression_over_return = true:suggestion
@@ -102,7 +103,7 @@ dotnet_remove_unnecessary_suppression_exclusions = none
 
 # New line preferences
 dotnet_style_allow_multiple_blank_lines_experimental = false:error
-dotnet_style_allow_statement_immediately_after_block_experimental = true
+dotnet_style_allow_statement_immediately_after_block_experimental = false
 
 #### C# Coding Conventions ####
 
@@ -226,6 +227,11 @@ csharp_preserve_single_line_statements = true
 
 # Naming rules
 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.private_constants_rule.severity = warning
+dotnet_naming_rule.private_constants_rule.style = pascal_case
+dotnet_naming_rule.private_constants_rule.symbols = private_constants_symbols
+
 dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
 dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
 dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
@@ -238,7 +244,20 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
+dotnet_naming_rule.private_static_fields_rule.severity = warning
+dotnet_naming_rule.private_static_fields_rule.style = s_lower_camel_case_style
+dotnet_naming_rule.private_static_fields_rule.symbols = private_static_fields_symbols
+dotnet_naming_rule.private_static_readonly_rule.severity = warning
+dotnet_naming_rule.private_static_readonly_rule.style = s_lower_camel_case_style
+dotnet_naming_rule.private_static_readonly_rule.symbols = private_static_readonly_symbols
+
+dotnet_naming_rule.private_members_with_underscore.symbols = private_fields
+dotnet_naming_rule.private_members_with_underscore.style = prefix_underscore
+dotnet_naming_rule.private_members_with_underscore.severity = warning
+
 # Symbol specifications
+
+dotnet_naming_symbols.constant_fields.required_modifiers = const
 
 dotnet_naming_symbols.interface.applicable_kinds = interface
 dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
@@ -252,6 +271,20 @@ dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, meth
 dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
 dotnet_naming_symbols.non_field_members.required_modifiers =
 
+dotnet_naming_symbols.private_static_fields_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields_symbols.required_modifiers = static
+dotnet_naming_symbols.private_static_readonly_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_readonly_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_readonly_symbols.required_modifiers = static, readonly
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_symbols.private_constants_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_constants_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_constants_symbols.required_modifiers = const
+
 # Naming styles
 
 dotnet_naming_style.pascal_case.required_prefix =
@@ -259,10 +292,16 @@ dotnet_naming_style.pascal_case.required_suffix =
 dotnet_naming_style.pascal_case.word_separator =
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
+dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _
+
 dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.s_lower_camel_case_style.capitalization = camel_case
+dotnet_naming_style.s_lower_camel_case_style.required_prefix = s_
 
 # Resharper
 resharper_max_formal_parameters_on_line = 6
@@ -270,15 +309,3 @@ resharper_csharp_max_formal_parameters_on_line = 6
 resharper_csharp_continuous_indent_multiplier = 1
 resharper_csharp_max_invocation_arguments_on_line = 6
 resharper_csharp_wrap_list_pattern = chop_if_long
-
-[*.{cs,vb}]
-dotnet_style_coalesce_expression = true:error
-dotnet_style_null_propagation = true:error
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_auto_properties = true
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_operator_placement_when_wrapping = beginning_of_line
-dotnet_style_prefer_collection_expression.when_types_loosely_match = true:suggestion
-tab_width = 4
-indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-# Remove the line below if you want to inherit .editorconfig settings from higher directories
 root = true
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
 
 # All files
 [*]
@@ -8,29 +8,47 @@ root = true
 guidelines = 140
 guidelines_style = 1px solid gray
 
+# ReSharper properties
+resharper_csharp_wrap_arguments_style = chop_if_long
+resharper_csharp_wrap_parameters_style = chop_if_long
+resharper_keep_existing_embedded_arrangement = false
+resharper_max_enum_members_on_line = 1
+resharper_nested_ternary_style = expanded
+resharper_place_simple_embedded_statement_on_same_line = false
+resharper_treat_case_statement_with_break_as_simple = false
+resharper_wrap_after_declaration_lpar = true
+resharper_wrap_after_invocation_lpar = true
+resharper_wrap_after_property_in_chained_method_calls = true
+resharper_wrap_array_initializer_style = chop_if_long
+resharper_wrap_before_first_method_call = true
+resharper_wrap_before_first_type_parameter_constraint = true
+resharper_wrap_chained_binary_expressions = chop_if_long
+resharper_wrap_chained_method_calls = chop_if_long
+resharper_wrap_list_pattern = chop_if_long
+
 # C# files
 [*.cs]
 
-dotnet_analyzer_diagnostic.category-Style.severity = warning
-dotnet_analyzer_diagnostic.category-Design.severity = warning
-dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
-dotnet_analyzer_diagnostic.category-Reliability.severity = warning
-dotnet_analyzer_diagnostic.category-Security.severity = warning
+dotnet_analyzer_diagnostic.category-style.severity = warning
+dotnet_analyzer_diagnostic.category-design.severity = warning
+dotnet_analyzer_diagnostic.category-maintainability.severity = warning
+dotnet_analyzer_diagnostic.category-reliability.severity = warning
+dotnet_analyzer_diagnostic.category-security.severity = warning
 
 # Suppress XML documentation warnings
-dotnet_diagnostic.CS1591.severity = none
+dotnet_diagnostic.cs1591.severity = none
 
 # Suppress ternary expression warning
-dotnet_diagnostic.IDE0046.severity = none
+dotnet_diagnostic.ide0046.severity = none
 
 # Suppress some indenting warnings
-dotnet_diagnostic.IDE0055.severity = none
+dotnet_diagnostic.ide0055.severity = none
 
 # Suppress requirement to deconstruct tuples
-dotnet_diagnostic.IDE0042.severity = suggestion
+dotnet_diagnostic.ide0042.severity = suggestion
 
 # Suppress requirement to always use collection initializers
-dotnet_diagnostic.IDE0305.severity = suggestion
+dotnet_diagnostic.ide0305.severity = suggestion
 
 #### Core EditorConfig Options ####
 
@@ -51,7 +69,7 @@ place_attribute_on_same_line = false
 # Organize usings
 dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = true
-file_header_template = unset
+file_header_template = 
 
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false:error
@@ -261,15 +279,15 @@ dotnet_naming_symbols.constant_fields.required_modifiers = const
 
 dotnet_naming_symbols.interface.applicable_kinds = interface
 dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers =
+dotnet_naming_symbols.interface.required_modifiers = 
 
 dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
 dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers =
+dotnet_naming_symbols.types.required_modifiers = 
 
 dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
 dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers =
+dotnet_naming_symbols.non_field_members.required_modifiers = 
 
 dotnet_naming_symbols.private_static_fields_symbols.applicable_accessibilities = private
 dotnet_naming_symbols.private_static_fields_symbols.applicable_kinds = field
@@ -287,17 +305,17 @@ dotnet_naming_symbols.private_constants_symbols.required_modifiers = const
 
 # Naming styles
 
-dotnet_naming_style.pascal_case.required_prefix =
-dotnet_naming_style.pascal_case.required_suffix =
-dotnet_naming_style.pascal_case.word_separator =
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
 dotnet_naming_style.prefix_underscore.capitalization = camel_case
 dotnet_naming_style.prefix_underscore.required_prefix = _
 
 dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix =
-dotnet_naming_style.begins_with_i.word_separator =
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
 dotnet_naming_style.s_lower_camel_case_style.capitalization = camel_case

--- a/src/Aquifer.AI/OpenAiTranslationService.cs
+++ b/src/Aquifer.AI/OpenAiTranslationService.cs
@@ -51,9 +51,9 @@ public sealed class OpenAiChatCompletionException(string message, string prompt,
 
 public sealed partial class OpenAiTranslationService : ITranslationService
 {
-    private const string _englishLanguageCode = "ENG";
-    private const int _maxContentLength = 5_000;
-    private const int _maxParallelizationForSingleTranslation = 3;
+    private const string EnglishLanguageCode = "ENG";
+    private const int MaxContentLength = 5_000;
+    private const int MaxParallelizationForSingleTranslation = 3;
 
     private static readonly TimeSpan s_openAiNetworkTimeout = TimeSpan.FromMinutes(10);
 
@@ -93,10 +93,10 @@ public sealed partial class OpenAiTranslationService : ITranslationService
         IDictionary<string, string> translationPairs,
         CancellationToken cancellationToken)
     {
-        if (text.Length > _maxContentLength)
+        if (text.Length > MaxContentLength)
         {
             throw new ArgumentException(
-                $"{nameof(text)} must have fewer than {_maxContentLength} characters but has {text.Length}.",
+                $"{nameof(text)} must have fewer than {MaxContentLength} characters but has {text.Length}.",
                 nameof(text));
         }
 
@@ -124,7 +124,7 @@ public sealed partial class OpenAiTranslationService : ITranslationService
         foreach (var paragraphs in ParagraphRegex()
             .Split(html)
             .Where(x => !string.IsNullOrWhiteSpace(x) && x.Length > 2)
-            .Chunk(_maxParallelizationForSingleTranslation))
+            .Chunk(MaxParallelizationForSingleTranslation))
         {
             // Operate on the paragraphs in each batch in parallel,
             // but wait for all paragraphs in the batch to finish before starting the next batch.
@@ -203,7 +203,7 @@ public sealed partial class OpenAiTranslationService : ITranslationService
 
     private string? GetHtmlTranslationPrompt((string Iso6393Code, string EnglishName) destinationLanguage)
     {
-        if (string.Equals(destinationLanguage.Iso6393Code, _englishLanguageCode, StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(destinationLanguage.Iso6393Code, EnglishLanguageCode, StringComparison.OrdinalIgnoreCase))
         {
             return null;
         }

--- a/src/Aquifer.API/Endpoints/Reports/Resources/ItemTotals/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Reports/Resources/ItemTotals/Endpoint.cs
@@ -9,7 +9,7 @@ namespace Aquifer.API.Endpoints.Reports.Resources.ItemTotals;
 
 public class Endpoint(AquiferDbContext dbContext) : EndpointWithoutRequest<Response>
 {
-    private readonly string TotalsQuery =
+    private readonly string _totalsQuery =
         $"""
          SELECT (SELECT COUNT(*)
           FROM Resources) AS TotalResources,
@@ -90,7 +90,7 @@ public class Endpoint(AquiferDbContext dbContext) : EndpointWithoutRequest<Respo
     public override async Task HandleAsync(CancellationToken cancellationToken)
     {
         var totals = await dbContext.Database
-            .SqlQuery<Response>($"exec ({TotalsQuery})")
+            .SqlQuery<Response>($"exec ({_totalsQuery})")
             .ToListAsync(cancellationToken);
 
         await SendAsync(totals.Single(), cancellation: cancellationToken);

--- a/src/Aquifer.API/Endpoints/Resources/Content/Helpers.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Helpers.cs
@@ -73,7 +73,8 @@ public static class Helpers
             await historyService.AddAssignedUserHistoryAsync(newResourceContentVersion, assignedUserId, user.Id, ct);
         }
 
-        var resourceContent = await dbContext.ResourceContents.AsTracking().SingleOrDefaultAsync(rc => rc.Id == contentId, ct) ?? throw new ArgumentNullException();
+        var resourceContent = await dbContext.ResourceContents.AsTracking().SingleOrDefaultAsync(rc => rc.Id == contentId, ct)
+            ?? throw new ArgumentException($"Content with ID {contentId} not found.", nameof(contentId));
 
         if (assignedUserId is null || resourceContent.LanguageId == Constants.EnglishLanguageId)
         {
@@ -105,6 +106,7 @@ public static class Helpers
             {
                 resourceContent.Updated = DateTime.UtcNow;
             }
+
             await historyService.AddStatusHistoryAsync(newResourceContentVersion, ResourceContentStatus.AquiferizeEditorReview, user.Id, ct);
         }
     }

--- a/src/Aquifer.API/Modules/IModule.cs
+++ b/src/Aquifer.API/Modules/IModule.cs
@@ -13,7 +13,7 @@ public interface IModule
 public static class ModuleExtensions
 {
     // this could also be added into the DI container
-    private static readonly List<IModule> registeredModules = [];
+    private static readonly List<IModule> s_registeredModules = [];
 
     public static IServiceCollection RegisterModules(this IServiceCollection services)
     {
@@ -21,7 +21,7 @@ public static class ModuleExtensions
         foreach (var module in modules)
         {
             module.RegisterModule(services);
-            registeredModules.Add(module);
+            s_registeredModules.Add(module);
         }
 
         return services;
@@ -29,7 +29,7 @@ public static class ModuleExtensions
 
     public static WebApplication MapEndpoints(this WebApplication app)
     {
-        foreach (var module in registeredModules)
+        foreach (var module in s_registeredModules)
         {
             module.MapEndpoints(app);
         }

--- a/src/Aquifer.Common/Messages/MessagesJsonSerializer.cs
+++ b/src/Aquifer.Common/Messages/MessagesJsonSerializer.cs
@@ -6,7 +6,7 @@ namespace Aquifer.Common.Messages;
 public sealed class MessagesJsonSerializer
 {
     // max Azure Storage Queue message size is 64 KB: https://learn.microsoft.com/en-us/azure/storage/queues/storage-queues-introduction
-    private const int _maxMessageSizeInBytes = 65_536;
+    private const int MaxMessageSizeInBytes = 65_536;
 
     private static readonly JsonSerializerSettings s_settings = new()
     {
@@ -27,10 +27,10 @@ public sealed class MessagesJsonSerializer
     {
         var json = JsonConvert.SerializeObject(dto, s_settings);
 
-        if (!shouldAllowInvalidMessageLength && System.Text.Encoding.Unicode.GetByteCount(json) > _maxMessageSizeInBytes)
+        if (!shouldAllowInvalidMessageLength && System.Text.Encoding.Unicode.GetByteCount(json) > MaxMessageSizeInBytes)
         {
             throw new ArgumentException(
-                $"Serialized JSON message is {System.Text.Encoding.Unicode.GetByteCount(json)} bytes but must be less than {_maxMessageSizeInBytes} bytes. Content: {json}",
+                $"Serialized JSON message is {System.Text.Encoding.Unicode.GetByteCount(json)} bytes but must be less than {MaxMessageSizeInBytes} bytes. Content: {json}",
                 nameof(dto));
         }
 

--- a/src/Aquifer.Common/Utilities/BibleBookCodeUtilities.cs
+++ b/src/Aquifer.Common/Utilities/BibleBookCodeUtilities.cs
@@ -5,8 +5,8 @@ namespace Aquifer.Common.Utilities;
 
 public static class BibleBookCodeUtilities
 {
-    private static readonly Dictionary<string, BibleBookMetadata> BookCodeToMetadata = [];
-    private static readonly Dictionary<BookId, BibleBookMetadata> BookIdToMetadata = [];
+    private static readonly Dictionary<string, BibleBookMetadata> s_bookCodeToMetadata = [];
+    private static readonly Dictionary<BookId, BibleBookMetadata> s_bookIdToMetadata = [];
 
     static BibleBookCodeUtilities()
     {
@@ -20,29 +20,29 @@ public static class BibleBookCodeUtilities
                 BookCode = bookId.ToString().Replace("Book", ""),
                 BookFullName = bookId.GetDisplayName()
             };
-            BookCodeToMetadata.Add(bookId.ToString().Replace("Book", ""), metadata);
-            BookIdToMetadata.Add(bookId, metadata);
+            s_bookCodeToMetadata.Add(bookId.ToString().Replace("Book", ""), metadata);
+            s_bookIdToMetadata.Add(bookId, metadata);
         }
     }
 
     public static string CodeFromId(BookId bookId)
     {
-        return BookIdToMetadata.TryGetValue(bookId, out var obj) ? obj.BookCode : "";
+        return s_bookIdToMetadata.TryGetValue(bookId, out var obj) ? obj.BookCode : "";
     }
 
     public static BookId IdFromCode(string stringValue)
     {
-        return BookCodeToMetadata.TryGetValue(stringValue.ToUpper(), out var obj) ? obj.BookId : BookId.None;
+        return s_bookCodeToMetadata.TryGetValue(stringValue.ToUpper(), out var obj) ? obj.BookId : BookId.None;
     }
 
     public static string FullNameFromId(BookId bookId)
     {
-        return BookIdToMetadata.TryGetValue(bookId, out var obj) ? obj.BookFullName : "";
+        return s_bookIdToMetadata.TryGetValue(bookId, out var obj) ? obj.BookFullName : "";
     }
 
     public static List<BibleBookMetadata> GetAll()
     {
-        return BookIdToMetadata.Select(x => x.Value).Skip(1).ToList();
+        return s_bookIdToMetadata.Select(x => x.Value).Skip(1).ToList();
     }
 
     public record BibleBookMetadata

--- a/src/Aquifer.Common/Utilities/BibleBookCodeUtilities.cs
+++ b/src/Aquifer.Common/Utilities/BibleBookCodeUtilities.cs
@@ -10,7 +10,7 @@ public static class BibleBookCodeUtilities
 
     static BibleBookCodeUtilities()
     {
-        var bookIds = Enum.GetValues(typeof(BookId)).Cast<BookId>();
+        var bookIds = Enum.GetValues<BookId>();
 
         foreach (var bookId in bookIds)
         {

--- a/src/Aquifer.Common/Utilities/CryptographyUtilities.cs
+++ b/src/Aquifer.Common/Utilities/CryptographyUtilities.cs
@@ -4,11 +4,11 @@ namespace Aquifer.Common.Utilities;
 
 public static class CryptographyUtilities
 {
-    private static readonly char[] LowerLetters = Enumerable.Range('A', 26).Select(Convert.ToChar).ToArray();
-    private static readonly char[] UpperLetters = Enumerable.Range('a', 26).Select(Convert.ToChar).ToArray();
-    private static readonly char[] Numbers = Enumerable.Range('0', 10).Select(Convert.ToChar).ToArray();
+    private static readonly char[] s_lowerLetters = Enumerable.Range('A', 26).Select(Convert.ToChar).ToArray();
+    private static readonly char[] s_upperLetters = Enumerable.Range('a', 26).Select(Convert.ToChar).ToArray();
+    private static readonly char[] s_numbers = Enumerable.Range('0', 10).Select(Convert.ToChar).ToArray();
 
-    private static readonly char[] SpecialCharacters =
+    private static readonly char[] s_specialCharacters =
     [
         '!',
         '@',
@@ -22,10 +22,10 @@ public static class CryptographyUtilities
 
     public static string GenerateSimplePassword()
     {
-        var lower = RandomNumberGenerator.GetString(LowerLetters, 4);
-        var upper = RandomNumberGenerator.GetString(UpperLetters, 4);
-        var numbers = RandomNumberGenerator.GetString(Numbers, 4);
-        var special = RandomNumberGenerator.GetString(SpecialCharacters, 4);
+        var lower = RandomNumberGenerator.GetString(s_lowerLetters, 4);
+        var upper = RandomNumberGenerator.GetString(s_upperLetters, 4);
+        var numbers = RandomNumberGenerator.GetString(s_numbers, 4);
+        var special = RandomNumberGenerator.GetString(s_specialCharacters, 4);
 
         var all = (lower + upper + numbers + special).ToArray();
         Random.Shared.Shuffle(all);

--- a/src/Aquifer.Common/Utilities/StringSimilarityUtilities.cs
+++ b/src/Aquifer.Common/Utilities/StringSimilarityUtilities.cs
@@ -65,6 +65,7 @@ public static class StringSimilarityUtilities
             
             result.Add(substring);
         }
+
         result.Add(text);
         
         return result;

--- a/src/Aquifer.Data/EventHandlers/BadTranslationPairHandler.cs
+++ b/src/Aquifer.Data/EventHandlers/BadTranslationPairHandler.cs
@@ -7,7 +7,7 @@ namespace Aquifer.Data.EventHandlers;
 
 public static class BadTranslationPairHandler
 {
-    private static readonly IReadOnlySet<string> s_KeyBlacklist = new HashSet<string>
+    private static readonly IReadOnlySet<string> s_keyBlacklist = new HashSet<string>
     {
         "span",
         "div"
@@ -25,7 +25,7 @@ public static class BadTranslationPairHandler
                     return;
                 }
 
-                if (x.Key.Length < 3 || s_KeyBlacklist.Contains(x.Key))
+                if (x.Key.Length < 3 || s_keyBlacklist.Contains(x.Key))
                 {
                     throw new TranslationPairKeyNotAllowedException(
                         $"The key ${x.Key} is not allowed. Keys 2 or fewer characters and some specific keys are not allowed.");

--- a/src/Aquifer.Data/EventHandlers/ResourceStatusChangeHandler.cs
+++ b/src/Aquifer.Data/EventHandlers/ResourceStatusChangeHandler.cs
@@ -6,7 +6,7 @@ namespace Aquifer.Data.EventHandlers;
 
 public static class ResourceStatusChangeHandler
 {
-    private static readonly List<ResourceContentStatus> InReviewOrGreaterStatuses =
+    private static readonly List<ResourceContentStatus> s_inReviewOrGreaterStatuses =
     [
         ResourceContentStatus.Complete, ResourceContentStatus.AquiferizePublisherReview, ResourceContentStatus.TranslationPublisherReview
     ];
@@ -63,7 +63,7 @@ public static class ResourceStatusChangeHandler
             await dbContext.Projects.Where(x =>
                     x.ProjectResourceContents.Any(prc => inReviewContentIds.Contains(prc.ResourceContent.Id)) &&
                     x.ProjectResourceContents.Where(prc => !inReviewContentIds.Contains(prc.ResourceContent.Id))
-                        .All(prc => InReviewOrGreaterStatuses.Contains(prc.ResourceContent.Status)))
+                        .All(prc => s_inReviewOrGreaterStatuses.Contains(prc.ResourceContent.Status)))
                 .ExecuteUpdateAsync(x => x
                     .SetProperty(p => p.ActualDeliveryDate, DateOnly.FromDateTime(DateTime.UtcNow))
                     .SetProperty(p => p.Updated, DateTime.UtcNow));
@@ -75,7 +75,7 @@ public static class ResourceStatusChangeHandler
                     x.ActualDeliveryDate != null &&
                     x.ActualPublishDate == null &&
                     x.ProjectResourceContents.Any(prc => editorReviewIds.Contains(prc.ResourceContent.Id)) &&
-                    x.ProjectResourceContents.Where(prc => !editorReviewIds.Contains(prc.ResourceContent.Id)).All(prc => InReviewOrGreaterStatuses.Contains(prc.ResourceContent.Status)))
+                    x.ProjectResourceContents.Where(prc => !editorReviewIds.Contains(prc.ResourceContent.Id)).All(prc => s_inReviewOrGreaterStatuses.Contains(prc.ResourceContent.Status)))
                 .ExecuteUpdateAsync(x => x
                     .SetProperty(p => p.ActualDeliveryDate, null as DateOnly?)
                     .SetProperty(p => p.Updated, DateTime.UtcNow));

--- a/src/Aquifer.Jobs/Managers/SendResourceAssignmentNotificationsManager.cs
+++ b/src/Aquifer.Jobs/Managers/SendResourceAssignmentNotificationsManager.cs
@@ -20,8 +20,8 @@ public sealed class SendResourceAssignmentNotificationsManager(
     ILogger<SendResourceAssignmentNotificationsManager> _logger)
     : ManagerBase<SendResourceAssignmentNotificationsManager>(_logger)
 {
-    private const int _maxNumberOfResourcesToDisplayInNotificationContent = 25;
-    private const int _maxAgeOfResourceAssignmentInMinutes = 120;
+    private const int MaxNumberOfResourcesToDisplayInNotificationContent = 25;
+    private const int MaxAgeOfResourceAssignmentInMinutes = 120;
 
     [Function(nameof(SendResourceAssignmentNotificationsManager))]
     [FixedDelayRetry(maxRetryCount: 1, Timings.TenSecondDelayInterval)]
@@ -42,7 +42,7 @@ public sealed class SendResourceAssignmentNotificationsManager(
         var includeResourcesAssignedSince = new[]
         {
             jobHistory.LastProcessed,
-            DateTime.UtcNow.AddMinutes(-_maxAgeOfResourceAssignmentInMinutes),
+            DateTime.UtcNow.AddMinutes(-MaxAgeOfResourceAssignmentInMinutes),
         }
         .Max();
 
@@ -86,9 +86,9 @@ public sealed class SendResourceAssignmentNotificationsManager(
                         [EmailMessagePublisher.DynamicTemplateDataSubjectPropertyName] = "Aquifer Notification: Resources Assigned",
                         ["aquiferAdminBaseUri"] = _configurationOptions.Value.AquiferAdminBaseUri,
                         ["resourceCount"] = countOfResourcesAssignedToUser,
-                        ["additionalResourceCount"] = Math.Max(countOfResourcesAssignedToUser - _maxNumberOfResourcesToDisplayInNotificationContent, 0),
+                        ["additionalResourceCount"] = Math.Max(countOfResourcesAssignedToUser - MaxNumberOfResourcesToDisplayInNotificationContent, 0),
                         ["parentResources"] = userGrouping
-                            .Take(_maxNumberOfResourcesToDisplayInNotificationContent)
+                            .Take(MaxNumberOfResourcesToDisplayInNotificationContent)
                             .GroupBy(uh => uh.ParentResourceName)
                             .OrderBy(parentResourceGrouping => parentResourceGrouping.Key)
                             .Select(parentResourceGrouping => new

--- a/src/Aquifer.Jobs/Services/SendGridEmailService.cs
+++ b/src/Aquifer.Jobs/Services/SendGridEmailService.cs
@@ -34,7 +34,7 @@ public sealed record EmailAddress(
 public class SendGridEmailService : IEmailService
 {
     // the SendGrid API limit is 1,000
-    private const int _maximumNumberOfTosPerApiCall = 1_000;
+    private const int MaximumNumberOfTosPerApiCall = 1_000;
     private static readonly Regex s_removePlusAddressing = new("\\+.*@", RegexOptions.Compiled);
 
     private readonly SendGridClient _sendGridClient;
@@ -180,7 +180,7 @@ public class SendGridEmailService : IEmailService
 
             return groups
                 .Select(grp => grp.First())
-                .Chunk(_maximumNumberOfTosPerApiCall)
+                .Chunk(MaximumNumberOfTosPerApiCall)
                 .Concat(
                     RecursivelyChunkAndZipGroupedItems(
                         groups

--- a/src/Aquifer.Jobs/Services/TranslationProcessors/FrenchTranslationProcessingService.cs
+++ b/src/Aquifer.Jobs/Services/TranslationProcessors/FrenchTranslationProcessingService.cs
@@ -9,7 +9,7 @@ public sealed partial class FrenchTranslationProcessingService : ILanguageSpecif
     private const string NonBreakingSpace = "\u00a0";
     private const string HtmlEncodedNonBreakingSpace = "&nbsp;";
 
-    private static readonly IReadOnlySet<string> s_RegexItemsThatHaveNnbspAfterSelf = new HashSet<string>
+    private static readonly IReadOnlySet<string> s_regexItemsThatHaveNnbspAfterSelf = new HashSet<string>
     {
         @"\bv\.", // v.
         @"\bp\.", // p.
@@ -19,7 +19,7 @@ public sealed partial class FrenchTranslationProcessingService : ILanguageSpecif
         @"\bav\." // av.
     };
 
-    private static readonly IReadOnlySet<string> s_RegexItemsThatHaveNnbspBeforeSelf = new HashSet<string>
+    private static readonly IReadOnlySet<string> s_regexItemsThatHaveNnbspBeforeSelf = new HashSet<string>
     {
         "»",
         "!",
@@ -28,8 +28,8 @@ public sealed partial class FrenchTranslationProcessingService : ILanguageSpecif
         ";"
     };
 
-    private readonly string _nnbspAfterPattern = @$"({string.Join("|", s_RegexItemsThatHaveNnbspAfterSelf)})(?=[A-Za-zà-üÀ-Ü0-9\x20])";
-    private readonly string _nnbspBeforePattern = @$"(\b|\x20)({string.Join("|", s_RegexItemsThatHaveNnbspBeforeSelf)})";
+    private readonly string _nnbspAfterPattern = @$"({string.Join("|", s_regexItemsThatHaveNnbspAfterSelf)})(?=[A-Za-zà-üÀ-Ü0-9\x20])";
+    private readonly string _nnbspBeforePattern = @$"(\b|\x20)({string.Join("|", s_regexItemsThatHaveNnbspBeforeSelf)})";
 
     public string Iso6393Code => "FRA";
 

--- a/src/Aquifer.Jobs/Subscribers/TranslationMessageSubscriber.cs
+++ b/src/Aquifer.Jobs/Subscribers/TranslationMessageSubscriber.cs
@@ -29,7 +29,7 @@ public sealed class TranslationMessageSubscriber(
     INotificationMessagePublisher _notificationMessagePublisher,
     IQueueClientFactory _queueClientFactory)
 {
-    private const int _englishLanguageId = 1;
+    private const int EnglishLanguageId = 1;
 
     private static readonly IReadOnlySet<TranslationOrigin> s_allowedTranslationOriginsForIndividualResourceContentTranslation =
         new HashSet<TranslationOrigin>
@@ -319,7 +319,7 @@ public sealed class TranslationMessageSubscriber(
         var englishResourceContentVersionsToTranslate = await _dbContext.ResourceContentVersions
             .Where(rcv =>
                 rcv.IsPublished &&
-                rcv.ResourceContent.LanguageId == _englishLanguageId &&
+                rcv.ResourceContent.LanguageId == EnglishLanguageId &&
                 rcv.ResourceContent.MediaType == ResourceContentMediaType.Text &&
                 rcv.ResourceContent.Resource.ParentResourceId == parentResource.Id)
             .ToListAsync(ct);
@@ -461,7 +461,7 @@ public sealed class TranslationMessageSubscriber(
             .Where(rcv =>
                 rcv.Id == dto.EnglishResourceContentVersionId &&
                 rcv.IsPublished &&
-                rcv.ResourceContent.LanguageId == _englishLanguageId &&
+                rcv.ResourceContent.LanguageId == EnglishLanguageId &&
                 rcv.ResourceContent.MediaType == ResourceContentMediaType.Text)
             .Include(x => x.ResourceContent)
             .SingleOrDefaultAsync(ct)
@@ -665,13 +665,13 @@ public sealed class TranslationMessageSubscriber(
 
         var resourceContentLanguage = resourceContentVersion.ResourceContent.Language;
 
-        if (isAquiferization && resourceContentLanguage.Id != _englishLanguageId)
+        if (isAquiferization && resourceContentLanguage.Id != EnglishLanguageId)
         {
             throw new InvalidOperationException(
                 $"Aborting aquiferization for Resource Content ID {resourceContentId} because status indicates aquiferization but content language is {resourceContentLanguage.EnglishDisplay}.");
         }
 
-        if (!isAquiferization && resourceContentLanguage.Id == _englishLanguageId)
+        if (!isAquiferization && resourceContentLanguage.Id == EnglishLanguageId)
         {
             throw new InvalidOperationException(
                 $"Aborting translation for Resource Content ID {resourceContentId} because status indicates translation but content language is English.");
@@ -690,7 +690,7 @@ public sealed class TranslationMessageSubscriber(
         // Translation should not have existing content (if not a forced retranslation)
         // but Aquiferization of English may have existing content.
         if (!shouldForceRetranslation &&
-            resourceContentLanguage.Id != _englishLanguageId &&
+            resourceContentLanguage.Id != EnglishLanguageId &&
             resourceContentVersion.ResourceContent.ContentUpdated != null)
         {
             _logger.LogInformation(

--- a/src/Aquifer.Public.API/Endpoints/Resources/Collections/Get/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Collections/Get/Endpoint.cs
@@ -41,6 +41,7 @@ public sealed class Endpoint(AquiferDbContext _dbContext, ICachingLanguageServic
         {
             ThrowError(r => r.LanguageIds, $"Invalid 'Language Ids': \"{string.Join("\", \"", invalidLanguageIds)}\"");
         }
+
         if (invalidLanguageCodes is not [])
         {
             ThrowError(r => r.LanguageCodes, $"Invalid 'Language Codes': \"{string.Join("\", \"", invalidLanguageCodes)}\"");

--- a/src/Aquifer.Public.API/OpenApi/ClientGenerationSettings.cs
+++ b/src/Aquifer.Public.API/OpenApi/ClientGenerationSettings.cs
@@ -10,7 +10,7 @@ namespace Aquifer.Public.API.OpenApi;
 /// </summary>
 public static class ClientGenerationSettings
 {
-    private const string _clientsRouteName = "clients";
+    private const string ClientsRouteName = "clients";
 
     public static IEndpointRouteBuilder ConfigureClientGeneration(
         this IEndpointRouteBuilder app,
@@ -18,7 +18,7 @@ public static class ClientGenerationSettings
         TimeSpan clientZipCacheDuration)
     {
         app.MapApiClientEndpoint(
-            $"/{_clientsRouteName}/cs",
+            $"/{ClientsRouteName}/cs",
             c =>
             {
                 c.SwaggerDocumentName = swaggerDocumentName;
@@ -26,7 +26,7 @@ public static class ClientGenerationSettings
                 c.ClientNamespaceName = "BiblioNexus.Aquifer.API.Client";
                 c.ClientClassName = "AquiferClient";
                 c.OutputPath = Path.Combine(c.OutputPath, "cs", Path.GetRandomFileName());
-                c.ExcludePatterns = [$"**/{_clientsRouteName}/**"];
+                c.ExcludePatterns = [$"**/{ClientsRouteName}/**"];
             },
             o =>
             {
@@ -143,7 +143,7 @@ public static class ClientGenerationSettings
             });
 
         app.MapApiClientEndpoint(
-            $"/{_clientsRouteName}/java",
+            $"/{ClientsRouteName}/java",
             c =>
             {
                 c.SwaggerDocumentName = swaggerDocumentName;
@@ -151,7 +151,7 @@ public static class ClientGenerationSettings
                 c.ClientNamespaceName = "org.biblionexus.aquifer.api.client";
                 c.ClientClassName = "AquiferClient";
                 c.OutputPath = Path.Combine(c.OutputPath, "java", Path.GetRandomFileName());
-                c.ExcludePatterns = [$"**/{_clientsRouteName}/**"];
+                c.ExcludePatterns = [$"**/{ClientsRouteName}/**"];
             },
             o =>
             {
@@ -171,7 +171,7 @@ public static class ClientGenerationSettings
             });
 
         app.MapApiClientEndpoint(
-            $"/{_clientsRouteName}/py",
+            $"/{ClientsRouteName}/py",
             c =>
             {
                 c.SwaggerDocumentName = swaggerDocumentName;
@@ -179,7 +179,7 @@ public static class ClientGenerationSettings
                 c.ClientNamespaceName = "biblionexus_aquifer_api_client";
                 c.ClientClassName = "AquiferClient";
                 c.OutputPath = Path.Combine(c.OutputPath, "py", Path.GetRandomFileName());
-                c.ExcludePatterns = [$"**/{_clientsRouteName}/**"];
+                c.ExcludePatterns = [$"**/{ClientsRouteName}/**"];
             },
             o =>
             {
@@ -198,7 +198,7 @@ public static class ClientGenerationSettings
             });
 
         app.MapApiClientEndpoint(
-            $"/{_clientsRouteName}/ts",
+            $"/{ClientsRouteName}/ts",
             c =>
             {
                 c.SwaggerDocumentName = swaggerDocumentName;
@@ -206,7 +206,7 @@ public static class ClientGenerationSettings
                 c.ClientNamespaceName = "biblionexus-aquifer-api-client";
                 c.ClientClassName = "AquiferClient";
                 c.OutputPath = Path.Combine(c.OutputPath, "ts", Path.GetRandomFileName());
-                c.ExcludePatterns = [$"**/{_clientsRouteName}/**"];
+                c.ExcludePatterns = [$"**/{ClientsRouteName}/**"];
             },
             o =>
             {

--- a/tests/Aquifer.Common.IntegrationTests/Utilities/VersificationUtilitiesTests.cs
+++ b/tests/Aquifer.Common.IntegrationTests/Utilities/VersificationUtilitiesTests.cs
@@ -7,24 +7,24 @@ public sealed class VersificationUtilitiesTests(App _app) : TestBase<App>
 {
     private readonly ICachingVersificationService _versificationService = _app.GetRequiredService<ICachingVersificationService>();
 
-    private const int _engVersificationSchemeBibleId = 0;
-    private const int _bsbBibleId = 1;
-    private const int _ls1910BibleId = 6;
-    private const int _rsbBibleId = 9;
-    private const int _gltBibleId = 10;
+    private const int EngVersificationSchemeBibleId = 0;
+    private const int BsbBibleId = 1;
+    private const int Ls1910BibleId = 6;
+    private const int RsbBibleId = 9;
+    private const int GltBibleId = 10;
 
     [Theory]
-    [InlineData(_bsbBibleId, 1001001001, true,
+    [InlineData(BsbBibleId, 1001001001, true,
         "the BSB contains the given verse")]
-    [InlineData(_bsbBibleId, 1041017021, false,
+    [InlineData(BsbBibleId, 1041017021, false,
         "the BSB does not have the given verse")]
-    [InlineData(_bsbBibleId, 1072001001, false,
+    [InlineData(BsbBibleId, 1072001001, false,
         "the BSB does not have the given book")]
-    [InlineData(_engVersificationSchemeBibleId, 1001001001, true,
+    [InlineData(EngVersificationSchemeBibleId, 1001001001, true,
         "ENG contains the given verse")]
-    [InlineData(_engVersificationSchemeBibleId, 1041017021, true,
+    [InlineData(EngVersificationSchemeBibleId, 1041017021, true,
         "the BSB does not have the given verse")]
-    [InlineData(_engVersificationSchemeBibleId, 1072001001, true,
+    [InlineData(EngVersificationSchemeBibleId, 1072001001, true,
         "ENG contains the given verse")]
     public async Task IsValidVerseId_ValidArguments_Success(
         int bibleId,
@@ -42,15 +42,15 @@ public sealed class VersificationUtilitiesTests(App _app) : TestBase<App>
     }
 
     [Theory]
-    [InlineData(_bsbBibleId, 1001001001, 1001001001, new[] { 1001001001 },
+    [InlineData(BsbBibleId, 1001001001, 1001001001, new[] { 1001001001 },
         "a range of a single verse should return that verse")]
-    [InlineData(_bsbBibleId, 1001001001, 1001001003, new[] { 1001001001, 1001001002, 1001001003 },
+    [InlineData(BsbBibleId, 1001001001, 1001001003, new[] { 1001001001, 1001001002, 1001001003 },
         "a simple range within a single chapter should be correctly returned")]
-    [InlineData(_bsbBibleId, 1041017020, 1041017022, new[] { 1041017020, 1041017022 },
+    [InlineData(BsbBibleId, 1041017020, 1041017022, new[] { 1041017020, 1041017022 },
         "a range should not include excluded verse IDs for the given Bible")]
-    [InlineData(_bsbBibleId, 1041017027, 1041018002, new[] { 1041017027, 1041018001, 1041018002 },
+    [InlineData(BsbBibleId, 1041017027, 1041018002, new[] { 1041017027, 1041018001, 1041018002 },
         "a range spanning two chapters should be correctly returned")]
-    [InlineData(_bsbBibleId, 1041028019, 1042001002, new[] { 1041028019, 1041028020, 1042001001, 1042001002 },
+    [InlineData(BsbBibleId, 1041028019, 1042001002, new[] { 1041028019, 1041028020, 1042001001, 1042001002 },
         "a range spanning two books should be correctly returned")]
     public async Task ExpandVerseIdRangeAsync_ValidArguments_Success(
         int bibleId,
@@ -70,25 +70,25 @@ public sealed class VersificationUtilitiesTests(App _app) : TestBase<App>
     }
 
     [Theory]
-    [InlineData(_bsbBibleId, _bsbBibleId, 1001001001, 1001001001,
+    [InlineData(BsbBibleId, BsbBibleId, 1001001001, 1001001001,
         "the source and target Bibles are the same (with versification mappings) so the source and target verse IDs should be the same")]
-    [InlineData(_engVersificationSchemeBibleId, _bsbBibleId, 1041017021, null,
+    [InlineData(EngVersificationSchemeBibleId, BsbBibleId, 1041017021, null,
         "the target (BSB) does not have the given verse")]
-    [InlineData(_bsbBibleId, _rsbBibleId, 1001003001, 1001003003,
+    [InlineData(BsbBibleId, RsbBibleId, 1001003001, 1001003003,
         "the RSB has a different versification than the BSB for the given verse")]
-    [InlineData(_rsbBibleId, _bsbBibleId, 1001003003, 1001003001,
+    [InlineData(RsbBibleId, BsbBibleId, 1001003003, 1001003001,
         "the RSB has a different versification than the BSB for the given verse")]
-    [InlineData(_bsbBibleId, _rsbBibleId, 1016007067, 1016007068,
+    [InlineData(BsbBibleId, RsbBibleId, 1016007067, 1016007068,
         "the RSB has a different versification than the BSB for the given verse with an ignored optional base verse part")]
-    [InlineData(_rsbBibleId, _bsbBibleId, 1016007068, 1016007067,
+    [InlineData(RsbBibleId, BsbBibleId, 1016007068, 1016007067,
         "the RSB has a different versification than the BSB for the given verse with a non-matching base verse part")]
-    [InlineData(_engVersificationSchemeBibleId, _ls1910BibleId, 1004026001, 1004026001,
+    [InlineData(EngVersificationSchemeBibleId, Ls1910BibleId, 1004026001, 1004026001,
         "the ENG and LS1910 have the same versification with matching base verse parts")]
-    [InlineData(_ls1910BibleId, _engVersificationSchemeBibleId, 1004026001, 1004026001,
+    [InlineData(Ls1910BibleId, EngVersificationSchemeBibleId, 1004026001, 1004026001,
         "the ENG and LS1910 have the same versification with matching base verse parts")]
-    [InlineData(_bsbBibleId, _engVersificationSchemeBibleId, 1004026001, 1004026001,
+    [InlineData(BsbBibleId, EngVersificationSchemeBibleId, 1004026001, 1004026001,
         "the ENG has a different versification than the BSB, the Bible verse part of 'b' is not loaded, and the base verse part of 'b' is ignored which results in mapping back to the same verse ID")]
-    [InlineData(_engVersificationSchemeBibleId, _bsbBibleId, 1004026001, 1004026001,
+    [InlineData(EngVersificationSchemeBibleId, BsbBibleId, 1004026001, 1004026001,
         "the ENG has a different versification than the BSB and the base verse part of 'b' is ignored which results in mapping to the same verse ID")]
     public async Task ConvertVersification_ValidArguments_Success(
         int sourceBibleId,
@@ -111,10 +111,10 @@ public sealed class VersificationUtilitiesTests(App _app) : TestBase<App>
     public async Task ConvertVersificationRange_ValidArgumentsWithExclusionInSourceAndTarget_Success()
     {
         var results = await VersificationUtilities.ConvertVersificationRangeAsync(
-            sourceBibleId: _bsbBibleId,
+            sourceBibleId: BsbBibleId,
             1046016023,
             1046016027,
-            targetBibleId: _gltBibleId,
+            targetBibleId: GltBibleId,
             _versificationService,
             CancellationToken.None);
 


### PR DESCRIPTION
Changes:
* Use `PascalCase` for contants, both `private` and `public`.
* Use `s_camelCase` for `static` and `static readonly` `private` fields.
* Use `_` for `private` fields.
* Require an empty line after statement blocks.
* Delete configuration that I accidentally duplicated.
* Update ReSharper wrapping settings for auto-format to put things on their own line.
