### PR TITLE
Add OpenAI reasoning model support with configurable temperature, rea…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,7 +58,7 @@
         </PackageVersion>
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageVersion Include="OpenAI" Version="2.1.0" />
+        <PackageVersion Include="OpenAI" Version="2.3.0" />
         <PackageVersion Include="Polly" Version="8.5.2" />
         <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
         <PackageVersion Include="ReverseMarkdown" Version="4.6.0" />

--- a/src/Aquifer.AI/Aquifer.AI.csproj
+++ b/src/Aquifer.AI/Aquifer.AI.csproj
@@ -11,6 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="Aquifer.Jobs.UnitTests" />
         <ProjectReference Include="..\Aquifer.Common\Aquifer.Common.csproj" />
     </ItemGroup>
 

--- a/src/Aquifer.AI/OpenAiTranslationService.cs
+++ b/src/Aquifer.AI/OpenAiTranslationService.cs
@@ -35,6 +35,21 @@ public interface ITranslationService
 public class OpenAiOptions
 {
     public required string Model { get; init; }
+
+    /// <summary>
+    /// Whether the configured model accepts a temperature value. Reasoning models (e.g. GPT-5 and o-series) reject it.
+    /// </summary>
+    public bool SupportsTemperature { get; init; } = true;
+
+    /// <summary>
+    /// Optional reasoning effort for reasoning models (e.g. "low", "medium", "high"). Not sent when null.
+    /// </summary>
+    public string? ReasoningEffortLevel { get; init; }
+
+    /// <summary>
+    /// Optional max output token count. Not sent when null.
+    /// </summary>
+    public int? MaxOutputTokens { get; init; }
 }
 
 public sealed class OpenAiTranslationOptions
@@ -59,6 +74,7 @@ public sealed partial class OpenAiTranslationService : ITranslationService
 
     private readonly ChatClient _chatClient;
 
+    private readonly OpenAiOptions _openAiOptions;
     private readonly OpenAiTranslationOptions _options;
     private readonly float _temperature;
 
@@ -67,6 +83,7 @@ public sealed partial class OpenAiTranslationService : ITranslationService
         OpenAiOptions openAiOptions,
         IAzureKeyVaultClient keyVaultClient)
     {
+        _openAiOptions = openAiOptions;
         _options = openAiTranslationOptions;
 
         const string openAiApiKeySecretName = "OpenAiApiKey";
@@ -185,10 +202,7 @@ public sealed partial class OpenAiTranslationService : ITranslationService
                 ChatMessage.CreateUserMessage(text),
             ],
             // DO NOT reuse ChatCompletionOptions because the Open AI client mutates this object under the hood
-            new ChatCompletionOptions
-            {
-                Temperature = _temperature,
-            },
+            CreateChatCompletionOptions(_openAiOptions, _temperature),
             cancellationToken);
 
         if (chatCompletion.Value.FinishReason != ChatFinishReason.Stop)
@@ -200,6 +214,30 @@ public sealed partial class OpenAiTranslationService : ITranslationService
         }
 
         return chatCompletion.Value.Content[0].Text.Replace(Environment.NewLine, "");
+    }
+
+    internal static ChatCompletionOptions CreateChatCompletionOptions(OpenAiOptions openAiOptions, float temperature)
+    {
+        var options = new ChatCompletionOptions();
+
+        if (openAiOptions.SupportsTemperature)
+        {
+            options.Temperature = temperature;
+        }
+
+#pragma warning disable OPENAI001 // ReasoningEffortLevel is experimental in the OpenAI SDK
+        if (openAiOptions.ReasoningEffortLevel is not null)
+        {
+            options.ReasoningEffortLevel = new ChatReasoningEffortLevel(openAiOptions.ReasoningEffortLevel);
+        }
+#pragma warning restore OPENAI001
+
+        if (openAiOptions.MaxOutputTokens is not null)
+        {
+            options.MaxOutputTokenCount = openAiOptions.MaxOutputTokens.Value;
+        }
+
+        return options;
     }
 
     private string GetHtmlTranslationPrompt((string Iso6393Code, string EnglishName) destinationLanguage)

