### PR TITLE
Support one-to-many versification mapping.

### DIFF
--- a/src/Aquifer.API/Endpoints/Bibles/Versification/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Bibles/Versification/Endpoint.cs
@@ -57,13 +57,14 @@ public class Endpoint(AquiferDbContext dbContext, ICachingVersificationService v
                 versificationService,
                 ct);
 
+            // exclude mappings where the source and target verse IDs are the same
             verseMappings = versificationMap
-                .Where(mapping => mapping.Value != mapping.Key)
+                .Where(mapping => mapping.Value.Count != 1 || mapping.Value[0] != mapping.Key)
                 .Select(
                     mapping => new VerseMapping
                     {
                         SourceVerse = MapToVerseReference(mapping.Key),
-                        TargetVerse = mapping.Value.HasValue ? MapToVerseReference(mapping.Value.Value) : null
+                        TargetVerses = mapping.Value.Select(MapToVerseReference).ToList(),
                     })
                 .ToList();
         }

--- a/src/Aquifer.API/Endpoints/Bibles/Versification/Response.cs
+++ b/src/Aquifer.API/Endpoints/Bibles/Versification/Response.cs
@@ -16,5 +16,5 @@ public class VerseReference
 public class VerseMapping
 {
     public required VerseReference SourceVerse { get; set; }
-    public required VerseReference? TargetVerse { get; set; }
+    public required IReadOnlyList<VerseReference> TargetVerses { get; set; }
 }

