### PR TITLE
Handle min verses and correctly return the max verse number for Bible chapters to the Bible Well.

### DIFF
--- a/src/Aquifer.API/Endpoints/Bibles/Book/List/Response.cs
+++ b/src/Aquifer.API/Endpoints/Bibles/Book/List/Response.cs
@@ -6,7 +6,7 @@ public class Response
     public required string Code { get; set; }
     public required string LocalizedName { get; set; }
     public required int TotalChapters { get; set; }
-    public required IEnumerable<ResponseChapter> Chapters { get; set; }
+    public required IReadOnlyList<ResponseChapter> Chapters { get; set; }
 }
 
 public class ResponseChapter

--- a/src/Aquifer.Common/Services/Caching/CachingVersificationService.cs
+++ b/src/Aquifer.Common/Services/Caching/CachingVersificationService.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using Aquifer.Common.Utilities;
 using Aquifer.Data;
 using Aquifer.Data.Enums;
 using Microsoft.EntityFrameworkCore;
@@ -14,8 +15,31 @@ public interface ICachingVersificationService
 
     Task<ReadOnlySet<int>> GetExcludedVerseIdsAsync(int bibleId, CancellationToken cancellationToken);
 
-    Task<ReadOnlyDictionary<BookId, (int MaxChapterNumber, ReadOnlyDictionary<int, int> MaxVerseNumberByChapterNumberMap)>>
-        GetMaxChapterNumberAndVerseNumbersByBookIdMapAsync(int bibleId, CancellationToken cancellationToken);
+    Task<bool> DoesBibleIncludeBookAsync(int bibleId, BookId bookId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns <c>null</c> if there is no Bible content for the given arguments.
+    /// </summary>
+    Task<int?> GetMaxChapterNumberForBookAsync(int bibleId, BookId bookId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns <c>null</c> if there is no Bible content for the given arguments.
+    /// </summary>
+    Task<(int MinVerseNumber, int MaxVerseNumber)?> GetBookendVerseNumbersForChapterAsync(
+        int bibleId,
+        BookId bookId,
+        int chapterNumber,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Prefer to use <see cref="GetMaxChapterNumberForBookAsync"/> or <see cref="GetBookendVerseNumbersForChapterAsync"/> instead
+    /// for ease of use.
+    /// </summary>
+    Task<ReadOnlyDictionary<
+            BookId,
+            (int MaxChapterNumber, ReadOnlyDictionary<int, (int MinVerseNumber, int MaxVerseNumber)>
+                BookendVerseNumbersByChapterNumberMap)>>
+        GetMaxChapterNumberAndBookendVerseNumbersByBookIdMapAsync(int bibleId, CancellationToken cancellationToken);
 }
 
 public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMemoryCache _memoryCache) : ICachingVersificationService
@@ -31,8 +55,8 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
     private const string ExcludedVerseIdsByBibleIdMapCacheKey =
         $"{nameof(CachingVersificationService)}:{nameof(ExcludedVerseIdsByBibleIdMapCacheKey)}";
 
-    private const string MaxVerseNumberByChapterNumberMapByBookIdMapCacheKey =
-        $"{nameof(CachingVersificationService)}:{nameof(MaxVerseNumberByChapterNumberMapByBookIdMapCacheKey)}";
+    private const string BookendVersesNumberByChapterNumberMapByBookIdMapCacheKey =
+        $"{nameof(CachingVersificationService)}:{nameof(BookendVersesNumberByChapterNumberMapByBookIdMapCacheKey)}";
 
     private static readonly TimeSpan s_cacheLifetime = TimeSpan.FromMinutes(120);
 
@@ -51,11 +75,14 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
             ?? new Dictionary<string, int>().AsReadOnly();
     }
 
