### PR TITLE
Pass queue name during queue client construction.

### DIFF
--- a/src/Aquifer.Common/Messages/QueueClientFactory.cs
+++ b/src/Aquifer.Common/Messages/QueueClientFactory.cs
@@ -55,9 +55,11 @@ public sealed class QueueClientFactory(AzureStorageAccountOptions _azureStorageA
     {
         var client = string.IsNullOrEmpty(_azureStorageAccountOptions.ConnectionStringOverride)
             ? new QueueClient(
-                _azureStorageAccountOptions.QueueEndpoint
-                    ?? throw new InvalidOperationException(
-                        $"The \"{nameof(AzureStorageAccountOptions.QueueEndpoint)}\" setting must be provided when \"{nameof(AzureStorageAccountOptions.ConnectionStringOverride)}\" is empty."),
+                new Uri(
+                    _azureStorageAccountOptions.QueueEndpoint
+                        ?? throw new InvalidOperationException(
+                            $"The \"{nameof(AzureStorageAccountOptions.QueueEndpoint)}\" setting must be provided when \"{nameof(AzureStorageAccountOptions.ConnectionStringOverride)}\" is empty."),
+                    queueName),
                 _azureClientService.GetCredential(),
                 s_clientOptions)
             : new QueueClient(


### PR DESCRIPTION
Fixes [this regression](https://github.com/BiblioNexusStudio/aquifer-server/commit/1d4cbc3762804c9f95aad962913b6e3ad7a1d44d#diff-4d5ebc059058589b8a9144dc737b2795d237c8dcdf6edd5592ce138fcd0be8a9L57).