--- a/src/Aquifer.Common/Services/Caching/CachingVersificationService.cs
+++ b/src/Aquifer.Common/Services/Caching/CachingVersificationService.cs
@@ -98,14 +98,12 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
                 {
                     cacheEntry.AbsoluteExpirationRelativeToNow = s_cacheLifetime;
 
-                    // TODO Update BookChapters to have a MinVerseNumber column so we don't have to assume 1.
-                    // Some Psalms begin with verse 0 for "eng" data which will need to be loaded from the mapping information.
                     return (await _dbContext.BookChapters
                             .Select(bc => new
                             {
                                 bc.BookId,
                                 bc.Number,
-                                MinVerseNumber = 1,
+                                bc.MinVerseNumber,
                                 bc.MaxVerseNumber,
                             })
                             .ToListAsync(cancellationToken))

--- a/src/Aquifer.Common/Services/Caching/CachingVersificationService.cs
+++ b/src/Aquifer.Common/Services/Caching/CachingVersificationService.cs
@@ -9,9 +9,13 @@ namespace Aquifer.Common.Services.Caching;
 
 public interface ICachingVersificationService
 {
-    Task<ReadOnlyDictionary<int, string>> GetBaseVerseIdWithOptionalPartByBibleVerseIdMapAsync(int bibleId, CancellationToken cancellationToken);
+    Task<ReadOnlyDictionary<int, IReadOnlyList<string>>> GetBaseVerseIdWithOptionalPartByBibleVerseIdMapAsync(
+        int bibleId,
+        CancellationToken cancellationToken);
 
-    Task<ReadOnlyDictionary<string, int>> GetBibleVerseIdByBaseVerseIdWithOptionalPartMapAsync(int bibleId, CancellationToken cancellationToken);
+    Task<ReadOnlyDictionary<string, IReadOnlyList<int>>> GetBibleVerseIdByBaseVerseIdWithOptionalPartMapAsync(
+        int bibleId,
+        CancellationToken cancellationToken);
 
     Task<ReadOnlySet<int>> GetExcludedVerseIdsAsync(int bibleId, CancellationToken cancellationToken);
 
@@ -60,19 +64,19 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
 
     private static readonly TimeSpan s_cacheLifetime = TimeSpan.FromMinutes(120);
 
-    public async Task<ReadOnlyDictionary<int, string>>
+    public async Task<ReadOnlyDictionary<int, IReadOnlyList<string>>>
         GetBaseVerseIdWithOptionalPartByBibleVerseIdMapAsync(int bibleId, CancellationToken cancellationToken)
     {
-        return (await GetBaseVerseIdWithOptionalPartByBibleVerseIdMapByBibleIdMapAsync(cancellationToken))
+        return (await GetBaseVerseIdsWithOptionalPartByBibleVerseIdMapByBibleIdMapAsync(cancellationToken))
             .GetValueOrDefault(bibleId)
-            ?? new Dictionary<int, string>().AsReadOnly();
+            ?? new Dictionary<int, IReadOnlyList<string>>().AsReadOnly();
     }
 
-    public async Task<ReadOnlyDictionary<string, int>> GetBibleVerseIdByBaseVerseIdWithOptionalPartMapAsync(int bibleId, CancellationToken cancellationToken)
+    public async Task<ReadOnlyDictionary<string, IReadOnlyList<int>>> GetBibleVerseIdByBaseVerseIdWithOptionalPartMapAsync(int bibleId, CancellationToken cancellationToken)
     {
-        return (await GetBibleVerseIdByBaseVerseIdWithOptionalPartMapByBibleIdMapAsync(cancellationToken))
+        return (await GetBibleVerseIdsByBaseVerseIdWithOptionalPartMapByBibleIdMapAsync(cancellationToken))
             .GetValueOrDefault(bibleId)
-            ?? new Dictionary<string, int>().AsReadOnly();
+            ?? new Dictionary<string, IReadOnlyList<int>>().AsReadOnly();
     }
 
     public async Task<ReadOnlyDictionary<
@@ -189,8 +193,8 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
             ?? new ReadOnlySet<int>(new HashSet<int>());
     }
 
-    private async Task<ReadOnlyDictionary<int, ReadOnlyDictionary<int, string>>>
-        GetBaseVerseIdWithOptionalPartByBibleVerseIdMapByBibleIdMapAsync(CancellationToken ct)
+    private async Task<ReadOnlyDictionary<int, ReadOnlyDictionary<int, IReadOnlyList<string>>>>
+        GetBaseVerseIdsWithOptionalPartByBibleVerseIdMapByBibleIdMapAsync(CancellationToken ct)
     {
         return await _memoryCache.GetOrCreateAsync(
             BaseVerseIdByBibleVerseIdMapsCacheKey,
@@ -200,21 +204,22 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
 
                 // Verse part handling:
                 // 1. Ignore BibleVerseIdPart because consumers don't care about parts when passing verse IDs.
-                //    There is part data in the DB, though, so take only the first mapping in the DB for a verse
-                //    (either the one with no verse part or the one with an 'a' verse part).
-                // 2. Keep BaseVerseIdPart in the mappings because it provides more accurate conversions between source -> base -> target.
+                //    (but if the BibleVerseId has multiple mappings using different parts keep all the mappings, just without a part).
+                // 3. Keep BaseVerseIdPart in the mappings because it provides more accurate conversions between source -> base -> target.
                 var versifications = await _dbContext.VersificationMappings
                     .GroupBy(x => x.BibleId)
                     .ToDictionaryAsync(
                         bibleGrouping => bibleGrouping.Key,
                         bibleGrouping => bibleGrouping
                             .GroupBy(x => x.BibleVerseId)
-                            .Select(bibleVerseIdGrouping => bibleVerseIdGrouping
-                                .OrderBy(x => x.BaseVerseIdPart)
-                                .First())
                             .ToDictionary(
-                                x => x.BibleVerseId,
-                                x => $"{x.BaseVerseId}{x.BaseVerseIdPart}")
+                                bibleVerseIdGrouping => bibleVerseIdGrouping.Key,
+                                IReadOnlyList<string> (bibleVerseIdGrouping) => bibleVerseIdGrouping
+                                    .OrderBy(x => x.BaseVerseId)
+                                    .ThenBy(x => x.BaseVerseIdPart)
+                                    .Select(x => $"{x.BaseVerseId}{x.BaseVerseIdPart}")
+                                    .Distinct()
+                                    .ToList())
                             .AsReadOnly(),
                         ct);
 
@@ -223,8 +228,8 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
             ?? throw new InvalidOperationException($"\"{BaseVerseIdByBibleVerseIdMapsCacheKey}\" unexpectedly had a null value cached.");
     }
 
-    private async Task<ReadOnlyDictionary<int, ReadOnlyDictionary<string, int>>>
-        GetBibleVerseIdByBaseVerseIdWithOptionalPartMapByBibleIdMapAsync(CancellationToken ct)
+    private async Task<ReadOnlyDictionary<int, ReadOnlyDictionary<string, IReadOnlyList<int>>>>
+        GetBibleVerseIdsByBaseVerseIdWithOptionalPartMapByBibleIdMapAsync(CancellationToken ct)
     {
         return await _memoryCache.GetOrCreateAsync(
             BibleVerseIdByBaseVerseIdMapsCacheKey,
@@ -233,17 +238,20 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
                 cacheEntry.AbsoluteExpirationRelativeToNow = s_cacheLifetime;
 
                 // When inverting the bibleVerseId -> baseVerseIdWithOptionalPart map, there may be multiple Bible verse IDs that map to
-                // the same base verse ID with optional part.  In that case, take the first entry ordered by
-                // baseVerseIdWithOptionalPart alphabetically (which will usually be no part or the 'a' part).
-                return (await GetBaseVerseIdWithOptionalPartByBibleVerseIdMapByBibleIdMapAsync(ct))
+                // the same base verse ID with optional part.  In that case, get all such mappings but drop the BibleVersePart.
+                return (await GetBaseVerseIdsWithOptionalPartByBibleVerseIdMapByBibleIdMapAsync(ct))
                     .ToDictionary(
                         x => x.Key,
                         x => x.Value
-                            .GroupBy(y => y.Value)
-                            .Select(baseVerseIdWithOptionalPartGrouping => baseVerseIdWithOptionalPartGrouping
-                                .OrderBy(y => y.Value)
-                                .First())
-                            .ToDictionary(y => y.Value, y => y.Key)
+                            .SelectMany(kvp => kvp.Value.Select(bvwp => (BibleVerseId: kvp.Key, BaseVerseIdWithOptionalVersePart: bvwp)))
+                            .GroupBy(vm => vm.BaseVerseIdWithOptionalVersePart)
+                            .ToDictionary(
+                                baseVerseIdWithOptionalPartGrouping => baseVerseIdWithOptionalPartGrouping.Key,
+                                IReadOnlyList<int> (baseVerseIdWithOptionalPartGrouping) => baseVerseIdWithOptionalPartGrouping
+                                    .Select(vm => vm.BibleVerseId)
+                                    .Order()
+                                    .Distinct()
+                                    .ToList())
                             .AsReadOnly())
                     .AsReadOnly();
             })

--- a/src/Aquifer.Common/Utilities/VersificationUtilities.cs
+++ b/src/Aquifer.Common/Utilities/VersificationUtilities.cs
@@ -48,7 +48,7 @@ public static class VersificationUtilities
 
         // Edge Case: It's theoretically possible that a Bible could be missing an entire chapter.
         if (!maxChapterNumberAndBookendVerseNumbers.BookendVerseNumbersByChapterNumberMap
-                .TryGetValue(verse.chapter, out var bookendVerseNumbers))
+            .TryGetValue(verse.chapter, out var bookendVerseNumbers))
         {
             return false;
         }
