### PR TITLE
Support generating Aquifer.Well.API client code into BibleWell solution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,12 @@ and [Azure Function Core Tools](https://learn.microsoft.com/en-us/azure/azure-fu
 
 1. Run Azurite so that you can have local queues. In the `aquifer-server` dir, run `azurite`.
 2. Run Aquifer.Jobs using the function core tools. In the `aquifer-server/src/Aquifer.Jobs` run `func start`.
+
+## Client Generation
+
+Aquifer.Well.API supports C# client generation based upon the OpenAPI spec. To generate the client, run:
+```bash
+dotnet run --project src/Aquifer.Well.API --generateclients true
+```
+This command assumes that you have a local clone of the bible-well repo that is sitting in a folder next to this repo.
+Running the command will update the client code in that repo based upon changes to the OpenAPI spec.

--- a/src/Aquifer.Public.API/OpenApi/SwaggerDocumentSettings.cs
+++ b/src/Aquifer.Public.API/OpenApi/SwaggerDocumentSettings.cs
@@ -48,6 +48,7 @@ public static class SwaggerDocumentSettings
                         In = OpenApiSecurityApiKeyLocation.Header,
                         Type = OpenApiSecuritySchemeType.ApiKey
                     });
+                ds.MarkNonNullablePropsAsRequired();
                 ds.SchemaSettings.SchemaProcessors.Add(new EnumSchemaProcessor());
                 ds.OperationProcessors.Add(new DefaultParameterOperationProcessor());
             };

--- a/src/Aquifer.Public.API/OpenApi/SwaggerDocumentSettings.cs
+++ b/src/Aquifer.Public.API/OpenApi/SwaggerDocumentSettings.cs
@@ -1,4 +1,6 @@
-﻿using Aquifer.Public.API.Helpers;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aquifer.Public.API.Helpers;
 using FastEndpoints.Swagger;
 using NSwag;
 
@@ -18,6 +20,11 @@ public static class SwaggerDocumentSettings
             sd.ShortSchemaNames = true;
             sd.EnableJWTBearerAuth = false;
             sd.EndpointFilter = ep => ep.EndpointTags?.Contains(EndpointHelpers.EndpointTags.ExcludeFromSwaggerDocument) != true;
+            sd.SerializerSettings = s =>
+            {
+                s.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+                s.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+            };
             sd.DocumentSettings = ds =>
             {
                 ds.DocumentName = DocumentName;

--- a/src/Aquifer.Well.API/Aquifer.Well.API.csproj
+++ b/src/Aquifer.Well.API/Aquifer.Well.API.csproj
@@ -11,8 +11,12 @@
 
     <ItemGroup>
         <PackageReference Include="FastEndpoints" />
+        <PackageReference Include="FastEndpoints.ClientGen.Kiota" />
+        <PackageReference Include="FastEndpoints.Swagger" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 
 </Project>

--- a/src/Aquifer.Well.API/Endpoints/Languages/List/ListLanguagesEndpoint.cs
+++ b/src/Aquifer.Well.API/Endpoints/Languages/List/ListLanguagesEndpoint.cs
@@ -11,6 +11,12 @@ public class ListLanguagesEndpoint(AquiferDbReadOnlyContext dbContext) : Endpoin
     {
         Get("/languages");
         Options(EndpointHelpers.ServerCacheInSeconds(EndpointHelpers.OneHourInSeconds));
+        Description(d => d.WithTags("Languages"));
+        Summary(s =>
+        {
+            s.Summary = "Return language list.";
+            s.Description = "Return a list of languages that can have associated resources in the Aquifer.";
+        });
     }
 
     public override async Task HandleAsync(CancellationToken ct)

--- a/src/Aquifer.Well.API/Endpoints/Languages/List/ListLanguagesEndpoint.cs
+++ b/src/Aquifer.Well.API/Endpoints/Languages/List/ListLanguagesEndpoint.cs
@@ -11,7 +11,6 @@ public class ListLanguagesEndpoint(AquiferDbReadOnlyContext dbContext) : Endpoin
     {
         Get("/languages");
         Options(EndpointHelpers.ServerCacheInSeconds(EndpointHelpers.OneHourInSeconds));
-        Description(d => d.WithTags("Languages"));
         Summary(s =>
         {
             s.Summary = "Return language list.";

--- a/src/Aquifer.Well.API/Endpoints/Languages/List/ListLanguagesResponse.cs
+++ b/src/Aquifer.Well.API/Endpoints/Languages/List/ListLanguagesResponse.cs
@@ -2,9 +2,9 @@
 
 public record ListLanguagesResponse
 {
-    public int Id { get; init; }
-    public string Code { get; init; } = null!;
-    public string EnglishDisplay { get; init; } = null!;
-    public string LocalizedDisplay { get; init; } = null!;
-    public string ScriptDirection { get; init; } = null!;
+    public required int Id { get; init; }
+    public required string Code { get; init; }
+    public required string EnglishDisplay { get; init; }
+    public required string LocalizedDisplay { get; init; }
+    public required string ScriptDirection { get; init; }
 }

--- a/src/Aquifer.Well.API/Helpers/EndpointHelpers.cs
+++ b/src/Aquifer.Well.API/Helpers/EndpointHelpers.cs
@@ -14,4 +14,9 @@ public static class EndpointHelpers
                 .Expire(TimeSpan.FromSeconds(seconds))
                 .Tag(AnonymousOutputCacheTag));
     }
+
+    public static class EndpointTags
+    {
+        public const string ExcludeFromSwaggerDocument = nameof(ExcludeFromSwaggerDocument);
+    }
 }

--- a/src/Aquifer.Well.API/OpenApi/ClientGenerationSettings.cs
+++ b/src/Aquifer.Well.API/OpenApi/ClientGenerationSettings.cs
@@ -22,6 +22,7 @@ public static class ClientGenerationSettings
             c.ClientNamespaceName = "BibleWell.Aquifer.API.Client";
             c.ClientClassName = "AquiferWellApiClient";
             c.OutputPath = Path.Combine(c.OutputPath, "../../../../bible-well/src/BibleWell.Aquifer.Api/Client");
+            c.ExcludePatterns = ["**/admin/**"];
         });
     }
 }

