### PR TITLE
Add ReviewLevel for resources

### DIFF
--- a/src/Aquifer.Public.API/Endpoints/Resources/Get/ResourceHelper.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Get/ResourceHelper.cs
@@ -26,6 +26,7 @@ public static class ResourceHelper
                 ReferenceId = x.ResourceContent.ResourceId,
                 Name = x.ResourceContent.Resource.EnglishLabel,
                 LocalizedName = x.DisplayName,
+                ReviewLevel = x.ReviewLevel,
                 ContentValue = x.Content,
                 Language = new ResourceContentLanguage
                 {

--- a/src/Aquifer.Public.API/Endpoints/Resources/Get/Response.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Get/Response.cs
@@ -9,6 +9,8 @@ public class Response
     public int ReferenceId { get; set; }
     public string Name { get; set; } = null!;
     public string LocalizedName { get; set; } = null!;
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public ResourceContentVersionReviewLevel ReviewLevel { get; set; }
 
     /// <summary>
     /// DB Value (Tiptap string).

--- a/src/Aquifer.Public.API/Endpoints/Resources/Search/GetResources/Endpoint.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Search/GetResources/Endpoint.cs
@@ -116,6 +116,7 @@ public class Endpoint(AquiferDbReadOnlyContext dbContext, ICachingLanguageServic
                 Id = x.ResourceContent.Id,
                 Name = x.ResourceContent.Resource.EnglishLabel,
                 LocalizedName = x.DisplayName,
+                ReviewLevel = x.ReviewLevel,
                 LanguageCode = languageCodeByIdMap[x.ResourceContent.LanguageId],
                 MediaType = x.ResourceContent.MediaType,
                 Grouping = new ResourceTypeMetadata

--- a/src/Aquifer.Public.API/Endpoints/Resources/Search/GetResources/Response.cs
+++ b/src/Aquifer.Public.API/Endpoints/Resources/Search/GetResources/Response.cs
@@ -1,4 +1,5 @@
-﻿using Aquifer.Data.Entities;
+﻿using System.Text.Json.Serialization;
+using Aquifer.Data.Entities;
 
 namespace Aquifer.Public.API.Endpoints.Resources.Search.GetResources;
 
@@ -15,6 +16,8 @@ public class ResponseContent
     public int Id { get; set; }
     public string Name { get; set; } = null!;
     public string LocalizedName { get; set; } = null!;
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public ResourceContentVersionReviewLevel ReviewLevel { get; set; }
 
     public ResourceContentMediaType MediaType { get; set; }
 


### PR DESCRIPTION
The content team has a need to be able to discern AI-generated content from non-AI-generated content.
This allows them to easily determine the review level of content when querying the public api.