### PR TITLE
Fix versifications

### DIFF
--- a/src/Aquifer.API/Endpoints/Bibles/Versification/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Bibles/Versification/Endpoint.cs
@@ -57,9 +57,7 @@ public class Endpoint(AquiferDbContext dbContext, ICachingVersificationService v
                 versificationService,
                 ct);
 
-            // exclude mappings where the source and target verse IDs are the same
             verseMappings = versificationMap
-                .Where(mapping => mapping.Value.Count != 1 || mapping.Value[0] != mapping.Key)
                 .Select(
                     mapping => new VerseMapping
                     {

--- a/src/Aquifer.Common/Services/Caching/CachingVersificationService.cs
+++ b/src/Aquifer.Common/Services/Caching/CachingVersificationService.cs
@@ -70,7 +70,7 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
         $"{nameof(CachingVersificationService)}:{nameof(BookendVersesNumberByChapterNumberMapByBookIdMapCacheKey)}";
 
     private const string DefaultLanguageBibleIdByBibleIdMapCacheKey =
-        $"{nameof(CachingVersificationService)}:{nameof(BaseVerseIdByBibleVerseIdMapsCacheKey)}";
+        $"{nameof(CachingVersificationService)}:{nameof(DefaultLanguageBibleIdByBibleIdMapCacheKey)}";
 
     private static readonly TimeSpan s_cacheLifetime = TimeSpan.FromMinutes(120);
 
@@ -96,7 +96,7 @@ public sealed class CachingVersificationService(AquiferDbContext _dbContext, IMe
                             b => defaultBibleIdByLanguageIdMap[b.LanguageId])
                         .AsReadOnly();
                 })
-            ?? throw new InvalidOperationException($"\"{BaseVerseIdByBibleVerseIdMapsCacheKey}\" unexpectedly had a null value cached.");
+            ?? throw new InvalidOperationException($"\"{DefaultLanguageBibleIdByBibleIdMapCacheKey}\" unexpectedly had a null value cached.");
     }
 
     public async Task<ReadOnlyDictionary<int, IReadOnlyList<string>>> GetBaseVerseIdWithOptionalPartByBibleVerseIdMapAsync(

--- a/src/Aquifer.Common/Utilities/VersificationUtilities.cs
+++ b/src/Aquifer.Common/Utilities/VersificationUtilities.cs
@@ -361,9 +361,9 @@ public static class VersificationUtilities
         }
 
         var baseVerseIdsWithOptionalPartBySourceBibleVerseIdMap =
-            await versificationService.GetBaseVerseIdWithOptionalPartByBibleVerseIdMapAsync(sourceBibleId, ct);
+            await versificationService.GetBaseVerseIdWithOptionalPartByBibleVerseIdMapAsync(sourceBibleId, true, ct);
         var targetBibleVerseIdsByBaseVerseIdWithOptionalPartMap =
-            await versificationService.GetBibleVerseIdByBaseVerseIdWithOptionalPartMapAsync(targetBibleId, ct);
+            await versificationService.GetBibleVerseIdByBaseVerseIdWithOptionalPartMapAsync(targetBibleId, true, ct);
         var targetBibleExcludedVerseIds = await versificationService.GetExcludedVerseIdsAsync(targetBibleId, ct);
         var maxChapterNumberAndBookendVerseNumbersByBookIdMap =
             await versificationService.GetMaxChapterNumberAndBookendVerseNumbersByBookIdMapAsync(targetBibleId, ct);
@@ -460,9 +460,10 @@ public static class VersificationUtilities
             ct);
 
         var baseVerseIdsWithOptionalPartBySourceBibleVerseIdMap =
-            await versificationService.GetBaseVerseIdWithOptionalPartByBibleVerseIdMapAsync(sourceBibleId, ct);
+            await versificationService.GetBaseVerseIdWithOptionalPartByBibleVerseIdMapAsync(sourceBibleId, true, ct);
+
         var targetBibleVerseIdsByBaseVerseIdWithOptionalPartMap =
-            await versificationService.GetBibleVerseIdByBaseVerseIdWithOptionalPartMapAsync(targetBibleId, ct);
+            await versificationService.GetBibleVerseIdByBaseVerseIdWithOptionalPartMapAsync(targetBibleId, true, ct);
         var targetBibleExcludedVerseIds = await versificationService.GetExcludedVerseIdsAsync(targetBibleId, ct);
         var maxChapterNumberAndBookendVerseNumbersByBookIdMap =
             await versificationService.GetMaxChapterNumberAndBookendVerseNumbersByBookIdMapAsync(targetBibleId, ct);

--- a/tests/Aquifer.Common.UnitTests/Utilities/VersificationUtilitiesTests.cs
+++ b/tests/Aquifer.Common.UnitTests/Utilities/VersificationUtilitiesTests.cs
@@ -383,7 +383,10 @@ public class MockCachingVersificationService : ICachingVersificationService
                 .AsReadOnly();
 
     public Task<ReadOnlyDictionary<int, IReadOnlyList<string>>>