@@ -123,9 +123,10 @@ public static class VersificationUtilities
 
         var (minVerseNumberForStartChapter, maxVerseNumberForStartChapter) =
             bookendVerseNumbersByChapterNumberMap[adjustedStartChapterNumber];
-        var adjustedStartVerseNumber = startVerseNumber >= minVerseNumberForStartChapter && startVerseNumber.Value <= maxVerseNumberForStartChapter
-            ? startVerseNumber.Value
-            : minVerseNumberForStartChapter;
+        var adjustedStartVerseNumber =
+            startVerseNumber >= minVerseNumberForStartChapter && startVerseNumber.Value <= maxVerseNumberForStartChapter
+                ? startVerseNumber.Value
+                : minVerseNumberForStartChapter;
 
         var (minVerseNumberForEndChapter, maxVerseNumberForEndChapter) =
             bookendVerseNumbersByChapterNumberMap[adjustedEndChapterNumber];
@@ -139,23 +140,111 @@ public static class VersificationUtilities
         // the min/max verse IDs are within the valid chapter ranges but there's no guarantee that the verses are not excluded
         return (await GetNearestNonExcludedVerseIdAsync(bibleId, minVerseId, versificationService, ct),
             await GetNearestNonExcludedVerseIdAsync(bibleId, maxVerseId, versificationService, ct));
