### PR TITLE
Update CI/CD to also deploy the Public API to India.

### DIFF
--- a/.github/actions/deploy-to-env/action.yml
+++ b/.github/actions/deploy-to-env/action.yml
@@ -12,8 +12,8 @@ inputs:
         description: Azure Resource Group
         required: true
     connection-url:
-        description: DB connection URL
-        required: true
+        description: DB connection URL (required for running migration scripts; leave empty if no migrations are needed)
+        required: false
     web-app-name:
         description: Azure Web App name
         required: true
@@ -68,9 +68,11 @@ runs:
               tenant-id: ${{ inputs.azure-tenant-id }}
               subscription-id: ${{ inputs.azure-subscription-id }}
         - name: Make migration script executable
+          if: ${{ inputs.connection-url != '' }}
           run: chmod +x ./build/Migrate
           shell: bash
         - name: Run migrations
+          if: ${{ inputs.connection-url != '' }}
           run: ./build/Migrate --connection '${{ inputs.connection-url }}'
           shell: bash
         - name: Deploy to staging slot if not dev
@@ -105,4 +107,3 @@ runs:
               SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
               GITHUB_TOKEN: ${{ inputs.github-token }}
               LINEAR_API_KEY: ${{ inputs.linear-api-key }}
-

--- a/.github/workflows/post-merge-internal-api.yml
+++ b/.github/workflows/post-merge-internal-api.yml
@@ -129,7 +129,7 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   linear-api-key: ${{ secrets.LINEAR_API_KEY }}
                   slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-                  service-name: Internal API
+                  service-name: Internal API (East US)
 
     deploy_internal_api_to_prod:
         if: needs.check_should_deploy.outputs.should_deploy == 'true'
@@ -160,7 +160,7 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   linear-api-key: ${{ secrets.LINEAR_API_KEY }}
                   slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-                  service-name: Internal API
+                  service-name: Internal API (East US)
             - uses: BiblioNexusStudio/github-actions/delete-hotfix-branch@master
               with:
                   current_branch: ${{ github.ref_name }}

--- a/.github/workflows/post-merge-jobs.yml
+++ b/.github/workflows/post-merge-jobs.yml
@@ -93,7 +93,7 @@ jobs:
                   color: warning
                   environment: dev-qa-jobs
                   default_branch_name: master
-                  service_name: Jobs
+                  service_name: Jobs (East US)
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -191,7 +191,7 @@ jobs:
                   color: ${{ job.status == 'failure' && 'danger' || 'good' }}
                   environment: prod-jobs
                   default_branch_name: master
-                  service_name: Jobs
+                  service_name: Jobs (East US)
                   message_id: ${{ steps.slack-notify.outputs.message_id }}
               env:
                     SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/post-merge-public-api.yml
+++ b/.github/workflows/post-merge-public-api.yml
@@ -101,6 +101,7 @@ jobs:
                   azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
                   azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+                  service-name: Public API (East US)
 
     deploy_public_api_to_qa:
         if: needs.check_should_deploy.outputs.should_deploy == 'true'
@@ -129,11 +130,10 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   linear-api-key: ${{ secrets.LINEAR_API_KEY }}
                   slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-                  service-name: Public API
 
-    deploy_public_api_to_prod:
+    deploy_public_api_to_prod_east_us:
         if: needs.check_should_deploy.outputs.should_deploy == 'true'
-        name: Deploy Public API to prod
+        name: Deploy Public API to prod (East US)
         runs-on: ubuntu-latest
         needs:
             - build
@@ -160,7 +160,53 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   linear-api-key: ${{ secrets.LINEAR_API_KEY }}
                   slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-                  service-name: Public API
