### PR TITLE
Use latest dotnet feature release.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
-  "sdk": {
-    "rollForward": "latestPatch",
-    "version": "9.0.100"
-  }
+    "sdk": {
+        "rollForward": "latestFeature",
+        "version": "9.0.100"
+    }
 }

--- a/src/Aquifer.AI/OpenAiTranslationService.cs
+++ b/src/Aquifer.AI/OpenAiTranslationService.cs
@@ -14,7 +14,7 @@ public interface ITranslationService
     /// Translates plain text.
     /// Note: It's up to the caller to guarantee that the text length is not too long.
     /// </summary>
-    public Task<string> TranslateTextAsync(
+    Task<string> TranslateTextAsync(
         string text,
         (string Iso6393Code, string EnglishName) destinationLanguage,
         IDictionary<string, string> translationPairs,
@@ -24,7 +24,7 @@ public interface ITranslationService
     /// Translates HTML content while preserving the HTML tags.
     /// Note: Translations are done on each individual paragraph in order to avoid hitting length limitations.
     /// </summary>
-    public Task<string> TranslateHtmlAsync(
+    Task<string> TranslateHtmlAsync(
         string html,
         (string Iso6393Code, string EnglishName) destinationLanguage,
         IDictionary<string, string> translationPairs,

--- a/src/Aquifer.API/Endpoints/Marketing/ParentResourceStatuses/BibleBooks/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Marketing/ParentResourceStatuses/BibleBooks/Get/Endpoint.cs
@@ -34,7 +34,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, List<Respo
             {
                 BibleBookId = x.Key,
                 BookName = x.Select(y => y.BookName).First(),
-                LastPublished = x.Select(y => y.LastPublished).Max(),
+                LastPublished = x.Max(y => y.LastPublished),
                 TotalResources = x.Sum(y => y.TotalResources)
             })
             .OrderBy(x => x.BibleBookId)
@@ -46,7 +46,7 @@ public class Endpoint(AquiferDbContext dbContext) : Endpoint<Request, List<Respo
             {
                 BibleBookId = x.Key,
                 BookName = x.Select(y => y.BookName).First(),
-                LastPublished = x.Select(y => y.LastPublished).Max(),
+                LastPublished = x.Max(y => y.LastPublished),
                 TotalResources = x.Sum(y => y.TotalResources)
             })
             .ToList();

--- a/src/Aquifer.API/Endpoints/Resources/Content/GeneralReportingSummary/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/GeneralReportingSummary/Endpoint.cs
@@ -54,7 +54,7 @@ public class Endpoint(AquiferDbContext dbContext) : EndpointWithoutRequest<Respo
             await GetDataAsync(dbContext, ct);
 
         // resourcesByParentResource sum will be changed later, so keep this at the top
-        var allResourcesCount = resourcesByParentResource.Select(x => x.ResourceCount).Sum();
+        var allResourcesCount = resourcesByParentResource.Sum(x => x.ResourceCount);
         var months = ReportUtilities.GetLastMonths(6);
         var languages = resourcesByLanguage.Select(x => x.LanguageName).Distinct().ToList();
         var parentResources = resourcesByLanguage.Select(x => x.ParentResourceName).Distinct().ToList();

--- a/src/Aquifer.Jobs/Managers/SendResourceAssignmentNotificationsManager.cs
+++ b/src/Aquifer.Jobs/Managers/SendResourceAssignmentNotificationsManager.cs
@@ -142,7 +142,7 @@ public sealed class SendResourceAssignmentNotificationsManager(
 
         if (successCount > 0)
         {
-            jobHistory.LastProcessed = userHistories.Select(uh => uh.Created).Max();
+            jobHistory.LastProcessed = userHistories.Max(uh => uh.Created);
             await _dbContext.SaveChangesAsync(CancellationToken.None);
         }
 

--- a/src/Aquifer.Jobs/Services/TranslationProcessors/TranslationProcessingService.cs
+++ b/src/Aquifer.Jobs/Services/TranslationProcessors/TranslationProcessingService.cs
@@ -5,13 +5,13 @@ namespace Aquifer.Jobs.Services.TranslationProcessors;
 
 public interface ITranslationProcessingService
 {
-    public Task<string> PostProcessHtmlAsync(string html, string languageIso6393Code, CancellationToken cancellationToken);
+    Task<string> PostProcessHtmlAsync(string html, string languageIso6393Code, CancellationToken cancellationToken);
 }
 
 public interface ILanguageSpecificTranslationProcessingService
 {
-    public string Iso6393Code { get; }
-    public Task<string> PostProcessHtmlAsync(string html, CancellationToken cancellationToken);
+    string Iso6393Code { get; }
+    Task<string> PostProcessHtmlAsync(string html, CancellationToken cancellationToken);
 }
 
 public static class TranslationProcessingServicesRegistry


### PR DESCRIPTION
We previously were using `9.x` [here](https://github.com/BiblioNexusStudio/aquifer-server/blob/e13ff656b846fb5045c3e3b46c203c6258655d83/.github/workflows/pre-merge.yml#L20) before the introduction of `global.json`.  Using `latestFeature` ([docs](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json)) is the equivalent of `9.0.x`.

We'll want to keep an eye on .net releases because the GHA runner images only have one 9.x version installed and we incur a 30-60 second build time penalty if we download and install a different version.  Switching to `latestFeature` let us use the current version on the GHA runner image but if there is a minor version release we'll need to manually update the `global.json` file.