### PR TITLE
Don't run pre-merge build and test job for Draft PRs.

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -2,6 +2,7 @@ name: Pre-merge
 
 on:
     pull_request:
+        types: [opened, synchronize, reopened, ready_for_review]
         branches:
             - '**'
 
@@ -10,6 +11,7 @@ permissions:
 
 jobs:
     build_and_test:
+        if: ${{ !github.event.pull_request.draft }}
         name: Build and test
         runs-on: ubuntu-latest
         environment:


### PR DESCRIPTION
The `Pre-merge / Build and test (pull_request)` job will no longer run for Draft PRs but is still required for merging.  Clicking "Ready for review" will result in the checks running.

Example:
![image](https://github.com/user-attachments/assets/fe0f5d8c-4db5-4174-8554-f54c4bd1d6ca)