+                  service-name: Public API (East US)
+
+    deploy_public_api_to_prod_central_india:
+        if: needs.check_should_deploy.outputs.should_deploy == 'true'
+        name: Deploy Public API to prod (Central India)
+        runs-on: ubuntu-latest
+        needs:
+            - build
+            - check_should_deploy
+            - deploy_public_api_to_prod_east_us
+        environment:
+            name: prod-public
+            url: ${{ vars.URL_PROD }}
+        steps:
+            - name: Checkout source code
+              uses: actions/checkout@v4.1.7
+              with:
+                  ref: ${{ github.event.pull_request.head.sha }}
+            - uses: ./.github/actions/deploy-to-env
+              id: deploy
+              with:
+                  environment: prod
+                  full-environment: prod-public
+                  connection-url: ${{ vars.DB_CONNECTION_URL_PROD }}
+                  web-app-name: ${{ vars.AZURE_WEB_APP_NAME_PUBLIC_PROD_INDIA }}
+                  resource-group: ${{ vars.AZURE_RESOURCE_GROUP_PROD_INDIA }}
+                  azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+                  azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+                  azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  linear-api-key: ${{ secrets.LINEAR_API_KEY }}
+                  slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  service-name: Public API (Central India)
+
+    delete_hotfix_branch:
+        if: needs.check_should_deploy.outputs.should_deploy == 'true'
+        name: Delete Hotfix Branch
+        runs-on: ubuntu-latest
+        needs:
+            - build
+            - check_should_deploy
+            - deploy_public_api_to_prod_east_us
+            - deploy_public_api_to_prod_central_india
+        environment:
+            name: prod-public
+            url: ${{ vars.URL_PROD }}
+        steps:
             - uses: BiblioNexusStudio/github-actions/delete-hotfix-branch@master
               with:
                   current_branch: ${{ github.ref_name }}

--- a/Aquifer.sln
+++ b/Aquifer.sln
@@ -59,6 +59,28 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aquifer.API.IntegrationTest
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aquifer.Common.IntegrationTests", "tests\Aquifer.Common.IntegrationTests\Aquifer.Common.IntegrationTests.csproj", "{73F5F966-C27E-47AB-8B02-7A4B48C374EC}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+	ProjectSection(SolutionItems) = preProject
+		.github\CODEOWNERS = .github\CODEOWNERS
+		.github\settings.yml = .github\settings.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "actions", "actions", "{61FDF919-192A-435C-8A61-2F7E97AC6454}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{7F69D32F-5B88-4B95-8AB7-9A8F72A36132}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\create-hotfix.yml = .github\workflows\create-hotfix.yml
+		.github\workflows\post-merge-internal-api.yml = .github\workflows\post-merge-internal-api.yml
+		.github\workflows\post-merge-jobs.yml = .github\workflows\post-merge-jobs.yml
+		.github\workflows\post-merge-public-api.yml = .github\workflows\post-merge-public-api.yml
+		.github\workflows\pre-merge.yml = .github\workflows\pre-merge.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "deploy-to-env", "deploy-to-env", "{92256CE3-C3B2-4A50-85B4-8D0564FB3E11}"
+	ProjectSection(SolutionItems) = preProject
+		.github\actions\deploy-to-env\action.yml = .github\actions\deploy-to-env\action.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -153,6 +175,10 @@ Global
 		{5205B15E-7521-40A7-8C66-19C231839E4F} = {51DD9DE3-DA20-4C0B-82D6-029445F6BD42}
 		{EFCB9F65-BC0A-4AB6-9A42-19A0BD15ED30} = {51DD9DE3-DA20-4C0B-82D6-029445F6BD42}
 		{73F5F966-C27E-47AB-8B02-7A4B48C374EC} = {51DD9DE3-DA20-4C0B-82D6-029445F6BD42}
+		{02EA681E-C7D8-13C7-8484-4AC65E1B71E8} = {180F25DB-77E1-47DA-B532-B40736EBFD15}
+		{61FDF919-192A-435C-8A61-2F7E97AC6454} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{7F69D32F-5B88-4B95-8AB7-9A8F72A36132} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{92256CE3-C3B2-4A50-85B4-8D0564FB3E11} = {61FDF919-192A-435C-8A61-2F7E97AC6454}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8E32492B-EA66-40E4-A7A8-67E4ABA14A53}


### PR DESCRIPTION
With this implementation we will deploy first to East US and then after that succeeds deploy to Central India.  If steps fail it should be possible to re-run each regional deployment independently.  I also added the region name to all deployment Slack notifications for clarity.

Future improvements:
* We could deploy to all regions in parallel if we move the migration script execution into a separate job that runs before deployment.
* [This commit](https://github.com/BiblioNexusStudio/aquifer-server/commit/b946fb00a6d5bb9b8d989bb506c9556e00ca90e5) added a bunch of redundant Git checkout steps.  I'm not sure why (possibly for Slack notifications?).  We could speed up deployments by removing that step.