--- a/src/Aquifer.Well.API/OpenApi/ClientGenerationSettings.cs
+++ b/src/Aquifer.Well.API/OpenApi/ClientGenerationSettings.cs
@@ -1,0 +1,27 @@
+﻿using FastEndpoints.ClientGen.Kiota;
+using Kiota.Builder;
+
+namespace Aquifer.Well.API.OpenApi;
+
+/// <summary>
+/// Generate client code and drop it into the BibleWell repo locally.
+/// See https://fast-endpoints.com/docs/swagger-support#save-to-disk-with-app-run.
+/// Generate the client with <code>dotnet run --project src/Aquifer.Well.API --generateclients true</code>.
+/// We could also generate clients on build if desired.
+/// </summary>
+public static class ClientGenerationSettings
+{
+    public static async Task GenerateApiClientAsync(
+        this IHost app,
+        string swaggerDocumentName)
+    {
+        await app.GenerateApiClientsAndExitAsync(c =>
+        {
+            c.SwaggerDocumentName = swaggerDocumentName;
+            c.Language = GenerationLanguage.CSharp;
+            c.ClientNamespaceName = "BibleWell.Aquifer.API.Client";
+            c.ClientClassName = "AquiferWellApiClient";
+            c.OutputPath = Path.Combine(c.OutputPath, "../../../../bible-well/src/BibleWell.Aquifer.Api/Client");
+        });
+    }
+}