+    }
 
-        static async Task<int> GetNearestNonExcludedVerseIdAsync(
-            int bibleId,
-            int verseId,
-            ICachingVersificationService versificationService,
-            CancellationToken ct)
+    /// <summary>
+    /// If the <paramref name="verseId"/> is outside the valid chapter/verse range for the given <paramref name="bibleId"/>  then the
+    /// <paramref name="verseId"/> will be adjusted to a valid verse ID within the book/chapter.  Furthermore, the returned verse ID is
+    /// guaranteed to not be an excluded verse in the given <paramref name="bibleId"/>.
+    /// If the Bible doesn't exist or the book is not present in the Bible then <c>null</c> will be returned.
+    /// Note: If a verse ID is invalid then this method will prefer to increment the verse whenever possible.
+    /// </summary>
+    public static async Task<int?> ConstrainToValidVerseIdAsync(
+        int bibleId,
+        int verseId,
+        ICachingVersificationService versificationService,
+        CancellationToken ct)
+    {
+        var notOutOfBoundsVerseId = await ConstrainOutOfBoundsVerseIdAsync(bibleId, verseId, versificationService, ct);
+
+        return notOutOfBoundsVerseId == null
+            ? null
+            : await GetNearestNonExcludedVerseIdAsync(bibleId, verseId, versificationService, ct);
+    }
+
+    /// <summary>
+    /// Note: The returned verse ID may still be outside the bounds of the chapter.
+    /// See <see cref="ConstrainOutOfBoundsVerseIdAsync"/> for solving that problem.
+    /// </summary>
+    private static async Task<int> GetNearestNonExcludedVerseIdAsync(
+        int bibleId,
+        int verseId,
+        ICachingVersificationService versificationService,
+        CancellationToken ct)
+    {
+        var excludedVerseIds = await versificationService.GetExcludedVerseIdsAsync(bibleId, ct);
+
+        var adjustedVerseId = verseId;
+        while (excludedVerseIds.Contains(adjustedVerseId))
         {
-            var excludedVerseIds = await versificationService.GetExcludedVerseIdsAsync(bibleId, ct);
-
-            var adjustedVerseId = verseId;
-            while (excludedVerseIds.Contains(adjustedVerseId))
-            {
-                adjustedVerseId++;
-            }
-
-            return adjustedVerseId;
+            adjustedVerseId++;
         }
+
+        return adjustedVerseId;
+    }
+
+    /// <summary>
+    /// If the verseId is outside the valid chapter/verse range for the given Bible and Book then the verse ID will be adjusted to
+    /// a valid verse ID. If the Bible doesn't exist or the book is not present in the Bible then <c>null</c> will be returned.
+    /// Note: The returned verse ID may be excluded.  See <see cref="GetNearestNonExcludedVerseIdAsync"/> for solving that problem.
+    /// </summary>
+    private static async Task<int?> ConstrainOutOfBoundsVerseIdAsync(
+        int bibleId,
+        int verseId,
+        ICachingVersificationService versificationService,
+        CancellationToken ct)
+    {
+        var maxChapterNumberAndBookendVerseNumbersByBookIdMap =
+            await versificationService.GetMaxChapterNumberAndBookendVerseNumbersByBookIdMapAsync(bibleId, ct);
+
+        return ConstrainOutOfBoundsVerseId(verseId, maxChapterNumberAndBookendVerseNumbersByBookIdMap);
+    }
+
+    /// <summary>
+    /// If the verseId is outside the valid chapter/verse range for the given Bible and Book then the verse ID will be adjusted to
+    /// a valid verse ID. If the Bible doesn't exist or the book is not present in the Bible then <c>null</c> will be returned.
+    /// Note: The returned verse ID may be excluded.  See <see cref="GetNearestNonExcludedVerseIdAsync"/> for solving that problem.
+    /// </summary>
+    private static int? ConstrainOutOfBoundsVerseId(
+        int verseId,
+        ReadOnlyDictionary<
+            BookId,
+            (int MaxChapterNumber, ReadOnlyDictionary<int, (int MinVerseNumber, int MaxVerseNumber)> BookendVerseNumbersByChapterNumberMap)>
+                maxChapterNumberAndBookendVerseNumbersByBookIdMap)
+    {
+        var (bookId, chapter, verse) = BibleUtilities.TranslateVerseId(verseId);
+
+        if (!maxChapterNumberAndBookendVerseNumbersByBookIdMap.TryGetValue(bookId, out var maxChapterNumberAndBookendVerseNumbers))
+        {
+            return null;
+        }
+
+        var (maxChapterNumber, bookendVerseNumbersByChapterNumberMap) = maxChapterNumberAndBookendVerseNumbers;
+
+        if (chapter < MinChapterNumber)
+        {
+            return BibleUtilities.GetVerseId(bookId, MinChapterNumber, bookendVerseNumbersByChapterNumberMap[maxChapterNumber].MinVerseNumber);
+        }
+
+        if (chapter > maxChapterNumber)
+        {
+            return BibleUtilities.GetVerseId(bookId, maxChapterNumber, bookendVerseNumbersByChapterNumberMap[maxChapterNumber].MaxVerseNumber);
+        }
+
+        if (verse < bookendVerseNumbersByChapterNumberMap[chapter].MinVerseNumber)
+        {
+            return BibleUtilities.GetVerseId(bookId, chapter, bookendVerseNumbersByChapterNumberMap[chapter].MinVerseNumber);
+        }
+
+        if (verse > bookendVerseNumbersByChapterNumberMap[chapter].MaxVerseNumber)
+        {
+            // increment the out-of-chapter verse to the start of the next chapter if possible
+            return chapter < maxChapterNumber
+                ? BibleUtilities.GetVerseId(bookId, chapter + 1, bookendVerseNumbersByChapterNumberMap[chapter + 1].MinVerseNumber)
+                : BibleUtilities.GetVerseId(bookId, chapter, bookendVerseNumbersByChapterNumberMap[chapter].MaxVerseNumber);
+        }
+
+        return verseId;
     }
 
     /// <summary>
