### PR TITLE
Add route to clear caches to Aquifer.API and Aquifer.PublicAPI.

### DIFF
--- a/src/Aquifer.API/Endpoints/Admin/Caches/Clear/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Admin/Caches/Clear/Endpoint.cs
@@ -1,0 +1,37 @@
+using Aquifer.API.Helpers;
+using FastEndpoints;
+using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Aquifer.API.Endpoints.Admin.Caches.Clear;
+
+public class Endpoint(IMemoryCache _memoryCache, IOutputCacheStore _outputCacheStore) : Endpoint<Request>
+{
+    public override void Configure()
+    {
+        Post("/admin/caches/clear");
+        AllowAnonymous();
+    }
+
+    public override async Task HandleAsync(Request request, CancellationToken ct)
+    {
+        if (request.ShouldClearMemoryCache)
+        {
+            // The IMemoryCache interface is normally injected into constructors, but it doesn't support clearing the entire cache.
+            if (_memoryCache is not MemoryCache memoryCache)
+            {
+                throw new InvalidOperationException($"The {nameof(IMemoryCache)} implementation is not {nameof(MemoryCache)}.");
+            }
+
+            memoryCache.Clear();
+        }
+
+        if (request.ShouldClearOutputCache)
+        {
+            // if any other output cache tags are added then they should also be cleared here
+            await _outputCacheStore.EvictByTagAsync(EndpointHelpers.AnonymousOutputCacheTag, ct);
+        }
+
+        await SendNoContentAsync(ct);
+    }
+}

--- a/src/Aquifer.API/Endpoints/Admin/Caches/Clear/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Admin/Caches/Clear/Endpoint.cs
@@ -1,11 +1,14 @@
 using Aquifer.API.Helpers;
+using Aquifer.Common.Services.Caching;
+using Aquifer.Data.Entities;
 using FastEndpoints;
 using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Aquifer.API.Endpoints.Admin.Caches.Clear;
 