--- a/src/Aquifer.Well.API/OpenApi/DefaultParameterOperationProcessor.cs
+++ b/src/Aquifer.Well.API/OpenApi/DefaultParameterOperationProcessor.cs
@@ -1,0 +1,39 @@
+﻿using System.ComponentModel;
+using System.Reflection;
+using NSwag.Generation.AspNetCore;
+using NSwag.Generation.Processors;
+using NSwag.Generation.Processors.Contexts;
+
+namespace Aquifer.Well.API.OpenApi;
+
+public class DefaultParameterOperationProcessor : IOperationProcessor
+{
+    public bool Process(OperationProcessorContext context)
+    {
+        var dtoType = ((AspNetCoreOperationProcessorContext)context).ApiDescription.ParameterDescriptions
+            .FirstOrDefault()?.Type;
+
+        if (dtoType is null)
+        {
+            return true;
+        }
+
+        foreach (var parameter in context.OperationDescription.Operation.Parameters)
+        {
+            var property = dtoType.GetProperty(parameter.Name,
+                BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+            if (HasDefaultValue(property))
+            {
+                parameter.IsRequired = false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool HasDefaultValue(PropertyInfo? property)
+    {
+        return property?.GetCustomAttributes(typeof(DefaultValueAttribute), false)
+            .FirstOrDefault() is DefaultValueAttribute;
+    }
+}

--- a/src/Aquifer.Well.API/OpenApi/EnumSchemaProcessor.cs
+++ b/src/Aquifer.Well.API/OpenApi/EnumSchemaProcessor.cs
@@ -1,0 +1,22 @@
+﻿using NJsonSchema;
+using NJsonSchema.Generation;
+
+namespace Aquifer.Well.API.OpenApi;
+
+public class EnumSchemaProcessor : ISchemaProcessor
+{
+    public void Process(SchemaProcessorContext context)
+    {
+        if (!context.ContextualType.Type.IsEnum)
+        {
+            return;
+        }
+
+        context.Schema.Enumeration.Clear();
+        context.Schema.Type = JsonObjectType.String;
+        context.Schema.Format = null;
+        Enum.GetNames(context.ContextualType.Type)
+            .ToList()
+            .ForEach(context.Schema.Enumeration.Add);
+    }
+}

--- a/src/Aquifer.Well.API/OpenApi/SwaggerDocumentSettings.cs
+++ b/src/Aquifer.Well.API/OpenApi/SwaggerDocumentSettings.cs
@@ -1,0 +1,44 @@
+﻿using Aquifer.Well.API.Helpers;
+using FastEndpoints.Swagger;
+using NSwag;
+
+namespace Aquifer.Well.API.OpenApi;
+
+public static class SwaggerDocumentSettings
+{
+    public const string DocumentName = "v1";
+
+    public static IServiceCollection AddSwaggerDocumentSettings(this IServiceCollection services)
+    {
+        return services.SwaggerDocument(sd =>
+        {
+            // turn off auto-grouping (but now must manually tag each endpoint using `WithTags()`)
+            sd.AutoTagPathSegmentIndex = 0;
+
+            sd.ShortSchemaNames = true;
+            sd.EnableJWTBearerAuth = false;
+            sd.EndpointFilter = ep => ep.EndpointTags?.Contains(EndpointHelpers.EndpointTags.ExcludeFromSwaggerDocument) != true;
+            sd.DocumentSettings = ds =>
+            {
+                ds.DocumentName = DocumentName;
+                ds.Title = "Aquifer Well API Documentation";
+                ds.Description = "All endpoints require an API key in the `api-key` header.";
+                ds.AddAuth(
+                    "ApiKey",
+                    new OpenApiSecurityScheme
+                    {
+                        Name = "api-key",
+                        In = OpenApiSecurityApiKeyLocation.Header,
+                        Type = OpenApiSecuritySchemeType.ApiKey
+                    });
+                ds.SchemaSettings.SchemaProcessors.Add(new EnumSchemaProcessor());
+                ds.OperationProcessors.Add(new DefaultParameterOperationProcessor());
+            };
+            sd.TagDescriptions = td =>
+            {
+                td["Languages"] = "Endpoints for pulling data specific to languages.";
+                td["Bibles"] = "Endpoints for discovering available Bibles and pulling down Bible text and audio information.";
+            };
+        });
+    }
+}

--- a/src/Aquifer.Well.API/OpenApi/SwaggerDocumentSettings.cs
+++ b/src/Aquifer.Well.API/OpenApi/SwaggerDocumentSettings.cs
@@ -15,9 +15,6 @@ public static class SwaggerDocumentSettings
         return services
             .SwaggerDocument(sd =>
         {
-            // turn off auto-grouping (but now must manually tag each endpoint using `WithTags()`)
-            sd.AutoTagPathSegmentIndex = 0;
-
             sd.ShortSchemaNames = true;
             sd.EnableJWTBearerAuth = false;
             sd.EndpointFilter = ep => ep.EndpointTags?.Contains(EndpointHelpers.EndpointTags.ExcludeFromSwaggerDocument) != true;

--- a/src/Aquifer.Well.API/OpenApi/SwaggerDocumentSettings.cs
+++ b/src/Aquifer.Well.API/OpenApi/SwaggerDocumentSettings.cs
@@ -1,4 +1,6 @@
-﻿using Aquifer.Well.API.Helpers;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aquifer.Well.API.Helpers;
 using FastEndpoints.Swagger;
 using NSwag;
 
@@ -19,6 +21,11 @@ public static class SwaggerDocumentSettings
             sd.ShortSchemaNames = true;
             sd.EnableJWTBearerAuth = false;
             sd.EndpointFilter = ep => ep.EndpointTags?.Contains(EndpointHelpers.EndpointTags.ExcludeFromSwaggerDocument) != true;
+            sd.SerializerSettings = s =>
+            {
+                s.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+                s.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+            };
             sd.DocumentSettings = ds =>
             {
                 ds.DocumentName = DocumentName;

--- a/src/Aquifer.Well.API/OpenApi/SwaggerDocumentSettings.cs
+++ b/src/Aquifer.Well.API/OpenApi/SwaggerDocumentSettings.cs
@@ -10,7 +10,8 @@ public static class SwaggerDocumentSettings
 
     public static IServiceCollection AddSwaggerDocumentSettings(this IServiceCollection services)
     {
-        return services.SwaggerDocument(sd =>
+        return services
+            .SwaggerDocument(sd =>
         {
             // turn off auto-grouping (but now must manually tag each endpoint using `WithTags()`)
             sd.AutoTagPathSegmentIndex = 0;
@@ -31,6 +32,7 @@ public static class SwaggerDocumentSettings
                         In = OpenApiSecurityApiKeyLocation.Header,
                         Type = OpenApiSecuritySchemeType.ApiKey
                     });
+                ds.MarkNonNullablePropsAsRequired();
                 ds.SchemaSettings.SchemaProcessors.Add(new EnumSchemaProcessor());
                 ds.OperationProcessors.Add(new DefaultParameterOperationProcessor());
             };

--- a/src/Aquifer.Well.API/Program.cs
+++ b/src/Aquifer.Well.API/Program.cs
@@ -8,6 +8,7 @@ using Aquifer.Common.Services.Caching;
 using Aquifer.Data;
 using Aquifer.Data.Entities;
 using Aquifer.Well.API.Configuration;
+using Aquifer.Well.API.OpenApi;
 using Aquifer.Well.API.Telemetry;
 using FastEndpoints;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -39,6 +40,7 @@ builder.Services
     .AddTrackResourceContentRequestServices()
     .AddSingleton<ITelemetryInitializer, RequestTelemetryInitializer>()
     .AddAzureClient(builder.Environment.IsDevelopment())
+    .AddSwaggerDocumentSettings()
     .AddOutputCache()
     .AddApplicationInsightsTelemetry()
     .AddHealthChecks()
@@ -55,6 +57,12 @@ app.UseHealthChecks("/_health")
     .UseMiddleware<ApiKeyAuthorizationMiddleware>()
     .UseResponseCaching()
     .UseOutputCache()
+    .UseOpenApi()
+    .UseReDoc(options =>
+    {
+        options.Path = "/docs";
+        options.DocumentTitle = "Aquifer Well API Documentation";
+    })
     .UseFastEndpoints(
         config =>
         {
@@ -63,5 +71,7 @@ app.UseHealthChecks("/_health")
             config.Versioning.Prefix = "v";
         })
     .UseResponseCachingVaryByAllQueryKeys();
+
+await app.GenerateApiClientAsync(SwaggerDocumentSettings.DocumentName);
 
 app.Run();

--- a/src/Aquifer.Well.API/Program.cs
+++ b/src/Aquifer.Well.API/Program.cs
@@ -58,11 +58,6 @@ app.UseHealthChecks("/_health")
     .UseResponseCaching()
     .UseOutputCache()
     .UseOpenApi()
-    .UseReDoc(options =>
-    {
-        options.Path = "/docs";
-        options.DocumentTitle = "Aquifer Well API Documentation";
-    })
     .UseFastEndpoints(
         config =>
         {


### PR DESCRIPTION
Also, fixes regression with latest FastEndpoints update where the OpenAPI spec switched from camelCase properties to PascalCase properties.  JSON is case-sensitive so the Kiota generated client is also case-sensitive and this change broke the generated clients for the Public API (we haven't deployed the regression commit to prod yet).  This PR fixes that only for response properties.  I couldn't figure out request query string parameter casing and opened a FastEndpoints issue: https://github.com/FastEndpoints/FastEndpoints/issues/947.  Technically speaking, PascalCase should be accepted in query strings on the server so there's no breaking change.  I still want to fix it if we get a good answer from them, though.

See https://github.com/BiblioNexusStudio/bible-well/pull/50 for usage.