@@ -225,7 +314,7 @@ public static class VersificationUtilities
             {
                 // Edge Case: It's theoretically possible that a Bible could be missing an entire chapter.
                 if (!maxChapterNumberAndBookendVerseNumbers.BookendVerseNumbersByChapterNumberMap
-                        .TryGetValue(chapterNumber, out var bookendVerseNumbers))
+                    .TryGetValue(chapterNumber, out var bookendVerseNumbers))
                 {
                     continue;
                 }
@@ -254,10 +343,10 @@ public static class VersificationUtilities
     }
 
     /// <summary>
-    /// Returns the verse ID in the target Bible that corresponds to the given verse ID in the source Bible.
-    /// <c>null</c> will be returned if it's not possible to map between the versification schemes.
+    /// Returns the verse ID(s) in the target Bible that corresponds to the given verse ID in the source Bible.
+    /// An empty collection will be returned if it's not possible to map between the versification schemes.
     /// </summary>
-    public static async Task<int?> ConvertVersificationAsync(
+    public static async Task<IReadOnlyList<int>> ConvertVersificationAsync(
         int sourceBibleId,
         int sourceVerseId,
         int targetBibleId,
@@ -271,64 +360,90 @@ public static class VersificationUtilities
                 nameof(sourceVerseId));
         }
 
-        var baseVerseIdWithOptionalPartBySourceBibleVerseIdMap =
+        var baseVerseIdsWithOptionalPartBySourceBibleVerseIdMap =
             await versificationService.GetBaseVerseIdWithOptionalPartByBibleVerseIdMapAsync(sourceBibleId, ct);
-        var targetBibleVerseIdByBaseVerseIdWithOptionalPartMap =
+        var targetBibleVerseIdsByBaseVerseIdWithOptionalPartMap =
             await versificationService.GetBibleVerseIdByBaseVerseIdWithOptionalPartMapAsync(targetBibleId, ct);
         var targetBibleExcludedVerseIds = await versificationService.GetExcludedVerseIdsAsync(targetBibleId, ct);