-        GetBaseVerseIdWithOptionalPartByBibleVerseIdMapAsync(int bibleId, CancellationToken cancellationToken)
+        GetBaseVerseIdWithOptionalPartByBibleVerseIdMapAsync(
+            int bibleId,
+            bool shouldFallBackToLanguageDefault,
+            CancellationToken cancellationToken)
     {
         return Task.FromResult(s_baseVerseIdWithOptionalPartByBibleVerseIdMapByBibleIdMap.GetValueOrDefault(bibleId)
             ?? new Dictionary<int, IReadOnlyList<string>>().AsReadOnly());
@@ -391,10 +394,11 @@ public class MockCachingVersificationService : ICachingVersificationService
 
     public async Task<ReadOnlyDictionary<string, IReadOnlyList<int>>> GetBibleVerseIdByBaseVerseIdWithOptionalPartMapAsync(
         int bibleId,
+        bool shouldFallBackToLanguageDefault,
         CancellationToken cancellationToken)
     {
         // this logic should match the CachingVersificationService
-        return (await GetBaseVerseIdWithOptionalPartByBibleVerseIdMapAsync(bibleId, cancellationToken))
+        return (await GetBaseVerseIdWithOptionalPartByBibleVerseIdMapAsync(bibleId, shouldFallBackToLanguageDefault, cancellationToken))
             .SelectMany(kvp => kvp.Value.Select(bvwp => (BibleVerseId: kvp.Key, BaseVerseIdWithOptionalVersePart: bvwp)))
             .GroupBy(vm => vm.BaseVerseIdWithOptionalVersePart)
             .ToDictionary(
@@ -412,25 +416,10 @@ public class MockCachingVersificationService : ICachingVersificationService
         return Task.FromResult(s_excludedVerseIdsByBibleIdMap.GetValueOrDefault(bibleId, new ReadOnlySet<int>(new HashSet<int>())));
     }
 
-    public Task<bool> DoesBibleIncludeBookAsync(int bibleId, BookId bookId, CancellationToken cancellationToken)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<int?> GetMaxChapterNumberForBookAsync(int bibleId, BookId bookId, CancellationToken cancellationToken)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<(int MinVerseNumber, int MaxVerseNumber)?> GetBookendVerseNumbersForChapterAsync(int bibleId, BookId bookId, int chapterNumber, CancellationToken cancellationToken)
-    {
-        throw new NotImplementedException();
-    }
-
     public Task<ReadOnlyDictionary<
             BookId,
             (int MaxChapterNumber,
-                ReadOnlyDictionary<int, (int MinVerseNumber, int MaxVerseNumber)> BookendVerseNumbersByChapterNumberMap)>>
+            ReadOnlyDictionary<int, (int MinVerseNumber, int MaxVerseNumber)> BookendVerseNumbersByChapterNumberMap)>>
         GetMaxChapterNumberAndBookendVerseNumbersByBookIdMapAsync(int bibleId, CancellationToken cancellationToken)
     {
         return Task.FromResult(bibleId switch
@@ -448,5 +437,25 @@ public class MockCachingVersificationService : ICachingVersificationService
             // Return the same max chapters/verses for all other Bibles.
             _ => s_baseMaxChapterNumberAndBookendVerseNumbersByBookIdMap,
         });
+    }
+
+    public Task<bool> DoesBibleIncludeBookAsync(int bibleId, BookId bookId, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<int?> GetMaxChapterNumberForBookAsync(int bibleId, BookId bookId, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<(int MinVerseNumber, int MaxVerseNumber)?> GetBookendVerseNumbersForChapterAsync(int bibleId, BookId bookId, int chapterNumber, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<ReadOnlyDictionary<int, int>> GetDefaultLanguageBibleIdByBibleIdMapAsync(CancellationToken ct)
+    {
+        throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
### Fix Bug

The CMS currently tries to fetch verse 0 mappings so it can handle Psalm superscripts correctly.  Unfortunately, there is no current way to distinguish between when (a) there are no mappings for verse 0 from source -> target and (b) verse 0 doesn't exist in the source Bible.  When this happens the front-end can map to a start verse ID that is greater than an end verse ID:
* `Unexpected versification mapping: sourceStartVerseId: 1019043000; sourceEndVerseId: 1019043001; targetBibleId: 11; targetStartVerseId: 1019043000; targetEndVerseId: 1019042001; languageId: 10`
* [Thread](https://biblionexusworkspace.slack.com/archives/C0662HZ7RKM/p1743600233099929)
* [Repro](https://qa.admin.aquifer.bible/resources/385026)

The only way I could think to solve this bug is to return all versification mappings, even identity mappings which are currently being excluded (e.g. verse 3 -> verse 3) because that's the only way to know if verse 0 is included or not.  If verse 0 is in the source then we'll see a mapping for it in the returned versification data and if it isn't included then that mapping will be missing.

Front-end CMS PR: https://github.com/BiblioNexusStudio/content-manager-web/pull/629

### Fall back to default language Bible versification mappings

I also updated versification mapping to have a fall back.  If the source or target Bible doesn't have any mappings then we try to use the mappings for the language default Bible for the same language.  If that also doesn't have mappings then we continue with the current behavior from before this PR of always doing an identity mapping.  Note that this fallback does _not_ happen for exclusions, just for mappings.

Adding this fall back mostly fixed versification for the other English Bibles by having them use the BSB versification, especially in Psalms where there are a lot of differences between ENG and ORG (base).  The only way to truly fix this is to import correct mapping data for all Bibles but this is a significant improvement when we don't have it.