### PR TITLE
Fix allow translation draft complete project create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -403,8 +403,8 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 *.DotSettings.user
-appsettings.Development.json
-appsettings.Production.json
+appsettings.Development*
+appsettings.Production*
 .idea/
 
 # Local queue development

--- a/src/Aquifer.API/Endpoints/Projects/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Projects/Create/Endpoint.cs
@@ -401,11 +401,11 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService, IRes
                 ThrowError(r => r.ResourceIds, "One or more resources are already in a project.");
             }
 
-            if (existingResourceContent.Status != ResourceContentStatus.TranslationAwaitingAiDraft)
+            if (existingResourceContent.Status is not (ResourceContentStatus.TranslationAwaitingAiDraft or ResourceContentStatus.TranslationAiDraftComplete))
             {
                 ThrowError(
                     r => r.ResourceIds,
-                    "One or more resources exist but are not in TranslationAwaitingAiDraft status.");
+                    "One or more resources exist but are not in TranslationAwaitingAiDraft or TranslationAiDraftComplete status.");
             }
 
             var existingVersion = existingResourceContent.Versions.FirstOrDefault(v => v.IsDraft);


### PR DESCRIPTION
This is to allow project creation with resources that already have completed AI drafts but have not been worked yet. This can be seen as a temporary action. It was precipitated by limited project management capabilities.