+        var maxChapterNumberAndBookendVerseNumbersByBookIdMap =
+            await versificationService.GetMaxChapterNumberAndBookendVerseNumbersByBookIdMapAsync(targetBibleId, ct);
 
         return ConvertVersificationCore(
             sourceVerseId,
-            baseVerseIdWithOptionalPartBySourceBibleVerseIdMap,
-            targetBibleVerseIdByBaseVerseIdWithOptionalPartMap,
-            targetBibleExcludedVerseIds);
+            baseVerseIdsWithOptionalPartBySourceBibleVerseIdMap,
+            targetBibleVerseIdsByBaseVerseIdWithOptionalPartMap,
+            targetBibleExcludedVerseIds,
+            maxChapterNumberAndBookendVerseNumbersByBookIdMap);
     }
 
     /// <summary>
     /// This method assumes that the <paramref name="sourceVerseId"/> is valid for the given maps and exclusions.
     /// </summary>
-    /// <returns>The converted verse ID or <c>null</c> if conversion is not possible.</returns>
-    private static int? ConvertVersificationCore(
+    /// <returns>The converted verse IDs (which may be empty if conversion is not possible).</returns>
+    private static IReadOnlyList<int> ConvertVersificationCore(
         int sourceVerseId,
-        ReadOnlyDictionary<int, string> baseVerseIdWithOptionalPartBySourceBibleVerseIdMap,
-        ReadOnlyDictionary<string, int> targetBibleVerseIdByBaseVerseIdWithOptionalPartMap,
-        ReadOnlySet<int> targetBibleExcludedVerseIds)
+        ReadOnlyDictionary<int, IReadOnlyList<string>> baseVerseIdsWithOptionalPartBySourceBibleVerseIdMap,
+        ReadOnlyDictionary<string, IReadOnlyList<int>> targetBibleVerseIdsByBaseVerseIdWithOptionalPartMap,
+        ReadOnlySet<int> targetBibleExcludedVerseIds,
+        ReadOnlyDictionary<
+            BookId,
+            (int MaxChapterNumber, ReadOnlyDictionary<int, (int MinVerseNumber, int MaxVerseNumber)>
+                BookendVerseNumbersByChapterNumberMap)> targetBibleMaxChapterNumberAndBookendVerseNumbersByBookIdMap)
     {
         // The dictionary only contains mappings where the key is different from the value.
         // If the key verse ID is not present in the mapping (and is not in the exclusions list) then the value matches the key.
-        var baseVerseIdWithOptionalPart = baseVerseIdWithOptionalPartBySourceBibleVerseIdMap.GetValueOrDefault(sourceVerseId)
-            ?? sourceVerseId.ToString();
+        var baseVerseIdsWithOptionalPart = baseVerseIdsWithOptionalPartBySourceBibleVerseIdMap.GetValueOrDefault(sourceVerseId) ??
+            [sourceVerseId.ToString()];
 
-        // Base Verse Data includes a Verse ID with an optional verse part at the end (such as 'a', 'b', etc.).
-        var baseVerseId = baseVerseIdWithOptionalPart[..10];
+        return baseVerseIdsWithOptionalPart
+            .SelectMany(
+                baseVerseIdWithOptionalPart =>
+                {
+                    // Base Verse Data includes a Verse ID with an optional verse part at the end (such as 'a', 'b', etc.).
+                    var baseVerseId = baseVerseIdWithOptionalPart[..10];
 
-        // Rules when a part is present on base verse ID:
-        // 1. Use the base verse ID with part if present in the target inverse mapping (the direct map).
-        // 2. If not found, then try to map using the base verse ID without a part (in case the target mapping doesn't use parts).
-        // 3. Default to the base verse ID without a part (no explicit mapping).
-        // Rules when a part is not present on base verse ID:
-        // 1. Use the base verse ID without a part if present in the target inverse mapping (the direct map).
-        // 2. If not found, then try to map using the base verse ID with part 'a' (in case the target mapping uses parts).
-        // 3. Default to the base verse ID without a part (no explicit mapping).
-        var targetVerseId = targetBibleVerseIdByBaseVerseIdWithOptionalPartMap.GetValueOrNull(baseVerseIdWithOptionalPart)
-               ?? targetBibleVerseIdByBaseVerseIdWithOptionalPartMap.GetValueOrNull(
-                   baseVerseIdWithOptionalPart.Length > 10
-                       ? baseVerseId
-                       : $"{baseVerseId}a")
-               ?? int.Parse(baseVerseId);
+                    // Rules when a part is present on base verse ID:
+                    // 1. Use the base verse ID with part if present in the target inverse mapping (the direct map).
+                    // 2. If not found, then try to map using the base verse ID without a part (in case the target mapping doesn't use parts).
+                    // 3. Default to the base verse ID without a part (no explicit mapping).
+                    // Rules when a part is not present on base verse ID:
+                    // 1. Use the base verse ID without a part if present in the target inverse mapping (the direct map).
+                    // 2. If not found, then try to map using the base verse ID with part 'a' (in case the target mapping uses parts).
+                    // 3. Default to the base verse ID without a part (no explicit mapping).
+                    var targetVerseIds =
+                        targetBibleVerseIdsByBaseVerseIdWithOptionalPartMap.GetValueOrDefault(baseVerseIdWithOptionalPart)
+                            ?? targetBibleVerseIdsByBaseVerseIdWithOptionalPartMap.GetValueOrDefault(
+                                baseVerseIdWithOptionalPart.Length > 10
+                                    ? baseVerseId
+                                    : $"{baseVerseId}a")
+                            ?? [int.Parse(baseVerseId)];
 
-        return targetBibleExcludedVerseIds.Contains(targetVerseId)
-            ? null
-            : targetVerseId;
+                    // Handle two scenarios:
+                    // 1. The target verse ID is in the exclusions list.  In this case omit it.
+                    // 2. The target verse ID is not in a valid book for the target Bible even though it exists in the base mapping.
+                    //    In this case omit it.
+                    // 3. The target verse ID is not in a valid chapter/verse range for the target Bible/book
+                    //    (e.g. it's "excluded" but at the very end of a chapter so it's not in the exclusions list).
+                    //    In this case constrain the verse to the nearest valid verse.
+                    return targetVerseIds
+                        .Select(targetVerseId => ConstrainOutOfBoundsVerseId(
+                            targetVerseId,
+                            targetBibleMaxChapterNumberAndBookendVerseNumbersByBookIdMap))
+                        .OfType<int>()
+                        .Where(constrainedTargetVerseId => !targetBibleExcludedVerseIds.Contains(constrainedTargetVerseId));
+                })
+            .Order()
+            .Distinct()
+            .ToList();
     }
 
     /// <summary>
     /// Returns the verse IDs in the target Bible that corresponds to the given verse IDs in the source Bible.
     /// Ranges will be expanded to their component verse IDs.
