### PR TITLE
Bib 849 update assign resources modal

### DIFF
--- a/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
@@ -67,7 +67,8 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
                 ProjectEntity = rc.ProjectResourceContents.FirstOrDefault(prc => prc.ResourceContentId == request.Id) == null
                     ? null
                     : rc.ProjectResourceContents.First(prc => prc.ResourceContentId == request.Id).Project,
-                HasPublishedVersion = rc.Versions.Any(rcv => rcv.IsPublished)
+                HasPublishedVersion = rc.Versions.Any(rcv => rcv.IsPublished),
+                HasAdditionalReviewer = rc.Versions.Any(rcv => rcv.AssignedReviewerUser != null)
             })
             .AsSplitQuery()
             .FirstOrDefaultAsync(ct);

--- a/src/Aquifer.API/Endpoints/Resources/Content/Get/Response.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Get/Response.cs
@@ -46,6 +46,7 @@ public class Response
             };
 
     public bool HasUnresolvedCommentThreads => CommentThreads?.Threads.Any(t => !t.Resolved) ?? false;
+    public bool HasAdditionalReviewer { get; set; }
     public CommentThreadsResponse? CommentThreads { get; set; }
 
     [JsonIgnore]

--- a/src/Aquifer.API/Endpoints/Resources/Content/SendForCompanyReview/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/SendForCompanyReview/Endpoint.cs
@@ -26,7 +26,8 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
         var contentIds = request.ContentId is not null ? [request.ContentId.Value] : request.ContentIds!;
         List<ResourceContentStatus> allowedStatuses =
         [
-            ResourceContentStatus.AquiferizeEditorReview, ResourceContentStatus.TranslationEditorReview
+            ResourceContentStatus.AquiferizeEditorReview, ResourceContentStatus.TranslationEditorReview,
+            ResourceContentStatus.AquiferizeCompanyReview, ResourceContentStatus.TranslationCompanyReview
         ];
 
         var draftVersions = await dbContext.ResourceContentVersions
@@ -56,18 +57,25 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
                 draftVersion.ResourceContent.Status,
                 ct);
 
-            var reviewPendingStatus = draftVersion.ResourceContent.Status == ResourceContentStatus.TranslationEditorReview
-                ? ResourceContentStatus.TranslationCompanyReview
-                : ResourceContentStatus.AquiferizeCompanyReview;
+            var reviewPendingStatus = draftVersion.ResourceContent.Status == ResourceContentStatus.AquiferizeEditorReview
+                ? ResourceContentStatus.AquiferizeCompanyReview
+                : draftVersion.ResourceContent.Status == ResourceContentStatus.TranslationEditorReview
+                    ? ResourceContentStatus.TranslationCompanyReview
+                    : draftVersion.ResourceContent.Status;
 
-            draftVersion.ResourceContent.Status = reviewPendingStatus;
+            if (draftVersion.ResourceContent.Status != reviewPendingStatus)
+            {
+                draftVersion.ResourceContent.Status = reviewPendingStatus;
+                await historyService.AddStatusHistoryAsync(draftVersion, reviewPendingStatus, user.Id, ct);
+            }
+
             await SetAssignedUserIdAsync(user,
                 draftVersion.ResourceContent.ProjectResourceContents.FirstOrDefault(x => x.Project.ActualPublishDate == null)?.Project,
                 managerIds,
                 draftVersion);
 
             await historyService.AddAssignedUserHistoryAsync(draftVersion, draftVersion.AssignedUserId, user.Id, ct);
-            await historyService.AddStatusHistoryAsync(draftVersion, reviewPendingStatus, user.Id, ct);
+
         }
 
         await dbContext.SaveChangesAsync(ct);


### PR DESCRIPTION
### Two changes:
1. Add a flag `HasAdditionalReviewer` that returns true if any of the drafts has an additional reviewer assigned. This is to help the frontend with whether or not to show "Send to Review" or "Send to Manager"
2. We need a way to advance the user assignment of content already in `Company Review` that an Editor is assigned to. When the Editor hits "Send to Review" in that status, it should be send to the Default Reviewer or Manager, following the same logical flow of the `send-for-company-reviewer` endpoint, only keeping the status. To do that, I've allowed the CompanyReview status into that endpoint, and added a check for the current status so it could determine whether it needs to advance while keeping the logic for determining which manager to assign to.