### PR TITLE
Restructure README and add comprehensive documentation for architectu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,124 +1,40 @@
-## Description
+# Aquifer Server
 
-Aquifer Server is the back-end server allowing access to data in the Aquifer.
+The back end of the [Aquifer](https://aquifer.bible) platform: three ASP.NET
+Core APIs plus background jobs over a single Azure SQL database, serving
+biblical translation resources to the apps in the
+[eten-tech ecosystem](docs/ecosystem.md).
 
-## Setup
+| API | Audience | Auth |
+|---|---|---|
+| `Aquifer.API` | Internal apps (content-manager-web, well-web) | Auth0 JWT / API key |
+| `Aquifer.Public.API` | External consumers | API key |
+| `Aquifer.Well.API` | bible-well mobile app | API key |
 
-- Make sure you have the [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) installed
-
-## Installation
+## Quickstart
 
 ```bash
+# 1. Install the .NET 9 SDK (see global.json)
+
+# 2. Configure settings for the project you want to run
+cp src/Aquifer.API/appsettings.example.json src/Aquifer.API/appsettings.Development.json
+#    ...fill in values for your environment...
+
+# 3. Run
 dotnet restore
-```
-
-Copy `appsettings.example.json` as `appsettings.Development.json` and provide the values needed for your instance.
-If you want multiple instances of this file, create them per environment and set your ASPNETCORE_ENVIRONMENT
-accordingly. For example: `dotnet run --environment Production`. Environment configurations have no reason
-to be checked in.
-
-## Running the app
-
-```bash
-# with hot reload
 dotnet watch run --project src/Aquifer.API
-
-# normal mode
-dotnet run --project src/Aquifer.API
 ```
 
-## CLI REPL
+Everything beyond this — EF migrations, running the jobs locally with
+Azurite, API client generation, lint/test — is in
+[docs/development.md](docs/development.md).
 
-If you want to use the REPL outside of an IDE, csharprepl is a good option.
+## Documentation
 
-```bash
-# install
-dotnet tool install -g csharprepl
-
-# run
-csharprepl
-```
-
-Then load the project from the csharprepl prompt: `#r "src/Aquifer.API/Aquifer.API.csproj"`
-
-## Lint
-
-```bash
-dotnet build --no-incremental /p:WarningsAsErrors=true
-```
-
-## Database Migrations
-
-***Important***: Initialize the settings file in the `src/Aquifer.Migrations` directory by copying `appsettings.example.json` as
-`appsettings.Development.json` and providing
-the values needed for your instance.
-
-Entity Framework will generate migrations by comparing the C# Entities defined
-in the project and the current state of the database.
-
-### Add New Entity/Migration
-
-First, create your entity in the `Aquifer.Data/Entities` directory.
-
-Next, add your entity definition to the `src/Aquifer.Data/AquiferDbContext.cs` file.
-Entities are listed in an alphabetical order.
-
-### Create a New Migration
-
-To create a new migration, run:
-
-```bash
-dotnet ef migrations add --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --context AquiferDbContext <MigrationNameHere>
-```
-
-Your new migration will be created in the `src/Aquifer.Data/Migrations` directory along with the `.Designer` file and updated
-`AquiferDbContextModelSnapshot.cs` file.
-
-If you run that command and the new migration file is empty, that means there
-were no changes detected between the C# Entities and the database. You can use
-this to your advantage to create empty migrations and add your own custom code.
-
-To see all migrations (useful before applying them to the DB), run:
-
-```bash
-dotnet ef migrations list --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --context AquiferDbContext
-```
-
-To run migrations and add your changes to the DB, run:
-
-```bash
-dotnet ef database update --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --context AquiferDbContext
-```
-
-To remove the last migration (useful when developing locally), run:
-
-```bash
-dotnet ef migrations remove --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --context AquiferDbContext
-```
-
-## Test
-
-```bash
-# unit tests
-dotnet test
-```
-
-## Jobs/Queues
-
-We use Azure Storage Queues and Azure Functions for queueing and running jobs. To develop locally, you'll need
-[Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=visual-studio,blob-storage)
-and [Azure Function Core Tools](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local).
-
-1. Run Azurite so that you can have local queues. In the `aquifer-server` dir, run `azurite`.
-2. Run Aquifer.Jobs using the function core tools. In the `aquifer-server/src/Aquifer.Jobs` run `func start`.
-
-## Client Generation
-
-Aquifer.Well.API supports C# client generation based upon the OpenAPI spec. To generate the client, run:
-
-```bash
-dotnet run --project src/Aquifer.Well.API --generateclients true
-```
-
-This command assumes that you have a local clone of the bible-well repo that is sitting in a folder next to this repo.
-Running the command will update the client code in that repo based upon changes to the OpenAPI spec.
+| Doc | What's in it |
+|---|---|
+| [docs/ecosystem.md](docs/ecosystem.md) | **Start here if you're new.** How all the repos in the org fit together |
+| [docs/architecture.md](docs/architecture.md) | The three APIs, project map, content format, background jobs, key flows |
+| [docs/database.md](docs/database.md) | Domain model, key tables, and schema conventions |
+| [docs/development.md](docs/development.md) | Setup, migrations, jobs, client generation, lint/test |
+| [docs/infrastructure.md](docs/infrastructure.md) | Azure SQL auth, managed identities, GitHub Actions OIDC |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,123 @@
+# Architecture
+
+`aquifer-server` is the back end of the Aquifer platform. It owns the single
+Azure SQL database and exposes it through three separate ASP.NET Core APIs
+(plus background jobs), each aimed at a different audience. For how this repo
+fits with the others in the org, see [ecosystem.md](ecosystem.md).
+
+## The three APIs
+
+All three APIs share the same data layer (`Aquifer.Data`), use FastEndpoints,
+and are deployed as separate Azure Web Apps. They are separate apps — rather
+than one API with varying auth — so that each can scale, deploy, and apply
+rate-limiting/caching policies independently.
+
+| App | Audience | Auth | Local port | Production |
+|---|---|---|---|---|
+| `Aquifer.API` | Internal apps: content-manager-web, well-web, marketing site | Auth0 JWT (users) **or** API key (scope `InternalApi`); `/marketing` routes are API-key-only | 5257 | `api-bn.aquifer.bible` |
+| `Aquifer.Public.API` | External consumers of Aquifer content | API key (scope `PublicApi`) | 5187 | `api.aquifer.bible` |
+| `Aquifer.Well.API` | bible-well mobile app (discontinued — see [ecosystem.md](ecosystem.md)) | API key (scope `WellApi`) | 5139 | `api-well.aquifer.bible` |
+
+Notes:
+
+- API keys are stored hashed in the `ApiKeys` table and checked by
+  `ApiKeyAuthorizationMiddleware` (cached via `CachingApiKeyService`).
+- `Aquifer.Well.API` is deliberately slim: it exposes exactly what the mobile
+  app needs to sync content, and its OpenAPI spec is the source for the
+  Kiota-generated C# client in the bible-well repo (see
+  [development.md](development.md#client-generation)).
+- `Aquifer.Public.API` owns its OpenAPI documentation (`OpenApi/`), which is
+  what external integrators see; keep it accurate.
+
+## Project map
+
+| Project | Purpose |
+|---|---|
+| `Aquifer.API` | Internal API (admin CMS operations, reporting, content workflow) |
+| `Aquifer.Public.API` | Public content-consumption API |
+| `Aquifer.Well.API` | Mobile sync API for bible-well |
+| `Aquifer.Data` | EF Core `DbContext`, entities, migrations, event handlers. The only project that talks to the database schema directly |
+| `Aquifer.Migrations` | Startup project for running EF migrations (used by the CLI commands and by CI/CD) |
+| `Aquifer.Common` | Shared utilities: configuration, queue message publishers, Azure clients (Key Vault, storage), caching services |
+| `Aquifer.Jobs` | Azure Functions app: queue subscribers, timer-triggered managers, durable-task orchestrations |
+| `Aquifer.AI` | Azure OpenAI integration for machine translation drafts |
+| `Aquifer.JsEngine` | Executes JavaScript from .NET (used to run the aquifer-tiptap package server-side) |
+| `Aquifer.Tiptap` | Bridges `Aquifer.JsEngine` and the aquifer-tiptap npm package to render/validate content HTML ↔ JSON on the server |
+
+## The content format
+
+Resource content is stored as **Tiptap/ProseMirror JSON** in
+`ResourceContentVersions.Content`. The node/mark vocabulary (Bible references,
+videos, comments, footnotes, indentation) is defined by the `aquifer-tiptap`
+package, which is shared with the front ends so that editing
+(content-manager-web), rendering (well-web), and server-side processing (this
+repo, via `Aquifer.JsEngine`/`Aquifer.Tiptap`) all agree on the schema. The
+`aquifer-api-samples` repo documents the JSON schema for external consumers.
+
+## Background jobs
+
+`Aquifer.Jobs` is an Azure Functions app using Azure Storage Queues. APIs
+publish messages via the queue publisher services in `Aquifer.Common`
+(`Messages/Publishers`); subscribers in `Aquifer.Jobs/Subscribers` consume
+them. Queue names are defined in `Aquifer.Common/Messages/Queues.cs`:
+
+| Queue | Purpose |
+|---|---|
+| `send-email`, `send-templated-email` | Transactional email via SendGrid |
+| `send-project-started-notification` | In-app/email notifications |
+| `track-resource-content-request` | Records content-request analytics |
+| `translate-language-resources`, `translate-project-resources`, `translate-resource` | AI machine-translation pipeline (durable-task fan-out per resource) |
+| `upload-resource-content-audio` | Audio upload processing |
+| `generate-resource-content-similarity-score` | Computes similarity scores between source and translated content |
+
+Timer-triggered managers (`Aquifer.Jobs/Managers`) handle periodic work:
+new-content digest emails, resource-assignment notifications, and poison-queue
+alerting. Language-specific translation post-processing lives in
+`Services/TranslationProcessors`.
+
+`JobHistory` rows in the database track durable orchestration runs so jobs are
+observable from the admin CMS.
+
+## Key flows
+
+### Content lifecycle (draft → published)
+
+1. An editor creates a draft `ResourceContentVersions` row in
+   content-manager-web (via `Aquifer.API`).
+2. The `ResourceContents.Status` moves through the workflow
+   (`New` → `Aquiferize*`/`Translation*` review steps → `Complete`); every
+   transition is recorded in `ResourceContentVersionStatusHistory` and
+   assignment changes in `ResourceContentVersionAssignedUserHistory`.
+3. "Aquiferizing" means creating content in a language directly from scratch;
+   "Translation" means deriving it from existing source-language content,
+   optionally starting from an AI draft (`TranslationAwaitingAiDraft` →
+   `TranslationAiDraftComplete`) produced by the translation queues above.
+4. On publish, the version's `IsPublished` flag is set (a version may be a
+   draft **or** published, never both — enforced by a check constraint and
+   filtered unique indexes) and a snapshot is written to
+   `ResourceContentVersionSnapshots`, which is what the public/well APIs serve.
+
+### Mobile sync (bible-well)
+
+> Note: the bible-well app is discontinued; this section documents the
+> Well.API design for reference in case mobile work resumes.
+
+
+
+bible-well calls `Aquifer.Well.API` with its API key to download published
+resource content and Bible texts into its on-device SQLite database. The API
+surface is versioned through the OpenAPI spec; regenerate the client after
+endpoint changes.
+
+## Cross-cutting concerns
+
+- **Configuration**: `appsettings.json` + `appsettings.{Environment}.json`
+  (not checked in); secrets come from Azure Key Vault via `AzureKeyVaultClient`.
+- **Telemetry**: Application Insights in all apps.
+- **Caching**: output caching in the public-facing APIs; `Caching*Service`
+  classes for hot lookup data (languages, API keys, versification).
+- **Read-only DB access**: `AquiferDbReadOnlyContext` is used for heavy
+  read paths so reporting doesn't contend with writes.
+
+---
+_Last verified: 2026-08-03_

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,192 @@
+# Database
+
+The Aquifer uses a single Azure SQL (MSSQL) database, accessed exclusively
+through EF Core via `Aquifer.Data`. This document explains the **domain model
+and conventions** so you can orient yourself quickly. It intentionally does not
+enumerate every table and column — the entity classes
+(`src/Aquifer.Data/Entities/`) and migrations (`src/Aquifer.Data/Migrations/`)
+are the source of truth for that.
+
+## Conventions
+
+- **Table names are plural**, entity classes are singular with an `Entity`
+  suffix (`ResourceContentEntity` → `ResourceContents`).
+- **`Created`/`Updated` timestamps**: `Created` defaults to `getutcdate()` via
+  the `[SqlDefaultValue]` attribute; `Updated` is maintained automatically by
+  a `SavingChanges` event handler for entities implementing
+  `IHasUpdatedTimestamp`. Set values in UTC; prefer letting the handlers do it.
+- **Entity configuration** lives next to the entity in an
+  `IEntityTypeConfiguration<T>` class wired up by the
+  `[EntityTypeConfiguration]` attribute — not in `OnModelCreating`.
+- **Indexes are explicit.** The `ForeignKeyIndexConvention` is removed, so EF
+  will not create FK indexes automatically; add them deliberately on the
+  entity. Filtered unique indexes enforce "only one draft/published version
+  per content" rules.
+- **JSON columns**: large structured payloads are stored as JSON strings
+  (`ResourceContentVersions.Content` is Tiptap JSON — see
+  [architecture.md](architecture.md#the-content-format);
+  `BibleBookContents.AudioUrls` has a documented POCO on the entity).
+- **Verse IDs are computed integers**, not auto-generated:
+  `1_000_000_000 + (bookNumber * 1_000_000) + (chapter * 1_000) + verse`.
+  `BibleUtilities` has helpers for the math; word-level identifiers extend
+  this to `BBCCCVVVWWWS`. This encoding lets range queries find all verses in
+  a chapter/book with simple integer bounds.
+
+## Core content model
+
+The heart of the schema. A **parent resource** (e.g. a translation guide or
+dictionary) contains many **resources** (individual articles/entries), each of
+which has **content** per language and media type, versioned over time.
+
+```mermaid
+erDiagram
+    ParentResources ||--o{ Resources : contains
+    Languages ||--o{ ResourceContents : "target language"
+    Resources ||--o{ ResourceContents : "has content in"
+    ResourceContents ||--o{ ResourceContentVersions : "versioned as"
+    ResourceContentVersions ||--o{ ResourceContentVersionSnapshots : "snapshotted to"
+    Users ||--o{ ResourceContentVersions : "assigned to"
+    Companies ||--o{ Projects : owns
+    Users ||--o{ Projects : manages
+    Projects ||--o{ ProjectResourceContents : includes
+    ResourceContents ||--o{ ProjectResourceContents : "worked on in"
+    Bibles ||--o{ BibleBookContents : contains
+    Bibles ||--o{ BibleTexts : contains
+    Verses ||--o{ VerseResources : "linked to"
+    Resources ||--o{ VerseResources : "relevant for"
+    Passages ||--o{ PassageResources : "linked to"
+```
+
+### Resources and content
+
+- **`ParentResources`** — The top-level "collection" a resource belongs to
+  (e.g. a specific translation guide, dictionary, image set). Carries
+  `ResourceType` (Guide / Dictionary / StudyNotes / Images / Videos),
+  `ComplexityLevel`, license info, and whether it's enabled. Localized display
+  names live in `ParentResourceLocalizations`.
+- **`Resources`** — An individual entry within a parent resource (one article,
+  one dictionary word). `EnglishLabel` is the canonical name; `ExternalId`
+  links back to the source system it was loaded from.
+- **`ResourceContents`** — One row per (resource, language, media type) —
+  enforced by a unique index. This is the workflow hub: `Status` tracks the
+  item through aquiferization/translation to `Complete` (see the lifecycle in
+  [architecture.md](architecture.md#content-lifecycle-draft--published)).
+  `LanguageId` is the target language, `SourceLanguageId` the language it was
+  derived from.
+- **`ResourceContentVersions`** — A version of the content. At any time a
+  `ResourceContent` has at most one draft (`IsDraft`) and one published
+  (`IsPublished`) version, enforced by filtered unique indexes and a check
+  constraint (a version can't be both). `Content` holds the Tiptap JSON;
+  `AssignedUserId`/`AssignedReviewerUserId` drive the editorial queues;
+  `WordCount`/`SourceWordCount` feed project costing.
+- **`ResourceContentVersionSnapshots`** — Immutable copies written at each
+  status transition/publish. **This is what the public and well APIs serve**;
+  the version tables are the working copy.
+
+### Version metadata (history, comments, AI)
+
+Hang off `ResourceContentVersions`:
+
+- **`ResourceContentVersionStatusHistory` / `...AssignedUserHistory`** —
+  Append-only audit trails of status transitions and assignments.
+- **`ResourceContentVersionEditTimes`** — Per-user editing time, used for
+  company billing/reporting.
+- **`ResourceContentVersionCommentThreads`** → **`CommentThreads`** →
+  **`Comments`** (+ **`CommentMentions`**) — Editorial commenting.
+- **`ResourceContentVersionMachineTranslations`** — AI-generated draft content
+  (HTML) with user ratings and retranslation feedback.
+- **`ResourceContentVersionSimilarityScores`** — Similarity between source and
+  translated content, computed by a background job; informs review effort.
+- **`ResourceContentVersionFeedback`** — Feedback submitted on a version.
+
+### Scripture linking
+
+How resources get attached to the Bible:
+
+- **`Verses`** — Every verse of the canon; the ID is the computed integer
+  described above. No text lives here — this is the anchor table.
+- **`Passages`** — Verse ranges (`StartVerseId`–`EndVerseId`, with a check
+  constraint `Start <= End`).
+- **`VerseResources` / `PassageResources`** — Many-to-many joins linking a
+  resource to the verses/passages it discusses. These power "what resources
+  exist for this passage?" queries.
+- **`BookChapters` / `BookChapterResources` / `BookResources`** — Book- and
+  chapter-level equivalents for resources that apply to whole chapters/books.
+- **`AssociatedResources`** — Resource-to-resource "see also" links.
+- **`VersificationMappings` / `VersificationExclusions`** — How verse
+  numbering differs between Bible traditions; used to translate references
+  across versifications.
+
+### Bibles
+
+- **`Bibles`** — A Bible version in a language (name, abbreviation, license,
+  `RestrictedLicense`, `LanguageDefault`, `GreekAlignment` flag).
+  `ContentIteration` bumps when content changes so clients know to re-sync.
+- **`BibleBookContents`** — Per-book metadata: display name, chapter count,
+  audio URLs (JSON, including per-verse timestamps), and content sizes for
+  download estimates.
+- **`BibleTexts`** — The actual verse text per (Bible, book, chapter, verse).
+- **`BibleVersionWords` (+ `...WordGroups`, `...WordGroupWords`)** —
+  Word-level tokenization of a Bible version, aligned to Greek data (word
+  identifiers use the `BBCCCVVVWWWS` format).
+
+### Greek / linguistic data
+
+Reference data for original-language study, mostly loaded by content-loader:
+`GreekNewTestaments`, `GreekWords`, `GreekLemmas`, `GreekSenses` (+
+`GreekSenseGlosses`), `StrongNumbers`, `NewTestamentAlignments` (word-level
+alignment between a Bible version and the Greek NT),
+`GreekNewTestamentWord*` tables. **`TranslationPairs`** are UI-string
+translations per language (not resource content).
+
+### Projects and users (workflow management)
+
+- **`Companies`** — Translation organizations; `CompanyLanguages` and
+  `CompanyReviewers` define what they work on.
+- **`Users`** — Internal users. `ProviderId` is the Auth0 subject;
+  `Role` (Editor / Manager / Publisher / Admin / ReportViewer /
+  CommunityReviewer / Reviewer) drives authorization in `Aquifer.API`.
+- **`Projects`** — A unit of contracted translation work: source→target
+  language, owning company, project manager, word counts, quoted cost,
+  projected/actual dates. **`ProjectResourceContents`** is the join table of
+  which resource contents are in scope. `ProjectPlatforms` is effectively a
+  lookup (always Aquifer now).
+
+### Engagement, notifications, and reporting
+
+- **`ContentSubscribers`** (+ `...Languages`, `...ParentResources`) — People
+  signed up for new-content digest emails (sent by an Aquifer.Jobs manager
+  using **`EmailTemplates`**).
+- **`Notifications`** — In-app notifications (e.g. assignment notices).
+- **`ResourceContentRequests`** — Analytics: which content was requested via
+  the APIs (tracked through a queue).
+- **`Reports`** — Saved/dynamic report definitions for the admin CMS.
+- **`Feedback`** — General user feedback submissions.
+- **`Uploads`** — Tracks bulk upload operations.
+- **`IpAddressData`** — Geolocation-ish metadata for request analytics.
+
+### System / operational
+
+- **`ApiKeys`** — Hashed API keys with a scope (`InternalApi`, `PublicApi`,
+  `WellApi`); see [architecture.md](architecture.md#the-three-apis).
+- **`JobHistory`** — Execution records for background job orchestrations.
+- **`HelpDocuments`** — CMS help content.
+- **`Languages`** — Language reference data (ISO codes, script, direction).
+
+## Querying tips
+
+- For anything user-facing, read from `ResourceContentVersionSnapshots`, not
+  the version tables.
+- Hot read paths go through `AquiferDbReadOnlyContext` (no change tracking,
+  no event handlers).
+- Some reporting endpoints use Dapper (`Aquifer.Data/DapperExtensions.cs`)
+  for queries EF doesn't express well — follow that pattern rather than adding
+  raw ADO.
+
+## Migrations
+
+Schema changes are EF Core migrations in this repo only. See
+[development.md](development.md#database-migrations) for the workflow.
+
+---
+_Last verified: 2026-08-03_

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,133 @@
+# Development Guide
+
+Day-to-day setup and workflows for working in this repo. For what the pieces
+are, see [architecture.md](architecture.md).
+
+## Setup
+
+- Install the [.NET 9 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)
+  (see `global.json` for the pinned version).
+- Copy `appsettings.example.json` as `appsettings.Development.json` in the
+  project(s) you're running and provide the values needed for your instance.
+  If you want multiple instances of this file, create them per environment and
+  set `ASPNETCORE_ENVIRONMENT` accordingly, e.g.
+  `dotnet run --environment Production`. Environment configurations have no
+  reason to be checked in.
+
+```bash
+dotnet restore
+```
+
+## Running the APIs
+
+```bash
+# with hot reload (substitute the project you want)
+dotnet watch run --project src/Aquifer.API
+
+# normal mode
+dotnet run --project src/Aquifer.API
+```
+
+The three APIs run side by side; see [architecture.md](architecture.md#the-three-apis)
+for their ports and audiences. `Aquifer.Jobs` runs separately (see below).
+
+## Database Migrations
+
+***Important***: Initialize the settings file in the `src/Aquifer.Migrations`
+directory by copying `appsettings.example.json` as
+`appsettings.Development.json` and providing the values needed for your
+instance.
+
+Entity Framework will generate migrations by comparing the C# entities defined
+in the project and the current state of the database.
+
+### Add New Entity/Migration
+
+First, create your entity in the `Aquifer.Data/Entities` directory.
+
+Next, add your entity definition to the `src/Aquifer.Data/AquiferDbContext.cs`
+file. Entities are listed in alphabetical order.
+
+### Create a New Migration
+
+```bash
+dotnet ef migrations add --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --context AquiferDbContext <MigrationNameHere>
+```
+
+Your new migration will be created in the `src/Aquifer.Data/Migrations`
+directory along with the `.Designer` file and updated
+`AquiferDbContextModelSnapshot.cs` file.
+
+If you run that command and the new migration file is empty, that means there
+were no changes detected between the C# entities and the database. You can use
+this to your advantage to create empty migrations and add your own custom code
+(some production indexes are maintained this way — see the note in
+`ResourceContentVersionEntityConfiguration`).
+
+### Apply, list, and remove migrations
+
+```bash
+# apply migrations to the DB
+dotnet ef database update --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --context AquiferDbContext
+
+# list all migrations (useful before applying)
+dotnet ef migrations list --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --context AquiferDbContext
+
+# remove the last migration (useful when developing locally)
+dotnet ef migrations remove --startup-project src/Aquifer.Migrations --project src/Aquifer.Data --context AquiferDbContext
+```
+
+## Jobs/Queues
+
+We use Azure Storage Queues and Azure Functions for queueing and running jobs
+(see [architecture.md](architecture.md#background-jobs) for the queue list).
+To develop locally, you'll need
+[Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=visual-studio,blob-storage)
+and
+[Azure Function Core Tools](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local).
+
+1. Run Azurite so that you can have local queues. In the `aquifer-server` dir, run `azurite`.
+2. Run Aquifer.Jobs using the function core tools. In `aquifer-server/src/Aquifer.Jobs` run `func start`.
+
+## Client Generation
+
+`Aquifer.Well.API` supports C# client generation based upon its OpenAPI spec.
+The generated client lives in the bible-well repo, so this command assumes you
+have a local clone of bible-well in a folder next to this repo:
+
+```bash
+dotnet run --project src/Aquifer.Well.API --generateclients true
+```
+
+Running the command updates the client code in that repo based on changes to
+the OpenAPI spec. Commit the result in bible-well as a separate PR.
+
+## Lint
+
+```bash
+dotnet build --no-incremental /p:WarningsAsErrors=true
+```
+
+## Test
+
+```bash
+dotnet test
+```
+
+## CLI REPL
+
+If you want to use a REPL outside of an IDE, csharprepl is a good option:
+
+```bash
+# install
+dotnet tool install -g csharprepl
+
+# run
+csharprepl
+```
+
+Then load a project from the csharprepl prompt:
+`#r "src/Aquifer.API/Aquifer.API.csproj"`
+
+---
+_Last verified: 2026-08-03_

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,0 +1,152 @@
+# Ecosystem Overview
+
+This is the authoritative map of how the repositories in the `eten-tech` GitHub
+organization relate to one another. Each repo's own documentation covers its
+internals; this document only covers cross-repo relationships. When you learn
+something here that has changed, update this file — every other repo links to it.
+
+## The big picture
+
+The Aquifer is a platform for creating, managing, and distributing biblical
+translation resources (guides, dictionaries, study notes, images, videos) and
+Bible texts in many languages. `aquifer-server` (this repo) is the hub: it owns
+the database and exposes all APIs. Everything else is either a client of those
+APIs, a tool for getting content into the database, or a shared library.
+
+```mermaid
+flowchart LR
+    subgraph Clients
+        CMW[content-manager-web<br/>admin CMS]
+        WW[well-web<br/>public PWA / Android]
+        BW[bible-well<br/>mobile app - discontinued]
+        MKT[marketing-aquifer<br/>static site]
+        EXT[external consumers<br/>see aquifer-api-samples]
+    end
+
+    subgraph aquifer-server
+        API[Aquifer.API<br/>internal]
+        PUB[Aquifer.Public.API<br/>public]
+        WELL[Aquifer.Well.API<br/>mobile]
+        JOBS[Aquifer.Jobs<br/>Azure Functions]
+        DB[(Azure SQL<br/>Aquifer DB)]
+    end
+
+    subgraph Content pipeline
+        UTIL[aquifer-utilities<br/>TS scripts]
+        CL[content-loader<br/>.NET console/worker]
+    end
+
+    TIP[aquifer-tiptap<br/>shared editor library]
+
+    CMW -- "Auth0 JWT" --> API
+    WW -- "API key" --> API
+    MKT -- "API key" --> API
+    EXT --> PUB
+    BW -- "API key, Kiota client" --> WELL
+
+    API --> DB
+    PUB --> DB
+    WELL --> DB
+    JOBS --> DB
+    API -- "queue messages" --> JOBS
+
+    UTIL -- "JSON output" --> CL
+    CL -- "project references<br/>Aquifer.Data" --> DB
+
+    CMW -.-> TIP
+    WW -.-> TIP
+    API -. "renders/validates content<br/>via Aquifer.JsEngine" .-> TIP
+    UTIL -.-> TIP
+```
+
+## Repository directory
+
+### Serving and storing content
+
+**aquifer-server** (this repo) — Three ASP.NET Core APIs plus background jobs,
+sharing one EF Core data layer over Azure SQL. See [architecture.md](architecture.md)
+and [database.md](database.md).
+
+### Consuming content
+
+**content-manager-web** — SvelteKit admin CMS. Where internal users and
+translation companies create, edit, review, and manage resource content,
+projects, and users. Calls `Aquifer.API` with Auth0 JWTs.
+
+**well-web** — SvelteKit PWA (and Capacitor Android app) for end users to read
+Aquifer content, with an offline-first service-worker caching model. Calls
+`Aquifer.API` with an API key.
+
+**bible-well** — ⚠️ **Discontinued.** An early cross-platform mobile app
+experiment (Avalonia UI + MAUI Essentials) that called `Aquifer.Well.API`
+through a Kiota-generated C# client. No new development is planned; the repo
+remains for reference only. `Aquifer.Well.API` still exists in this repo and
+its client-generation flow targets this repo's sibling clone convention, but
+treat the mobile app itself as archived.
+
+**marketing-aquifer** — Framework-less static marketing site for the Aquifer,
+including a public resource-availability tracker that calls `Aquifer.API`
+directly from the browser with an API key.
+
+**aquifer-api-samples** — Example projects (C#, React) showing external
+consumers how to use `Aquifer.Public.API`. Also hosts the most complete
+documentation of the resource content (Tiptap/ProseMirror JSON) schema in its
+`documentation/` folder — read it before hand-rolling content JSON.
+
+### Getting content into the database
+
+**content-loader** — .NET console apps and worker services for bulk-loading and
+transforming content in the Aquifer DB. **Project-references `Aquifer.Data`,
+`Aquifer.Common`, `Aquifer.JsEngine`, and `Aquifer.Tiptap`, so it must be
+cloned as a sibling directory of this repo.** Long-running loads are deployed
+to Azure Container Instances via Azure Container Registry.
+
+**aquifer-utilities** — TypeScript (Bun) scripts and a small pipeline framework
+for scraping, downloading, and normalizing external content sources (e.g. FIA,
+Open Bible). Produces JSON that is then loaded by `content-loader`. Expects
+`content-loader` as a sibling directory.
+
+### Shared libraries and tooling
+
+**aquifer-tiptap** — Custom Tiptap rich-text editor extensions (Bible
+references, videos, comments, footnotes) plus HTML/JSON parsing helpers. This
+is the shared definition of Aquifer's content format, consumed by:
+- `content-manager-web` and `well-web` (rendering/editing in the browser),
+- `aquifer-server` (server-side rendering/validation in .NET via
+  `Aquifer.JsEngine`, which executes the package's JS),
+- `aquifer-utilities` (building content JSON).
+
+Distributed via GitHub releases (not npm), referenced as a GitHub dependency.
+
+**github-action-slack-notify-build** — Forked GitHub Action that posts
+deployment/build status to Slack (with Linear ticket enrichment). Used by the
+deploy workflows of `aquifer-server`, `content-manager-web`, and `well-web`.
+
+## Working across repos
+
+Some tasks span multiple repos; clone these as sibling directories:
+
+| Task | Siblings required |
+|---|---|
+| Run or build `content-loader` | `aquifer-server` |
+| Regenerate the bible-well API client | `aquifer-server`, `bible-well` |
+| Run `aquifer-utilities` pipelines | `content-loader` (and transitively `aquifer-server`) |
+| Change content JSON structure | `aquifer-tiptap` + all consumers above |
+
+Schema changes to the Aquifer DB always happen in this repo via EF Core
+migrations (see [development.md](development.md#database-migrations)); other
+repos never migrate the database themselves.
+
+## Deployed environments
+
+| API | Production | QA |
+|---|---|---|
+| Aquifer.API (internal) | `https://api-bn.aquifer.bible/` | `https://qa.api-bn.aquifer.bible/` |
+| Aquifer.Well.API | `https://api-well.aquifer.bible/` | `https://qa.api-well.aquifer.bible/` |
+| Aquifer.Public.API | `https://api.aquifer.bible/` | — |
+
+Front-ends are Azure Static Web Apps; APIs are Azure Web Apps; jobs are Azure
+Functions; see [infrastructure.md](infrastructure.md) for the Azure specifics.
+
+---
+_Last verified: 2026-08-03_


### PR DESCRIPTION
…re, database, development, ecosystem, and infrastructure

- Replace verbose README with concise quickstart and documentation index
- Add docs/architecture.md covering three APIs, project map, content format, background jobs, and key flows
- Add docs/database.md documenting domain model, schema conventions, core tables, and querying patterns
- Add docs/development.md with setup instructions, EF migrations workflow, jobs/queues, client