### PR TITLE
Add original English snapshot when source language is not English.

### DIFF
--- a/src/Aquifer.Data/Services/ResourceHistoryService.cs
+++ b/src/Aquifer.Data/Services/ResourceHistoryService.cs
@@ -19,6 +19,14 @@ public interface IResourceHistoryService
         int? oldUserId,
         ResourceContentStatus oldStatus,
         CancellationToken ct);
+
+    Task AddSnapshotHistoryAsync(ResourceContentVersionEntity contentVersionEntity,
+        string content,
+        string displayName,
+        int? wordCount,
+        int? oldUserId,
+        ResourceContentStatus oldStatus,
+        CancellationToken ct);
 }
 
 public class ResourceHistoryService(AquiferDbContext _dbContext) : IResourceHistoryService
@@ -74,18 +82,36 @@ public class ResourceHistoryService(AquiferDbContext _dbContext) : IResourceHist
 
         if (snapshotEntity?.Content != contentVersionEntity.Content)
         {
-            var resourceContentVersionSnapshot = new ResourceContentVersionSnapshotEntity
-            {
-                ResourceContentVersion = contentVersionEntity,
-                Content = contentVersionEntity.Content,
-                DisplayName = contentVersionEntity.DisplayName,
-                WordCount = contentVersionEntity.WordCount,
-                UserId = oldUserId,
-                Status = oldStatus,
-                Created = DateTime.UtcNow
-            };
-
-            await _dbContext.ResourceContentVersionSnapshots.AddAsync(resourceContentVersionSnapshot, ct);
+            await AddSnapshotHistoryAsync(
+                contentVersionEntity,
+                contentVersionEntity.Content,
+                contentVersionEntity.DisplayName,
+                contentVersionEntity.WordCount,
+                oldUserId,
+                oldStatus,
+                ct);
         }
+    }
+
+    public async Task AddSnapshotHistoryAsync(ResourceContentVersionEntity contentVersionEntity,
+        string content,
+        string displayName,
+        int? wordCount,
+        int? oldUserId,
+        ResourceContentStatus oldStatus,
+        CancellationToken ct)
+    {
+        var resourceContentVersionSnapshot = new ResourceContentVersionSnapshotEntity
+        {
+            ResourceContentVersion = contentVersionEntity,
+            Content = content,
+            DisplayName = displayName,
+            WordCount = wordCount,
+            UserId = oldUserId,
+            Status = oldStatus,
+            Created = DateTime.UtcNow
+        };
+
+        await _dbContext.ResourceContentVersionSnapshots.AddAsync(resourceContentVersionSnapshot, ct);
     }
 }


### PR DESCRIPTION
See https://biblionexusworkspace.slack.com/archives/C05K5N7F44Q/p1744137443282489.

Example:

https://qa.admin.aquifer.bible/resources/385220 (English -> Spanish -> Portuguese).

The "Source" snapshot is English, the "{Username} New" snapshot is Spanish (the translation source text), and the newest snapshot is the translation in Portuguese.
![image](https://github.com/user-attachments/assets/5f2a2db6-c047-4b84-9a04-3c5e9d1f4500)
