### PR TITLE
Add first snapshot to the end of the list

### DIFF
--- a/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Resources/Content/Get/Endpoint.cs
@@ -202,7 +202,7 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService) : En
 
                 if (firstVersionSnapshot is not null)
                 {
-                    snapshots.Insert(0, firstVersionSnapshot);
+                    snapshots.Add(firstVersionSnapshot);
                 }
             }
         }


### PR DESCRIPTION
Since the snapshots are ordered by descending createdBy, the earliest created snapshot should be at the end of the list. The CMS expects this, and assumes the first snapshot is at the end of all snapshots, displaying it as the source.

So to fix it, add the snapshot to the end of the list instead of the beginning.