-public class Endpoint(IMemoryCache _memoryCache, IOutputCacheStore _outputCacheStore) : Endpoint<Request>
+public class Endpoint(ICachingApiKeyService _cachingApiKeyService, IMemoryCache _memoryCache, IOutputCacheStore _outputCacheStore)
+    : Endpoint<Request>
 {
     public override void Configure()
     {
@@ -15,6 +18,13 @@ public class Endpoint(IMemoryCache _memoryCache, IOutputCacheStore _outputCacheS
 
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
+        var apiKey = _cachingApiKeyService.CurrentApiKey;
+        if (!apiKey.HasScope(ApiKeyScope.Admin))
+        {
+            await SendUnauthorizedAsync(ct);
+            return;
+        }
+
         if (request.ShouldClearMemoryCache)
         {
             // The IMemoryCache interface is normally injected into constructors, but it doesn't support clearing the entire cache.

--- a/src/Aquifer.API/Endpoints/Admin/Caches/Clear/Request.cs
+++ b/src/Aquifer.API/Endpoints/Admin/Caches/Clear/Request.cs
@@ -1,0 +1,7 @@
+namespace Aquifer.API.Endpoints.Admin.Caches.Clear;
+
+public sealed class Request
+{
+    public bool ShouldClearMemoryCache { get; set; }
+    public bool ShouldClearOutputCache { get; set; }
+}

--- a/src/Aquifer.API/Endpoints/Admin/Caches/Clear/Validator.cs
+++ b/src/Aquifer.API/Endpoints/Admin/Caches/Clear/Validator.cs
@@ -1,0 +1,14 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Aquifer.API.Endpoints.Admin.Caches.Clear;
+
+public class Validator : Validator<Request>
+{
+    public Validator()
+    {
+        RuleFor(r => r)
+            .Must(r => r.ShouldClearMemoryCache || r.ShouldClearOutputCache)
+            .WithMessage("At least one argument is required.");
+    }
+}

--- a/src/Aquifer.API/Endpoints/Marketing/ParentResourceStatuses/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Marketing/ParentResourceStatuses/List/Endpoint.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Aquifer.API.Endpoints.Marketing.ParentResourceStatuses.List;
 
-public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IEnumerable<Response>>
+public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IReadOnlyList<Response>>
 {
     private const int EnglishLanguageId = 1;
 
@@ -77,7 +77,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, IEnumerabl
             Status = ParentResourceStatusHelpers.GetStatus(x.TotalResources, x.TotalLanguageResources, x.LastPublished)
         });
 
-        Response = selectedBibles.Concat(selectedRows);
+        Response = selectedBibles.Concat(selectedRows).ToList();
     }
 }
 

--- a/src/Aquifer.API/Helpers/EndpointHelpers.cs
+++ b/src/Aquifer.API/Helpers/EndpointHelpers.cs
@@ -10,10 +10,15 @@ public static class EndpointHelpers
     public const int OneHourInSeconds = 3600;
     public const int TenMinutesInSeconds = 600;
 
+    public const string AnonymousOutputCacheTag = "anonymous";
+
     // Because CacheOutput ignores requests that include an Authorization header, this is only meant for use on AllowAnonymous() endpoints.
     public static Action<RouteHandlerBuilder> UnauthenticatedServerCacheInSeconds(int seconds)
     {
-        return x => x.CacheOutput(c => c.Expire(TimeSpan.FromSeconds(seconds)));
+        return x => x.CacheOutput(
+            c => c
+                .Expire(TimeSpan.FromSeconds(seconds))
+                .Tag(AnonymousOutputCacheTag));
     }
 
     [DoesNotReturn]

--- a/src/Aquifer.API/Telemetry/RequestTelemetryInitializer.cs
+++ b/src/Aquifer.API/Telemetry/RequestTelemetryInitializer.cs
@@ -26,7 +26,7 @@ public class RequestTelemetryInitializer(IHttpContextAccessor httpContextAccesso
 
         if ((httpContextAccessor.HttpContext?.Items.TryGetValue(Constants.HttpContextItemCachedApiKey, out var maybeCachedApiKey) ??
                 false) &&
-            maybeCachedApiKey is CachedApiKey cachedApiKey)
+            maybeCachedApiKey is ApiKey cachedApiKey)
         {
             requestTelemetry.Properties[Constants.TelemetryBnApiCallerIdPropertyName] = cachedApiKey.Id.ToString();
             requestTelemetry.Properties[Constants.TelemetryBnApiCallerPropertyName] = cachedApiKey.Organization;

--- a/src/Aquifer.Common/Constants.cs
+++ b/src/Aquifer.Common/Constants.cs
@@ -7,7 +7,7 @@ public static class Constants
 {
     public const int EnglishLanguageId = 1;
 
-    public const string HttpContextItemCachedApiKey = "CachedApiKey";
+    public const string HttpContextItemCachedApiKey = "ApiKey";
 
     public const string TelemetryBnApiPropertyName = "bnApi";
     public const string TelemetryBnApiCallerPropertyName = "bnApiCaller";

--- a/src/Aquifer.Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Aquifer.Common/Extensions/ServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddTrackResourceContentRequestServices(this IServiceCollection services)
     {
         return services
-            .AddSingleton<IResourceContentRequestTrackingMessagePublisher, ResourceContentRequestTrackingMessagePublisher>()
+            .AddScoped<IResourceContentRequestTrackingMessagePublisher, ResourceContentRequestTrackingMessagePublisher>()
             .AddHostedService<TrackResourceContentRequestBackgroundService>()
             .AddSingleton(
                 _ => Channel.CreateUnbounded<TrackResourceContentRequestMessage>(

--- a/src/Aquifer.Common/Middleware/ApiKeyAuthorizationMiddleware.cs
+++ b/src/Aquifer.Common/Middleware/ApiKeyAuthorizationMiddleware.cs
@@ -28,7 +28,7 @@ public class ApiKeyAuthorizationMiddleware(RequestDelegate _next, IOptions<ApiKe
             return;
         }
 
-        var scopedApiKey = await cachingApiKeyService.GetCachedApiKeyAsync(apiKeyToValidate, _options.Value.Scope, context.RequestAborted);
+        var scopedApiKey = await cachingApiKeyService.GetApiKeyAsync(apiKeyToValidate, _options.Value.Scope, context.RequestAborted);
 
         if (scopedApiKey is null)
         {
@@ -38,7 +38,7 @@ public class ApiKeyAuthorizationMiddleware(RequestDelegate _next, IOptions<ApiKe
             return;
         }
 
-        context.Items.Add(Constants.HttpContextItemCachedApiKey, scopedApiKey);
+        cachingApiKeyService.CurrentApiKey = scopedApiKey;
 
         await _next(context);
     }

--- a/src/Aquifer.Common/Services/Caching/CachingApiKeyService.cs
+++ b/src/Aquifer.Common/Services/Caching/CachingApiKeyService.cs
@@ -1,5 +1,6 @@
 ﻿using Aquifer.Data;
 using Aquifer.Data.Entities;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -7,34 +8,42 @@ namespace Aquifer.Common.Services.Caching;
 
 public interface ICachingApiKeyService
 {
+    ApiKey CurrentApiKey { get; set; }
+    Task<ApiKey?> GetApiKeyAsync(string apiKey, CancellationToken ct);
+    Task<ApiKey?> GetApiKeyAsync(string apiKey, ApiKeyScope scope, CancellationToken ct);
     Task<bool> IsValidApiKeyAsync(string apiKey, ApiKeyScope scope, CancellationToken ct);
-    Task<CachedApiKey?> GetCachedApiKeyAsync(string apiKey, CancellationToken ct);
-    Task<CachedApiKey?> GetCachedApiKeyAsync(string apiKey, ApiKeyScope scope, CancellationToken ct);
 }
 
-public class CachingApiKeyService(AquiferDbContext _dbContext, IMemoryCache _memoryCache) : ICachingApiKeyService
+public class CachingApiKeyService(AquiferDbContext _dbContext, IMemoryCache _memoryCache, IHttpContextAccessor _httpContextAccessor)
+    : ICachingApiKeyService
 {
     private const string ApiKeysCacheKey = $"{nameof(CachingApiKeyService)}:ApiKeys";
     private static readonly TimeSpan s_cacheLifetime = TimeSpan.FromMinutes(10);
 
-    public async Task<CachedApiKey?> GetCachedApiKeyAsync(string apiKey, CancellationToken ct)
+    public ApiKey CurrentApiKey
     {
-        return (await GetApiKeysFromCacheAsync(ct)).SingleOrDefault(x => x.ApiKey == apiKey);
+        get => _httpContextAccessor.HttpContext?.Items[Constants.HttpContextItemCachedApiKey] as ApiKey
+            ?? throw new InvalidOperationException("API Key should be saved on HTTP Context!");
+        set => _httpContextAccessor.HttpContext?.Items.Add(Constants.HttpContextItemCachedApiKey, value);
     }
 
-    public async Task<CachedApiKey?> GetCachedApiKeyAsync(string apiKey, ApiKeyScope scope, CancellationToken ct)
+    public async Task<ApiKey?> GetApiKeyAsync(string apiKey, CancellationToken ct)
     {
-        return (await GetApiKeysFromCacheAsync(ct)).SingleOrDefault(
-            x => (x.Scope == scope || x.Scope == ApiKeyScope.All) && x.ApiKey == apiKey);
+        return (await GetApiKeysFromCacheAsync(ct)).SingleOrDefault(x => x.Key == apiKey);
+    }
+
+    public async Task<ApiKey?> GetApiKeyAsync(string apiKey, ApiKeyScope scope, CancellationToken ct)
+    {
+        return (await GetApiKeysFromCacheAsync(ct)).SingleOrDefault(x => x.Key == apiKey && x.HasScope(scope));
     }
 
     public async Task<bool> IsValidApiKeyAsync(string apiKey, ApiKeyScope scope, CancellationToken ct)
     {
-        var scopedApiKey = await GetCachedApiKeyAsync(apiKey, scope, ct);
+        var scopedApiKey = await GetApiKeyAsync(apiKey, scope, ct);
         return scopedApiKey is not null;
     }
 
-    private async Task<List<CachedApiKey>> GetApiKeysFromCacheAsync(CancellationToken ct)
+    private async Task<List<ApiKey>> GetApiKeysFromCacheAsync(CancellationToken ct)
     {
         return await _memoryCache.GetOrCreateAsync(
                 ApiKeysCacheKey,
@@ -42,10 +51,23 @@ public class CachingApiKeyService(AquiferDbContext _dbContext, IMemoryCache _mem
                 {
                     cacheEntry.AbsoluteExpirationRelativeToNow = s_cacheLifetime;
 
-                    return await _dbContext.ApiKeys.Select(x => new CachedApiKey(x.Id, x.ApiKey, x.Scope, x.Organization)).ToListAsync(ct);
+                    return await _dbContext.ApiKeys.Select(x => new ApiKey(x.Id, x.ApiKey, x.Scope, x.Organization)).ToListAsync(ct);
                 }) ??
             throw new InvalidOperationException($"{ApiKeysCacheKey} unexpectedly had a null value cached.");
     }
 }
 
-public record CachedApiKey(int Id, string ApiKey, ApiKeyScope Scope, string? Organization);
+public sealed class ApiKey(int _id, string _key, ApiKeyScope _scope, string? _organization)
+{
+    public int Id { get; } = _id;
+    public string Key { get; } = _key;
+    public ApiKeyScope Scope { get; } = _scope;
+    public string? Organization { get; } = _organization;
+
+    public bool HasScope(ApiKeyScope scope)
+    {
+        return scope is ApiKeyScope.Admin or ApiKeyScope.None
+            ? Scope == scope
+            : Scope == scope || Scope == ApiKeyScope.All || Scope == ApiKeyScope.Admin;
+    }
+}

--- a/src/Aquifer.Data/Entities/ApiKeyEntity.cs
+++ b/src/Aquifer.Data/Entities/ApiKeyEntity.cs
@@ -42,7 +42,8 @@ public enum ApiKeyScope
     None = 0,
     All = 1,
     InternalApi = 2,
-    PublicApi = 3
+    PublicApi = 3,
+    Admin = 4,
 }
 
 public class ApiKeyEntityConfiguration : IEntityTypeConfiguration<ApiKeyEntity>

--- a/src/Aquifer.Public.API/Endpoints/Admin/Caches/Clear/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Admin/Caches/Clear/Endpoint.cs
@@ -1,0 +1,39 @@
+using Aquifer.Public.API.Helpers;
+using Aquifer.Public.API.OpenApi;
+using FastEndpoints;
+using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Aquifer.Public.API.Endpoints.Admin.Caches.Clear;
+
+public class Endpoint(IMemoryCache _memoryCache, IOutputCacheStore _outputCacheStore) : Endpoint<Request>
+{
+    public override void Configure()
+    {
+        Post("/admin/caches/clear");
+        AllowAnonymous();
+    }
+
+    public override async Task HandleAsync(Request request, CancellationToken ct)
+    {
+        if (request.ShouldClearMemoryCache)
+        {
+            // The IMemoryCache interface is normally injected into constructors, but it doesn't support clearing the entire cache.
+            if (_memoryCache is not MemoryCache memoryCache)
+            {
+                throw new InvalidOperationException($"The {nameof(IMemoryCache)} implementation is not {nameof(MemoryCache)}.");
+            }
+
+            memoryCache.Clear();
+        }
+
+        if (request.ShouldClearOutputCache)
+        {
+            // if any other output cache tags are added then they should also be cleared here
+            await _outputCacheStore.EvictByTagAsync(EndpointHelpers.AnonymousOutputCacheTag, ct);
+            await _outputCacheStore.EvictByTagAsync(ClientGenerationSettings.ClientGenerationOutputCacheTag, ct);
+        }
+
+        await SendNoContentAsync(ct);
+    }
+}

--- a/src/Aquifer.Public.API/Endpoints/Admin/Caches/Clear/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Admin/Caches/Clear/Endpoint.cs
@@ -1,3 +1,5 @@
+using Aquifer.Common.Services.Caching;
+using Aquifer.Data.Entities;
 using Aquifer.Public.API.Helpers;
 using Aquifer.Public.API.OpenApi;
 using FastEndpoints;
@@ -6,17 +8,24 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace Aquifer.Public.API.Endpoints.Admin.Caches.Clear;
 
-public class Endpoint(IMemoryCache _memoryCache, IOutputCacheStore _outputCacheStore) : Endpoint<Request>
+public class Endpoint(ICachingApiKeyService _cachingApiKeyService, IMemoryCache _memoryCache, IOutputCacheStore _outputCacheStore)
+    : Endpoint<Request>
 {
     public override void Configure()
     {
         Post("/admin/caches/clear");
         Tags(EndpointHelpers.EndpointTags.ExcludeFromSwaggerDocument);
-        AllowAnonymous();
     }
 
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
+        var apiKey = _cachingApiKeyService.CurrentApiKey;
+        if (!apiKey.HasScope(ApiKeyScope.Admin))
+        {
+            await SendUnauthorizedAsync(ct);
+            return;
+        }
+
         if (request.ShouldClearMemoryCache)
         {
             // The IMemoryCache interface is normally injected into constructors, but it doesn't support clearing the entire cache.

--- a/src/Aquifer.Public.API/Endpoints/Admin/Caches/Clear/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Admin/Caches/Clear/Endpoint.cs
@@ -11,6 +11,7 @@ public class Endpoint(IMemoryCache _memoryCache, IOutputCacheStore _outputCacheS
     public override void Configure()
     {
         Post("/admin/caches/clear");
+        Tags(EndpointHelpers.EndpointTags.ExcludeFromSwaggerDocument);
         AllowAnonymous();
     }
 

--- a/src/Aquifer.Public.API/Endpoints/Admin/Caches/Clear/Request.cs
+++ b/src/Aquifer.Public.API/Endpoints/Admin/Caches/Clear/Request.cs
@@ -1,0 +1,7 @@
+namespace Aquifer.Public.API.Endpoints.Admin.Caches.Clear;
+
+public sealed class Request
+{
+    public bool ShouldClearMemoryCache { get; set; }
+    public bool ShouldClearOutputCache { get; set; }
+}

--- a/src/Aquifer.Public.API/Endpoints/Admin/Caches/Clear/Validator.cs
+++ b/src/Aquifer.Public.API/Endpoints/Admin/Caches/Clear/Validator.cs
@@ -1,0 +1,14 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Aquifer.Public.API.Endpoints.Admin.Caches.Clear;
+
+public class Validator : Validator<Request>
+{
+    public Validator()
+    {
+        RuleFor(r => r)
+            .Must(r => r.ShouldClearMemoryCache || r.ShouldClearOutputCache)
+            .WithMessage("At least one argument is required.");
+    }
+}

--- a/src/Aquifer.Public.API/Helpers/EndpointHelpers.cs
+++ b/src/Aquifer.Public.API/Helpers/EndpointHelpers.cs
@@ -5,10 +5,15 @@ public static class EndpointHelpers
     public const int OneHourInSeconds = 3600;
     public const int TenMinutesInSeconds = 600;
 
+    public const string AnonymousOutputCacheTag = "anonymous";
+
     // Because CacheOutput ignores requests that include an Authorization header, this is only meant for use on AllowAnonymous() endpoints.
     public static Action<RouteHandlerBuilder> UnauthenticatedServerCacheInSeconds(int seconds)
     {
-        return x => x.CacheOutput(c => c.Expire(TimeSpan.FromSeconds(seconds)));
+        return x => x.CacheOutput(
+            c => c
+                .Expire(TimeSpan.FromSeconds(seconds))
+                .Tag(AnonymousOutputCacheTag));
     }
 
     public static class EndpointTags

--- a/src/Aquifer.Public.API/OpenApi/ClientGenerationSettings.cs
+++ b/src/Aquifer.Public.API/OpenApi/ClientGenerationSettings.cs
@@ -28,7 +28,7 @@ public static class ClientGenerationSettings
                 c.ClientNamespaceName = "BiblioNexus.Aquifer.API.Client";
                 c.ClientClassName = "AquiferClient";
                 c.OutputPath = Path.Combine(c.OutputPath, "cs", Path.GetRandomFileName());
-                c.ExcludePatterns = [$"**/{ClientsRouteName}/**"];
+                c.ExcludePatterns = [$"**/{ClientsRouteName}/**", "**/admin/**"];
             },
             o =>
             {

--- a/src/Aquifer.Public.API/OpenApi/ClientGenerationSettings.cs
+++ b/src/Aquifer.Public.API/OpenApi/ClientGenerationSettings.cs
@@ -10,6 +10,8 @@ namespace Aquifer.Public.API.OpenApi;
 /// </summary>
 public static class ClientGenerationSettings
 {
+    public const string ClientGenerationOutputCacheTag = "client-generation";
+
     private const string ClientsRouteName = "clients";
 
     public static IEndpointRouteBuilder ConfigureClientGeneration(
@@ -30,7 +32,7 @@ public static class ClientGenerationSettings
             },
             o =>
             {
-                o.CacheOutput(p => p.Expire(clientZipCacheDuration));
+                o.CacheOutput(p => p.Expire(clientZipCacheDuration).Tag(ClientGenerationOutputCacheTag));
                 o.WithTags("Clients");
                 o.WithSummary("Download C# client.");
                 o.WithDescription(""""
@@ -155,7 +157,7 @@ public static class ClientGenerationSettings
             },
             o =>
             {
-                o.CacheOutput(p => p.Expire(clientZipCacheDuration));
+                o.CacheOutput(p => p.Expire(clientZipCacheDuration).Tag(ClientGenerationOutputCacheTag));
                 o.WithTags("Clients");
                 o.WithSummary("Download Java client.");
                 o.WithDescription("""
@@ -183,7 +185,7 @@ public static class ClientGenerationSettings
             },
             o =>
             {
-                o.CacheOutput(p => p.Expire(clientZipCacheDuration));
+                o.CacheOutput(p => p.Expire(clientZipCacheDuration).Tag(ClientGenerationOutputCacheTag));
                 o.WithTags("Clients");
                 o.WithSummary("Download Python client.");
                 o.WithDescription("""
@@ -210,7 +212,7 @@ public static class ClientGenerationSettings
             },
             o =>
             {
-                o.CacheOutput(p => p.Expire(clientZipCacheDuration));
+                o.CacheOutput(p => p.Expire(clientZipCacheDuration).Tag(ClientGenerationOutputCacheTag));
                 o.WithTags("Clients");
                 o.WithSummary("Download TypeScript client.");
                 o.WithDescription("""

--- a/src/Aquifer.Public.API/Telemetry/RequestTelemetryInitializer.cs
+++ b/src/Aquifer.Public.API/Telemetry/RequestTelemetryInitializer.cs
@@ -19,7 +19,7 @@ public class RequestTelemetryInitializer(IHttpContextAccessor httpContextAccesso
 
         if ((httpContextAccessor.HttpContext?.Items.TryGetValue(Constants.HttpContextItemCachedApiKey, out var maybeCachedApiKey) ??
                 false) &&
-            maybeCachedApiKey is CachedApiKey cachedApiKey)
+            maybeCachedApiKey is ApiKey cachedApiKey)
         {
             requestTelemetry.Properties[Constants.TelemetryBnApiCallerIdPropertyName] = cachedApiKey.Id.ToString();
             requestTelemetry.Properties[Constants.TelemetryBnApiCallerPropertyName] = cachedApiKey.Organization;

--- a/tests/Aquifer.API.IntegrationTests/Endpoints/Marketing/ParentResourceStatuses/List/EndpointTests.cs
+++ b/tests/Aquifer.API.IntegrationTests/Endpoints/Marketing/ParentResourceStatuses/List/EndpointTests.cs
@@ -1,0 +1,24 @@
+﻿using System.Net;
+using Aquifer.API.Endpoints.Marketing.ParentResourceStatuses.List;
+using FastEndpoints;
+using FastEndpoints.Testing;
+
+namespace Aquifer.API.IntegrationTests.Endpoints.Marketing.ParentResourceStatuses.List;
+
+public sealed class EndpointTests(App _app) : TestBase<App>
+{
+    [Fact]
+    public async Task NoAuthenticationAndNoApiKey_ShouldReturnSuccess()
+    {
+        var request = new Request
+        {
+            LanguageId = 1,
+        };
+
+        var (response, result) = await _app.Client.GETAsync<Endpoint, Request, IReadOnlyList<Response>>(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        result.Should().NotBeNullOrEmpty();
+        result.Should().Contain(r => r.Title == "Berean Standard Bible");
+    }
+}


### PR DESCRIPTION
I tested and both cache clearing scenarios work as expected on both endpoints.  I also confirmed that the swagger docs do not include the new endpoint and no client code is generated for it in the Public API.  The endpoints are gated by a new Admin ApiKeyScope which, in addition to everything granted by `All`, also grants access to admin routes.