### PR TITLE
Fix Azure Functions display of metrics in Azure Portal.

### DIFF
--- a/src/Aquifer.Jobs/host.json
+++ b/src/Aquifer.Jobs/host.json
@@ -15,7 +15,7 @@
             // additional logging
             "Host.Triggers.DurableTask": "Information",
             "Host.Aggregator": "Trace",
-            "Host.Results": "Error"
+            "Host.Results": "Information"
         },
         "ApplicationInsights": {
             "LogLevel": {


### PR DESCRIPTION
Azure Portal uses this logging to populate the Metrics tab:
![image](https://github.com/user-attachments/assets/6b2d7bcb-c13b-425f-b1c3-99c8d7dcf6fb)
