### PR TITLE
Use channels to publish track resource content requests in background.

### DIFF
--- a/src/Aquifer.API/Services/QueueMessagePublisherServices.cs
+++ b/src/Aquifer.API/Services/QueueMessagePublisherServices.cs
@@ -1,3 +1,4 @@
+using Aquifer.Common.Extensions;
 using Aquifer.Common.Messages.Publishers;
 
 namespace Aquifer.API.Services;
@@ -7,7 +8,7 @@ public static class QueueMessagePublisherServices
     public static IServiceCollection AddQueueMessagePublisherServices(this IServiceCollection services)
     {
         services
-            .AddSingleton<IResourceContentRequestTrackingMessagePublisher, ResourceContentRequestTrackingMessagePublisher>()
+            .AddTrackResourceContentRequestServices()
             .AddSingleton<INotificationMessagePublisher, NotificationMessagePublisher>()
             .AddSingleton<ITranslationMessagePublisher, TranslationMessagePublisher>()
             .AddSingleton<IResourceContentVersionSimilarityMessagePublisher, ResourceContentVersionSimilarityMessagePublisher>();

--- a/src/Aquifer.Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Aquifer.Common/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Channels;
+using Aquifer.Common.Messages.Models;
+using Aquifer.Common.Messages.Publishers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aquifer.Common.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddTrackResourceContentRequestServices(this IServiceCollection services)
+    {
+        return services
+            .AddSingleton<IResourceContentRequestTrackingMessagePublisher, ResourceContentRequestTrackingMessagePublisher>()
+            .AddHostedService<ResourceContentRequestTrackingMessagePublisher.TrackResourceContentRequestBackgroundService>()
+            .AddSingleton(
+                _ => Channel.CreateUnbounded<TrackResourceContentRequestMessage>(
+                    new UnboundedChannelOptions
+                    {
+                        AllowSynchronousContinuations = false,
+                        SingleReader = false,
+                        SingleWriter = false,
+                    }));
+    }
+}

--- a/src/Aquifer.Common/Messages/Publishers/ResourceContentRequestTrackingMessagePublisher.cs
+++ b/src/Aquifer.Common/Messages/Publishers/ResourceContentRequestTrackingMessagePublisher.cs
@@ -1,6 +1,8 @@
-﻿using Aquifer.Common.Messages.Models;
+﻿using System.Threading.Channels;
+using Aquifer.Common.Messages.Models;
 using Aquifer.Common.Services.Caching;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
 
 namespace Aquifer.Common.Messages.Publishers;
 
@@ -25,15 +27,21 @@ public interface IResourceContentRequestTrackingMessagePublisher
         CancellationToken cancellationToken);
 }
 
-public class ResourceContentRequestTrackingMessagePublisher(IQueueClientFactory _queueClientFactory)
+/// <summary>
+/// This class uses channels to write messages to a background service that will then publish the messages to a queue.
+/// This allows the caller to publish messages without waiting for the distributed queue request/response, but it is unreliable because
+/// if the API unexpectedly ends/crashes then the queue publish action may not be sent. Therefore, this strategy should only be used for
+/// queues where it is acceptable to drop messages on rare occasions.
+/// </summary>
+public class ResourceContentRequestTrackingMessagePublisher(
+    Channel<TrackResourceContentRequestMessage> _channel)
     : IResourceContentRequestTrackingMessagePublisher
 {
     public async Task PublishTrackResourceContentRequestMessageAsync(
         TrackResourceContentRequestMessage message,
         CancellationToken ct)
     {
-        var queueClient = await _queueClientFactory.GetQueueClientAsync(Queues.TrackResourceContentRequest, ct);
-        await queueClient.SendMessageAsync(message, cancellationToken: ct);
+        await _channel.Writer.WriteAsync(message, ct);
     }
 
     public async Task PublishTrackResourceContentRequestMessageAsync(
@@ -91,5 +99,28 @@ public class ResourceContentRequestTrackingMessagePublisher(IQueueClientFactory 
         }
 
         return httpContext.Connection.RemoteIpAddress?.ToString() ?? "Unknown";
+    }
+
+    public sealed class TrackResourceContentRequestBackgroundService(
+        Channel<TrackResourceContentRequestMessage> _channel,
+        IQueueClientFactory _queueClientFactory)
+        : BackgroundService
+    {
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (await _channel.Reader.WaitToReadAsync(stoppingToken))
+            {
+                var message = await _channel.Reader.ReadAsync(stoppingToken);
+                await PublishTrackResourceContentRequestMessageCoreAsync(message, stoppingToken);
+            }
+        }
+
+        private async Task PublishTrackResourceContentRequestMessageCoreAsync(
+            TrackResourceContentRequestMessage message,
+            CancellationToken ct)
+        {
+            var queueClient = await _queueClientFactory.GetQueueClientAsync(Queues.TrackResourceContentRequest, ct);
+            await queueClient.SendMessageAsync(message, cancellationToken: ct);
+        }
     }
 }

--- a/src/Aquifer.Public.API/Program.cs
+++ b/src/Aquifer.Public.API/Program.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Aquifer.Common.Extensions;
 using Aquifer.Common.Messages;
-using Aquifer.Common.Messages.Publishers;
 using Aquifer.Common.Middleware;
 using Aquifer.Common.Services;
 using Aquifer.Data;
@@ -31,7 +31,7 @@ builder.Services
     .AddMemoryCache()
     .AddCachingServices()
     .AddQueueServices(configuration.ConnectionStrings.AzureStorageAccount)
-    .AddSingleton<IResourceContentRequestTrackingMessagePublisher, ResourceContentRequestTrackingMessagePublisher>()
+    .AddTrackResourceContentRequestServices()
     .AddSingleton<ITelemetryInitializer, RequestTelemetryInitializer>()
     .AddAzureClient(builder.Environment.IsDevelopment())
     .AddSwaggerDocumentSettings()


### PR DESCRIPTION
I confirmed locally that the response returns before the channel processing runs.