--- a/src/Aquifer.Jobs/appsettings.json
+++ b/src/Aquifer.Jobs/appsettings.json
@@ -33,7 +33,10 @@
         "SendProjectStartedNotificationTemplateId": "d-7760ec3b5ce34b179384d4783cc1bd81"
     },
     "OpenAi": {
-        "Model": "gpt-4o"
+        "Model": "gpt-4o",
+        "SupportsTemperature": true,
+        "ReasoningEffortLevel": null,
+        "MaxOutputTokens": null
     },
     "OpenAiTranslation": {
         "HtmlBasePrompt": "You receive HTML and then return the HTML with an altered version of the text therein. Never change the formatting of the HTML elements or attributes. For example, if text has an <em> tag around it or a <span> tag with attributes, that tag and its attributes should stay with the text even if it is simplified or moved within the text. Keep the HTML tags and attributes no matter what. Never add a missing html element (i.e. if something starts with <p> but the end is missing </p>, don't add it). Never remove '&nbsp;'.",

--- a/tests/Aquifer.Jobs.UnitTests/Services/OpenAiTranslationServiceTests.cs
+++ b/tests/Aquifer.Jobs.UnitTests/Services/OpenAiTranslationServiceTests.cs
@@ -1,0 +1,73 @@
+using Aquifer.AI;
+using OpenAI.Chat;
+
+#pragma warning disable OPENAI001 // ReasoningEffortLevel is experimental in the OpenAI SDK
+
+namespace Aquifer.Jobs.UnitTests.Services;
+
+public sealed class OpenAiTranslationServiceTests
+{
+    private const float Temperature = 0.2f;
+
+    private static OpenAiOptions CreateOptions()
+    {
+        return new OpenAiOptions
+        {
+            Model = "gpt-4o",
+        };
+    }
+
+    [Fact]
+    public void CreateChatCompletionOptions_WhenTemperatureIsSupported_ShouldSetTemperature()
+    {
+        var options = OpenAiTranslationService.CreateChatCompletionOptions(CreateOptions(), Temperature);
+
+        Assert.Equal(Temperature, options.Temperature);
+    }
+
+    [Fact]
+    public void CreateChatCompletionOptions_WhenTemperatureIsNotSupported_ShouldNotSetTemperature()
+    {
+        var options = OpenAiTranslationService.CreateChatCompletionOptions(
+            new OpenAiOptions { Model = "gpt-5", SupportsTemperature = false },
+            Temperature);
+
+        Assert.Null(options.Temperature);
+    }
+
+    [Fact]
+    public void CreateChatCompletionOptions_WhenReasoningEffortLevelIsNotConfigured_ShouldNotSetReasoningEffortLevel()
+    {
+        var options = OpenAiTranslationService.CreateChatCompletionOptions(CreateOptions(), Temperature);
+
+        Assert.Null(options.ReasoningEffortLevel);
+    }
+
+    [Fact]
+    public void CreateChatCompletionOptions_WhenReasoningEffortLevelIsConfigured_ShouldSetReasoningEffortLevel()
+    {
+        var options = OpenAiTranslationService.CreateChatCompletionOptions(
+            new OpenAiOptions { Model = "gpt-5", ReasoningEffortLevel = "low" },
+            Temperature);
+
+        Assert.Equal(ChatReasoningEffortLevel.Low, options.ReasoningEffortLevel);
+    }
+
+    [Fact]
+    public void CreateChatCompletionOptions_WhenMaxOutputTokensIsNotConfigured_ShouldNotSetMaxOutputTokenCount()
+    {
+        var options = OpenAiTranslationService.CreateChatCompletionOptions(CreateOptions(), Temperature);
+
+        Assert.Null(options.MaxOutputTokenCount);
+    }
+
+    [Fact]
+    public void CreateChatCompletionOptions_WhenMaxOutputTokensIsConfigured_ShouldSetMaxOutputTokenCount()
+    {
+        var options = OpenAiTranslationService.CreateChatCompletionOptions(
+            new OpenAiOptions { Model = "gpt-4o", MaxOutputTokens = 1_000 },
+            Temperature);
+
+        Assert.Equal(1_000, options.MaxOutputTokenCount);
+    }
+}


### PR DESCRIPTION
…soning effort, and max tokens

- Upgrade OpenAI package from 2.1.0 to 2.3.0
- Add SupportsTemperature flag to OpenAiOptions to handle models that reject temperature (e.g. GPT-5, o-series)
- Add optional ReasoningEffortLevel configuration for reasoning models
- Add optional MaxOutputTokens configuration
- Extract ChatCompletionOptions creation logic to testable internal method
- Add unit tests for ChatCompletionOptions creation with various configurations
- Add In