-    public async Task<ReadOnlyDictionary<BookId, (int MaxChapterNumber, ReadOnlyDictionary<int, int> MaxVerseNumberByChapterNumberMap)>>
-        GetMaxChapterNumberAndVerseNumbersByBookIdMapAsync(int bibleId, CancellationToken cancellationToken)
+    public async Task<ReadOnlyDictionary<
+            BookId,
+            (int MaxChapterNumber, ReadOnlyDictionary<int, (int MinVerseNumber, int MaxVerseNumber)>
+                BookendVerseNumbersByChapterNumberMap)>>
+        GetMaxChapterNumberAndBookendVerseNumbersByBookIdMapAsync(int bibleId, CancellationToken cancellationToken)
     {
         // Cache each Bible's data independently in order to have cheaper SQL queries for each Bible.
-        var cacheKey = $"{MaxVerseNumberByChapterNumberMapByBookIdMapCacheKey}:{bibleId}";
+        var cacheKey = $"{BookendVersesNumberByChapterNumberMapByBookIdMapCacheKey}:{bibleId}";
 
         // Special case: The "eng" (common superset of most English Bibles) versification scheme's max verses are saved in the
         // BookChapters DB table because we use that scheme for Resource verse references (Bible ID 0 has no BibleTexts data).
@@ -67,11 +94,14 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
                 {
                     cacheEntry.AbsoluteExpirationRelativeToNow = s_cacheLifetime;
 
+                    // TODO Update BookChapters to have a MinVerseNumber column so we don't have to assume 1.
+                    // Some Psalms begin with verse 0 for "eng" data which will need to be loaded from the mapping information.
                     return (await _dbContext.BookChapters
                             .Select(bc => new
                             {
                                 bc.BookId,
                                 bc.Number,
+                                MinVerseNumber = 1,
                                 bc.MaxVerseNumber,
                             })
                             .ToListAsync(cancellationToken))
@@ -81,10 +111,10 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
                             grp =>
                             (
                                 MaxChapterNumber: grp.Max(x => x.Number),
-                                MaxVerseNumberByChapterNumberMap: grp
+                                BookendVerseNumbersByChapterNumberMap: grp
                                     .ToDictionary(
                                         x => x.Number,
-                                        x => x.MaxVerseNumber)
+                                        x => (x.MinVerseNumber, x.MaxVerseNumber))
                                     .AsReadOnly()
                             ))
                         .AsReadOnly();
@@ -106,6 +136,7 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
                         {
                             grp.Key.BookId,
                             grp.Key.ChapterNumber,
+                            MinVerseNumber = grp.Min(x => x.VerseNumber),
                             MaxVerseNumber = grp.Max(x => x.VerseNumber),
                         })
                         .ToListAsync(cancellationToken))
@@ -118,12 +149,37 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
                             MaxVerseNumberByChapterNumberMap: grp
                                 .ToDictionary(
                                     x => x.ChapterNumber,
-                                    x => x.MaxVerseNumber)
+                                    x => (x.MinVerseNumber, x.MaxVerseNumber))
                                 .AsReadOnly()
                         ))
                     .AsReadOnly();
             })
             ?? throw new InvalidOperationException($"\"{cacheKey}\" unexpectedly had a null value cached.");
+    }
+
+    public async Task<bool> DoesBibleIncludeBookAsync(int bibleId, BookId bookId, CancellationToken cancellationToken)
+    {
+        return (await GetMaxChapterNumberAndBookendVerseNumbersByBookIdMapAsync(bibleId, cancellationToken))
+            .ContainsKey(bookId);
+    }
+
+    public async Task<int?> GetMaxChapterNumberForBookAsync(int bibleId, BookId bookId, CancellationToken cancellationToken)
+    {
+        return (await GetMaxChapterNumberAndBookendVerseNumbersByBookIdMapAsync(bibleId, cancellationToken))
+            .GetValueOrNull(bookId)
+            ?.MaxChapterNumber;
+    }
+
+    public async Task<(int MinVerseNumber, int MaxVerseNumber)?> GetBookendVerseNumbersForChapterAsync(
+        int bibleId,
+        BookId bookId,
+        int chapterNumber,
+        CancellationToken cancellationToken)
+    {
+        return (await GetMaxChapterNumberAndBookendVerseNumbersByBookIdMapAsync(bibleId, cancellationToken))
+            .GetValueOrNull(bookId)
+            ?.BookendVerseNumbersByChapterNumberMap
+            .GetValueOrNull(chapterNumber);
     }
 
     public async Task<ReadOnlySet<int>> GetExcludedVerseIdsAsync(int bibleId, CancellationToken cancellationToken)

--- a/src/Aquifer.Data/Entities/BookEntity.cs
+++ b/src/Aquifer.Data/Entities/BookEntity.cs
@@ -11,8 +11,4 @@ public class BookEntity
 
     [MaxLength(5)]
     public string Code { get; set; } = null!;
-
-    // TODO delete this after there aren't any usages left.
-    // Each Bible has potentially unique chapter/verse information.
-    public ICollection<BookChapterEntity> Chapters { get; set; } = null!;
 }


### PR DESCRIPTION
1. Cache the min verse ID for each chapter.  For now it's always 1 based upon DB data but this paves the way for having verse 0 data for Psalms with superscripts. As part of this I factored out some of the new Versifications endpoint into a shared method in the VersificationsUtility.
2. Use the `CachingVersificationService` to populate the max verse ID per chapter for display in the Bible Well's verse selector.  This fixes a bunch of bugs where ENG's max verse number (which was always previously returned) was used instead of the actual Bible's max verse numbers:
    * Psalm 3:9 cannot currently be selected in the RSB because ENG only has up to 3:8.
    * Revelation 12:18 is shown in the verse picker for the BSB [but displays nothing](https://qa.well.bible/view-content/-/REV012018-012018?tab=Bible).  Since it is the last verse in the chapter it will now be omitted from the verse picker.
    * Note the the verse picker in the Well appears to use the first Bible selected in order to display the verse picker.
    * Excluded verses in the middle of a chapter will still be shown in the picker for the given Bible.