### PR TITLE
Update comment notifications.

### DIFF
--- a/src/Aquifer.API/Endpoints/Notifications/List/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Notifications/List/Endpoint.cs
@@ -153,9 +153,11 @@ public class Endpoint(AquiferDbContext _dbContext, IUserService _userService) : 
         DateTime minimumCommentCreatedDate,
         CancellationToken ct)
     {
-        // Get comment notifications for the current user where that user is assigned or has previously been assigned to the associated
-        // resource and where the current user is in the same company as the user who made the comment.  The user who made the comment
-        // should not get a notification.
+        // Get comments for the current user where:
+        // 1. The user was assigned or has previously been assigned to the resource content on which the comment was made.
+        // 2. The user has previously interacted in the comment thread for the comment.
+        // 3. The user was at-mentioned on the comment.
+        // The user who made the comment should not get a notification.
         const string query = """
             SELECT
                 c.Id AS CommentId,
@@ -176,14 +178,35 @@ public class Endpoint(AquiferDbContext _dbContext, IUserService _userService) : 
                 JOIN Resources r ON r.Id = rc.ResourceId
                 JOIN ParentResources pr ON pr.Id = r.ParentResourceId
             WHERE
-                EXISTS
                 (
-                    SELECT NULL
-                    FROM ResourceContentVersionAssignedUserHistory rcvauh
-                    WHERE
-                        rcvauh.ResourceContentVersionId = rcv.Id AND
-                        rcvauh.Created < c.Created AND
-                        rcvauh.AssignedUserId = @userId
+                    EXISTS
+                    (
+                        SELECT NULL
+                        FROM ResourceContentVersionAssignedUserHistory rcvauh
+                        WHERE
+                            rcvauh.ResourceContentVersionId = rcv.Id AND
+                            rcvauh.Created < c.Created AND
+                            rcvauh.AssignedUserId = @userId
+                    ) OR
+                    EXISTS
+                    (
+                        SELECT NULL
+                        FROM CommentThreads ct2
+                        JOIN Comments c2 ON c2.ThreadId = ct2.Id
+                        WHERE
+                            c.ThreadId = ct2.Id AND
+                            c2.UserId = @userId AND
+                            c.Created > c2.Created
+                    ) OR
+                    EXISTS
+                    (
+                        SELECT NULL
+                        FROM CommentMentions cm
+                        WHERE
+                            cm.CommentId = c.Id AND
+                            cm.UserId <> c.UserId AND
+                            cm.UserId = @userId
+                    )
                 ) AND
                 c.UserId <> @userId AND
                 c.Created > @minimumCommentCreatedDate AND

--- a/src/Aquifer.Data/Entities/CommentEntity.cs
+++ b/src/Aquifer.Data/Entities/CommentEntity.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Aquifer.Data.Entities;
 
+[Index(nameof(UserId))]
 [Index(nameof(ThreadId))]
 public class CommentEntity : IHasUpdatedTimestamp
 {

--- a/src/Aquifer.Data/Entities/CommentMentionEntity.cs
+++ b/src/Aquifer.Data/Entities/CommentMentionEntity.cs
@@ -3,6 +3,8 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Aquifer.Data.Entities;
 
+[Index(nameof(CommentId), nameof(UserId))]
+[Index(nameof(UserId), nameof(CommentId))]
 [EntityTypeConfiguration(typeof(CommentMentionEntityConfiguration))]
 public sealed class CommentMentionEntity
 {

--- a/src/Aquifer.Data/Migrations/20250328151017_AddCommentMentionsIndices.Designer.cs
+++ b/src/Aquifer.Data/Migrations/20250328151017_AddCommentMentionsIndices.Designer.cs
@@ -4,6 +4,7 @@ using Aquifer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Aquifer.Data.Migrations
 {
     [DbContext(typeof(AquiferDbContext))]
-    partial class AquiferDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250328151017_AddCommentMentionsIndices")]
+    partial class AddCommentMentionsIndices
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Aquifer.Data/Migrations/20250328151017_AddCommentMentionsIndices.cs
+++ b/src/Aquifer.Data/Migrations/20250328151017_AddCommentMentionsIndices.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Aquifer.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommentMentionsIndices : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_CommentMentions_CommentId_UserId",
+                table: "CommentMentions",
+                columns: new[] { "CommentId", "UserId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommentMentions_UserId_CommentId",
+                table: "CommentMentions",
+                columns: new[] { "UserId", "CommentId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CommentMentions_CommentId_UserId",
+                table: "CommentMentions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CommentMentions_UserId_CommentId",
+                table: "CommentMentions");
+        }
+    }
+}

--- a/src/Aquifer.Data/Migrations/20250328152857_AddUserIdIndexToComment.Designer.cs
+++ b/src/Aquifer.Data/Migrations/20250328152857_AddUserIdIndexToComment.Designer.cs
@@ -4,6 +4,7 @@ using Aquifer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Aquifer.Data.Migrations
 {
     [DbContext(typeof(AquiferDbContext))]
-    partial class AquiferDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250328152857_AddUserIdIndexToComment")]
+    partial class AddUserIdIndexToComment
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Aquifer.Data/Migrations/20250328152857_AddUserIdIndexToComment.cs
+++ b/src/Aquifer.Data/Migrations/20250328152857_AddUserIdIndexToComment.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Aquifer.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserIdIndexToComment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Comments_UserId",
+                table: "Comments",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Comments_UserId",
+                table: "Comments");
+        }
+    }
+}


### PR DESCRIPTION
Changes:
* Comment mentions result in a notification.
* Participation in a comment thread results in notifications for future comments in that thread.
* Users who were previously assigned the resource content will no longer get notifications for comments.  Only the user actively assigned at the time the comment was made will get a notification.

Unchanged:
* The user who created the comment will never get a notification for that comment.
* Only `ResourceContentVersion`s in the Draft status will show notifications.

Implications:
* If a `ResourceContentVersion` is Published then notifications for any comments while it was in Draft will disappear.
* If a Comment is edited to remove a Mention then the notification for that Mention will disappear.
* If a Comment is edited to add a Mention then a notification for that Mention will appear.  However, it will be sorted by the time that the comment was originally _created_, not the time of the update to include the mention.