-    /// The source verse ID is the dictionary key and the target verse ID is the dictionary value.
-    /// <c>null</c> will be returned for the target verse ID if it's not possible to map between the versification schemes.
+    /// The source verse ID is the dictionary key and the target verse ID(s) are the dictionary value.
+    /// An empty collection will be returned for the target verse IDs if it's not possible to map between the versification schemes.
     /// </summary>
-    public static async Task<ReadOnlyDictionary<int, int?>> ConvertVersificationRangeAsync(
+    public static async Task<ReadOnlyDictionary<int, IReadOnlyList<int>>> ConvertVersificationRangeAsync(
         int sourceBibleId,
         int sourceStartVerseId,
         int sourceEndVerseId,
@@ -344,20 +459,23 @@ public static class VersificationUtilities
             versificationService,
             ct);
 
-        var baseVerseIdWithOptionalPartBySourceBibleVerseIdMap =
+        var baseVerseIdsWithOptionalPartBySourceBibleVerseIdMap =
             await versificationService.GetBaseVerseIdWithOptionalPartByBibleVerseIdMapAsync(sourceBibleId, ct);
-        var targetBibleVerseIdByBaseVerseIdWithOptionalPartMap =
+        var targetBibleVerseIdsByBaseVerseIdWithOptionalPartMap =
             await versificationService.GetBibleVerseIdByBaseVerseIdWithOptionalPartMapAsync(targetBibleId, ct);
         var targetBibleExcludedVerseIds = await versificationService.GetExcludedVerseIdsAsync(targetBibleId, ct);
+        var maxChapterNumberAndBookendVerseNumbersByBookIdMap =
+            await versificationService.GetMaxChapterNumberAndBookendVerseNumbersByBookIdMapAsync(targetBibleId, ct);
 
         return expandedSourceVerseIds
             .ToDictionary(
                 sourceVerseId => sourceVerseId,
                 sourceVerseId => ConvertVersificationCore(
                     sourceVerseId,
-                    baseVerseIdWithOptionalPartBySourceBibleVerseIdMap,
-                    targetBibleVerseIdByBaseVerseIdWithOptionalPartMap,
-                    targetBibleExcludedVerseIds))
+                    baseVerseIdsWithOptionalPartBySourceBibleVerseIdMap,
+                    targetBibleVerseIdsByBaseVerseIdWithOptionalPartMap,
+                    targetBibleExcludedVerseIds,
+                    maxChapterNumberAndBookendVerseNumbersByBookIdMap))
             .AsReadOnly();
     }
 }

