### PR TITLE
Remove publish profile from Jobs deployment.

### DIFF
--- a/.github/actions/deploy-to-env/action.yml
+++ b/.github/actions/deploy-to-env/action.yml
@@ -57,12 +57,12 @@ runs:
               SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
               GITHUB_TOKEN: ${{ inputs.github-token }}
               LINEAR_API_KEY: ${{ inputs.linear-api-key }}
-        - uses: actions/download-artifact@v4.1.8
+        - uses: actions/download-artifact@v4.1.9
           with:
               name: build
               path: build
         - name: Login to Azure
-          uses: azure/login@v2.1.1
+          uses: azure/login@v2.2.0
           with:
               creds: ${{ secrets.AZURE_CREDENTIALS }}
         - name: Make migration script executable
@@ -75,7 +75,7 @@ runs:
           shell: bash
         - name: Deploy to staging slot if not dev
           if: inputs.environment != 'dev'
-          uses: azure/webapps-deploy@v3.0.1
+          uses: azure/webapps-deploy@v3.0.2
           with:
               app-name: ${{ inputs.web-app-name }}
               slot-name: staging
@@ -86,7 +86,7 @@ runs:
           shell: bash
         - name: Deploy directly to production if dev
           if: inputs.environment == 'dev'
-          uses: azure/webapps-deploy@v3.0.1
+          uses: azure/webapps-deploy@v3.0.2
           with:
               app-name: ${{ inputs.web-app-name }}
               package: ./build/Build.zip

--- a/.github/workflows/post-merge-internal-api.yml
+++ b/.github/workflows/post-merge-internal-api.yml
@@ -56,9 +56,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4.1.7
+              uses: actions/checkout@v4.2.2
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4.0.1
+              uses: actions/setup-dotnet@v4.3.0
               with:
                   global-json-file: "./global.json"
             - name: Install NuGet packages (linux)
@@ -74,7 +74,7 @@ jobs:
             - name: Bundle migrations
               run: dotnet ef migrations bundle --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --context AquiferDbContext --output build/Migrate --self-contained
             - name: Publish artifact
-              uses: actions/upload-artifact@v4.4.0
+              uses: actions/upload-artifact@v4.6.1
               with:
                   include-hidden-files: true
                   name: build
