### PR TITLE
Revert Azure login action to use credentials instead of OIDC inputs

### DIFF
--- a/.github/actions/deploy-to-env/action.yml
+++ b/.github/actions/deploy-to-env/action.yml
@@ -17,14 +17,8 @@ inputs:
     web-app-name:
         description: Azure Web App name
         required: true
-    azure-client-id:
-        description: Azure Client ID
-        required: true
-    azure-tenant-id:
-        description: Azure Tenant ID
-        required: true
-    azure-subscription-id:
-        description: Azure Subscription ID
+    azure-credentials:
+        description: Azure credentials JSON (contains clientId, clientSecret, subscriptionId, tenantId)
         required: true
     linear-api-key:
         description: Linear API key
@@ -64,9 +58,7 @@ runs:
         - name: Login to Azure
           uses: azure/login@v2.2.0
           with:
-              client-id: ${{ inputs.azure-client-id }}
-              tenant-id: ${{ inputs.azure-tenant-id }}
-              subscription-id: ${{ inputs.azure-subscription-id }}
+              creds: ${{ inputs.azure-credentials }}
         - name: Make migration script executable
           if: ${{ inputs.connection-url != '' }}
           run: chmod +x ./build/Migrate


### PR DESCRIPTION
- Change Azure login from OIDC (client-id, tenant-id, subscription-id) back to credentials JSON
- Replace three separate Azure input parameters with single azure-credentials input
- Update login action to use creds parameter instead of individual OIDC parameters