--- a/src/Aquifer.Common/Utilities/VersificationUtilities.cs
+++ b/src/Aquifer.Common/Utilities/VersificationUtilities.cs
@@ -20,7 +20,7 @@ public static class VersificationUtilities
     {
         var verse = BibleUtilities.TranslateVerseId(verseId);
 
-        if (verse.bookId == BookId.None || verse.chapter == 0 || verse.verse == 0)
+        if (verse.bookId == BookId.None || verse.chapter == 0)
         {
             return false;
         }

--- a/src/Aquifer.Data/Entities/BookChapterEntity.cs
+++ b/src/Aquifer.Data/Entities/BookChapterEntity.cs
@@ -7,6 +7,7 @@ public class BookChapterEntity
     public int Id { get; set; }
     public BookId BookId { get; set; }
     public int Number { get; set; }
+    public int MinVerseNumber { get; set; }
     public int MaxVerseNumber { get; set; }
 
     public BookEntity Book { get; set; } = null!;

--- a/src/Aquifer.Data/Migrations/20250324175904_AddMinVerseNumberToBookChapters.Designer.cs
+++ b/src/Aquifer.Data/Migrations/20250324175904_AddMinVerseNumberToBookChapters.Designer.cs
@@ -4,6 +4,7 @@ using Aquifer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Aquifer.Data.Migrations
 {
     [DbContext(typeof(AquiferDbContext))]
-    partial class AquiferDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250324175904_AddMinVerseNumberToBookChapters")]
+    partial class AddMinVerseNumberToBookChapters
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Aquifer.Data/Migrations/20250324175904_AddMinVerseNumberToBookChapters.cs
+++ b/src/Aquifer.Data/Migrations/20250324175904_AddMinVerseNumberToBookChapters.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Aquifer.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMinVerseNumberToBookChapters : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MinVerseNumber",
+                table: "BookChapters",
+                type: "int",
+                nullable: false,
+                defaultValue: 1);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MinVerseNumber",
+                table: "BookChapters");
+        }
+    }
+}


### PR DESCRIPTION
* Consider verse parts (data was already in the DB) during versification mapping, which allows a single verse to map to more than one verse.  This update resulted in a breaking change for the versifications endpoint which is [addressed in the CMS]().
* Add `MinVerseNumber` to `BookChapters` which allows the `ENG` data to know when there is a verse 0 (Psalm superscript).

Example of where this allows two verses in ENG (verse 0 for superscript and standard verse 1) to map to a single verse (verse 1 only which includes superscript) in Russian:
![image](https://github.com/user-attachments/assets/6047aa98-266a-4ed7-ae57-e5f51fc15614)

Example of new multi-mapping in Russian from existing Nehemiah data:
![image](https://github.com/user-attachments/assets/36d0d460-d6e7-476b-85c2-6c86bf8f1e16)