@@ -92,7 +92,7 @@ jobs:
             url: ${{ vars.URL_DEV }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4.1.7
+              uses: actions/checkout@v4.2.2
             - uses: ./.github/actions/deploy-to-env
               id: deploy
               with:
@@ -116,7 +116,7 @@ jobs:
             url: ${{ vars.URL_QA }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4.1.7
+              uses: actions/checkout@v4.2.2
             - uses: ./.github/actions/deploy-to-env
               id: deploy
               with:
@@ -145,7 +145,7 @@ jobs:
             url: ${{ vars.URL_PROD }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4.1.7
+              uses: actions/checkout@v4.2.2
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
             - uses: ./.github/actions/deploy-to-env

--- a/.github/workflows/post-merge-jobs.yml
+++ b/.github/workflows/post-merge-jobs.yml
@@ -53,9 +53,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4.1.7
+              uses: actions/checkout@v4.2.2
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4.0.1
+              uses: actions/setup-dotnet@v4.3.0
               with:
                   global-json-file: "./global.json"
             - name: Restore .net tools
@@ -86,7 +86,7 @@ jobs:
                 rm ./temp/ffmpeg.zip
               shell: bash
             - name: Publish artifact
-              uses: actions/upload-artifact@v4.4.0
+              uses: actions/upload-artifact@v4.6.1
               with:
                   include-hidden-files: true
                   name: build
@@ -116,12 +116,12 @@ jobs:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-            - uses: actions/download-artifact@v4.1.8
+            - uses: actions/download-artifact@v4.1.9
               with:
                   name: build
                   path: build
             - name: Login to Azure
-              uses: azure/login@v2.1.1
+              uses: azure/login@v2.2.0
               with:
                   creds: ${{ secrets.AZURE_CREDENTIALS }}
             - name: Make migration script executable
@@ -135,7 +135,6 @@ jobs:
               with:
                   app-name: ${{ vars.AZURE_FUNCTION_APP_NAME_DEV_QA }}
                   package: build
-                  publish-profile: ${{ secrets.AZURE_FUNCTION_APP_PUBLISH_PROFILE_DEV_QA }}
             - name: Notify Slack deploy status
               if: ${{ !cancelled()  }}
               uses: BiblioNexusStudio/github-action-slack-notify-build@main
@@ -176,16 +175,14 @@ jobs:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-            - uses: actions/download-artifact@v4.1.8
+            - uses: actions/download-artifact@v4.1.9
               with:
                   name: build
                   path: build
             - name: Login to Azure
-              uses: azure/login@v2.1.1
+              uses: azure/login@v2.2.0
               with:
-                  client-id: ${{ secrets.AZURE_CLIENT_ID }}
-                  tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-                  subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+                  creds: ${{ secrets.AZURE_CREDENTIALS }}
             - name: Make migration script executable
               run: chmod +x ./build/Migrate
               shell: bash
@@ -197,7 +194,6 @@ jobs:
               with:
                   app-name: ${{ vars.AZURE_FUNCTION_APP_NAME_PROD }}
                   package: build
-                  publish-profile: ${{ secrets.AZURE_FUNCTION_APP_PUBLISH_PROFILE_PROD }}
             - name: Notify Slack deploy status
               if: ${{ !cancelled()  }}
               uses: BiblioNexusStudio/github-action-slack-notify-build@main

--- a/.github/workflows/post-merge-public-api.yml
+++ b/.github/workflows/post-merge-public-api.yml
@@ -56,9 +56,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4.1.7
+              uses: actions/checkout@v4.2.2
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4.0.1
+              uses: actions/setup-dotnet@v4.3.0
               with:
                   global-json-file: "./global.json"
             - name: Install NuGet packages (linux)
@@ -74,7 +74,7 @@ jobs:
             - name: Bundle migrations
               run: dotnet ef migrations bundle --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --context AquiferDbContext --output build/Migrate --self-contained
             - name: Publish artifact
-              uses: actions/upload-artifact@v4.4.0
+              uses: actions/upload-artifact@v4.6.1
               with:
                   include-hidden-files: true
                   name: build
@@ -92,7 +92,7 @@ jobs:
             url: ${{ vars.URL_DEV }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4.1.7
+              uses: actions/checkout@v4.2.2
             - uses: ./.github/actions/deploy-to-env
               id: deploy
               with:
@@ -116,7 +116,7 @@ jobs:
             url: ${{ vars.URL_QA }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4.1.7
+              uses: actions/checkout@v4.2.2
             - uses: ./.github/actions/deploy-to-env
               id: deploy
               with:
@@ -145,7 +145,7 @@ jobs:
             url: ${{ vars.URL_PROD }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4.1.7
+              uses: actions/checkout@v4.2.2
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
             - uses: ./.github/actions/deploy-to-env
@@ -176,7 +176,7 @@ jobs:
             url: ${{ vars.URL_PROD }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4.1.7
+              uses: actions/checkout@v4.2.2
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
             - uses: ./.github/actions/deploy-to-env

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -16,17 +16,17 @@ jobs:
             name: qa-tests
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v4.1.7
+              uses: actions/checkout@v4.2.2
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4.0.1
+              uses: actions/setup-dotnet@v4.3.0
               with:
                   global-json-file: "./global.json"
             - name: Build
               run: dotnet build --no-incremental -m:1 --configuration Release /p:WarningsAsErrors=true /warnaserror
             - name: Login to Azure
-              uses: azure/login@v2.1.1
+              uses: azure/login@v2.2.0
               with:
                   creds: ${{ secrets.AZURE_CREDENTIALS }}
             - name: Test


### PR DESCRIPTION
1. Update GitHub Actions action versions to latest for all third-party actions.
2. Stop passing a publish profile for Jobs deployments (per https://github.com/Azure/functions-action?tab=readme-ov-file#use-an-azure-service-principal-not-recommeded).