### PR TITLE
Fix OpenAPI spec query param property name casing.

### DIFF
--- a/src/Aquifer.Public.API/OpenApi/SwaggerDocumentSettings.cs
+++ b/src/Aquifer.Public.API/OpenApi/SwaggerDocumentSettings.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json;
-using System.Text.Json.Serialization;
-using Aquifer.Public.API.Helpers;
+﻿using Aquifer.Public.API.Helpers;
 using FastEndpoints.Swagger;
 using NSwag;
 
@@ -20,11 +18,6 @@ public static class SwaggerDocumentSettings
             sd.ShortSchemaNames = true;
             sd.EnableJWTBearerAuth = false;
             sd.EndpointFilter = ep => ep.EndpointTags?.Contains(EndpointHelpers.EndpointTags.ExcludeFromSwaggerDocument) != true;
-            sd.SerializerSettings = s =>
-            {
-                s.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-                s.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
-            };
             sd.DocumentSettings = ds =>
             {
                 ds.DocumentName = DocumentName;

--- a/src/Aquifer.Public.API/Program.cs
+++ b/src/Aquifer.Public.API/Program.cs
@@ -34,6 +34,7 @@ builder.Services
             .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking))
     .AddScoped<AquiferDbContext, AquiferDbReadOnlyContext>()
     .Configure<JsonOptions>(options => options.SerializerOptions.Converters.Add(new JsonStringEnumConverter()))
+    .AddSwaggerDocumentSettings()
     .AddFastEndpoints()
     .AddMemoryCache()
     .AddCachingServices()
@@ -41,7 +42,6 @@ builder.Services
     .AddTrackResourceContentRequestServices()
     .AddSingleton<ITelemetryInitializer, RequestTelemetryInitializer>()
     .AddAzureClient(builder.Environment.IsDevelopment())
-    .AddSwaggerDocumentSettings()
     .AddOutputCache()
     .AddApplicationInsightsTelemetry()
     .AddHealthChecks()
@@ -57,6 +57,11 @@ StaticLoggerFactory.LoggerFactory = app.Services.GetRequiredService<ILoggerFacto
 app.UseHealthChecks("/_health")
     .UseResponseCaching()
     .UseOutputCache()
+    .UseFastEndpoints(config =>
+    {
+        config.Serializer.Options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        config.Endpoints.Configurator = ep => ep.AllowAnonymous();
+    })
     .UseOpenApi()
     .UseReDoc(options =>
     {
@@ -66,11 +71,6 @@ app.UseHealthChecks("/_health")
         options.DocumentTitle = "Aquifer API Documentation";
     })
     .UseMiddleware<ApiKeyAuthorizationMiddleware>()
-    .UseFastEndpoints(config =>
-    {
-        config.Serializer.Options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-        config.Endpoints.Configurator = ep => ep.AllowAnonymous();
-    })
     .UseResponseCachingVaryByAllQueryKeys();
 
 app.ConfigureClientGeneration(SwaggerDocumentSettings.DocumentName, TimeSpan.FromDays(365));

--- a/src/Aquifer.Well.API/OpenApi/SwaggerDocumentSettings.cs
+++ b/src/Aquifer.Well.API/OpenApi/SwaggerDocumentSettings.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json;
-using System.Text.Json.Serialization;
-using Aquifer.Well.API.Helpers;
+﻿using Aquifer.Well.API.Helpers;
 using FastEndpoints.Swagger;
 using NSwag;
 
@@ -18,11 +16,6 @@ public static class SwaggerDocumentSettings
             sd.ShortSchemaNames = true;
             sd.EnableJWTBearerAuth = false;
             sd.EndpointFilter = ep => ep.EndpointTags?.Contains(EndpointHelpers.EndpointTags.ExcludeFromSwaggerDocument) != true;
-            sd.SerializerSettings = s =>
-            {
-                s.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-                s.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
-            };
             sd.DocumentSettings = ds =>
             {
                 ds.DocumentName = DocumentName;

--- a/src/Aquifer.Well.API/Program.cs
+++ b/src/Aquifer.Well.API/Program.cs
@@ -32,6 +32,7 @@ builder.Services
             .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking))
     .AddScoped<AquiferDbContext, AquiferDbReadOnlyContext>()
     .Configure<JsonOptions>(options => options.SerializerOptions.Converters.Add(new JsonStringEnumConverter()))
+    .AddSwaggerDocumentSettings()
     .AddFastEndpoints()
     .AddMemoryCache()
     .AddScoped<ICachingLanguageService, CachingLanguageService>()
@@ -40,7 +41,6 @@ builder.Services
     .AddTrackResourceContentRequestServices()
     .AddSingleton<ITelemetryInitializer, RequestTelemetryInitializer>()
     .AddAzureClient(builder.Environment.IsDevelopment())
-    .AddSwaggerDocumentSettings()
     .AddOutputCache()
     .AddApplicationInsightsTelemetry()
     .AddHealthChecks()
@@ -57,7 +57,6 @@ app.UseHealthChecks("/_health")
     .UseMiddleware<ApiKeyAuthorizationMiddleware>()
     .UseResponseCaching()
     .UseOutputCache()
-    .UseOpenApi()
     .UseFastEndpoints(
         config =>
         {
@@ -65,6 +64,7 @@ app.UseHealthChecks("/_health")
             config.Endpoints.Configurator = ep => ep.AllowAnonymous();
             config.Versioning.Prefix = "v";
         })
+    .UseOpenApi()
     .UseResponseCachingVaryByAllQueryKeys();
 
 await app.GenerateApiClientAsync(SwaggerDocumentSettings.DocumentName);


### PR DESCRIPTION
It turns out that the ordering of `app.UseOpenAPI()` and `app.UseFastEndpoints()` matters.

See https://github.com/FastEndpoints/FastEndpoints/issues/947 for details.