### PR TITLE
Add admin endpoint to create API keys

### DIFF
--- a/src/Aquifer.API/Common/Permissions.cs
+++ b/src/Aquifer.API/Common/Permissions.cs
@@ -12,6 +12,7 @@ public static class PermissionName
         AssignContent = "assign:content",
         AssignOutsideCompany = "assign:outside-company",
         AssignOverride = "assign:override",
+        CreateApiKey = "create:apikey",
         CreateCommunityContent = "create:community-content",
         CreateContent = "create:content",
         CreateProject = "create:project",

--- a/src/Aquifer.API/Endpoints/Admin/ApiKeys/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Admin/ApiKeys/Create/Endpoint.cs
@@ -1,0 +1,56 @@
+using System.Security.Cryptography;
+using Aquifer.API.Services;
+using Aquifer.Data;
+using Aquifer.Data.Entities;
+using FastEndpoints;
+using Microsoft.EntityFrameworkCore;
+
+namespace Aquifer.API.Endpoints.Admin.ApiKeys.Create;
+
+public class Endpoint(AquiferDbContext dbContext, IUserService userService)
+    : Endpoint<Request, Response>
+{
+    private const int ApiKeyLength = 64;
+
+    public override void Configure()
+    {
+        Post("/admin/api-keys");
+    }
+
+    public override async Task HandleAsync(Request request, CancellationToken ct)
+    {
+        var currentUser = await userService.GetUserFromJwtAsync(ct);
+        if (currentUser.Role != UserRole.Admin)
+        {
+            await SendForbiddenAsync(ct);
+            return;
+        }
+
+        var apiKey = new ApiKeyEntity
+        {
+            ApiKey = await GenerateUniqueApiKeyAsync(ct),
+            Scope = request.Scope,
+            Organization = request.Organization,
+            ContactName = request.ContactName,
+            Email = request.Email,
+            Phone = request.Phone,
+            UseCase = request.UseCase,
+        };
+
+        await dbContext.ApiKeys.AddAsync(apiKey, ct);
+        await dbContext.SaveChangesAsync(ct);
+
+        await SendOkAsync(new Response { Id = apiKey.Id, ApiKey = apiKey.ApiKey }, ct);
+    }
+
+    private async Task<string> GenerateUniqueApiKeyAsync(CancellationToken ct)
+    {
+        string candidateKey;
+        do
+        {
+            candidateKey = RandomNumberGenerator.GetHexString(ApiKeyLength);
+        } while (await dbContext.ApiKeys.AnyAsync(x => x.ApiKey == candidateKey, ct));
+
+        return candidateKey;
+    }
+}

--- a/src/Aquifer.API/Endpoints/Admin/ApiKeys/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Admin/ApiKeys/Create/Endpoint.cs
@@ -1,5 +1,5 @@
 using System.Security.Cryptography;
-using Aquifer.API.Services;
+using Aquifer.API.Common;
 using Aquifer.Data;
 using Aquifer.Data.Entities;
 using FastEndpoints;
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Aquifer.API.Endpoints.Admin.ApiKeys.Create;
 
-public class Endpoint(AquiferDbContext dbContext, IUserService userService)
+public class Endpoint(AquiferDbContext dbContext)
     : Endpoint<Request, Response>
 {
     private const int ApiKeyLength = 64;
@@ -15,17 +15,11 @@ public class Endpoint(AquiferDbContext dbContext, IUserService userService)
     public override void Configure()
     {
         Post("/admin/api-keys");
+        Permissions(PermissionName.CreateApiKey);
     }
 
     public override async Task HandleAsync(Request request, CancellationToken ct)
     {
-        var currentUser = await userService.GetUserFromJwtAsync(ct);
-        if (currentUser.Role != UserRole.Admin)
-        {
-            await SendForbiddenAsync(ct);
-            return;
-        }
-
         var apiKey = new ApiKeyEntity
         {
             ApiKey = await GenerateUniqueApiKeyAsync(ct),

--- a/src/Aquifer.API/Endpoints/Admin/ApiKeys/Create/Endpoint.cs
+++ b/src/Aquifer.API/Endpoints/Admin/ApiKeys/Create/Endpoint.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using Aquifer.API.Common;
 using Aquifer.Data;
 using Aquifer.Data.Entities;
@@ -10,8 +9,6 @@ namespace Aquifer.API.Endpoints.Admin.ApiKeys.Create;
 public class Endpoint(AquiferDbContext dbContext)
     : Endpoint<Request, Response>
 {
-    private const int ApiKeyLength = 64;
-
     public override void Configure()
     {
         Post("/admin/api-keys");
@@ -42,7 +39,8 @@ public class Endpoint(AquiferDbContext dbContext)
         string candidateKey;
         do
         {
-            candidateKey = RandomNumberGenerator.GetHexString(ApiKeyLength);
+            // equivalent to the historical SQL key generation: LOWER(REPLACE(CAST(NEWID() AS NVARCHAR(36)), '-', ''))
+            candidateKey = Guid.NewGuid().ToString("N");
         } while (await dbContext.ApiKeys.AnyAsync(x => x.ApiKey == candidateKey, ct));
 
         return candidateKey;

--- a/src/Aquifer.API/Endpoints/Admin/ApiKeys/Create/Request.cs
+++ b/src/Aquifer.API/Endpoints/Admin/ApiKeys/Create/Request.cs
@@ -1,0 +1,13 @@
+using Aquifer.Data.Entities;
+
+namespace Aquifer.API.Endpoints.Admin.ApiKeys.Create;
+
+public sealed class Request
+{
+    public ApiKeyScope Scope { get; set; }
+    public string? Organization { get; set; }
+    public string? ContactName { get; set; }
+    public string? Email { get; set; }
+    public string? Phone { get; set; }
+    public string? UseCase { get; set; }
+}

--- a/src/Aquifer.API/Endpoints/Admin/ApiKeys/Create/Response.cs
+++ b/src/Aquifer.API/Endpoints/Admin/ApiKeys/Create/Response.cs
@@ -1,0 +1,7 @@
+namespace Aquifer.API.Endpoints.Admin.ApiKeys.Create;
+
+public sealed class Response
+{
+    public int Id { get; set; }
+    public string ApiKey { get; set; } = null!;
+}

--- a/src/Aquifer.API/Endpoints/Admin/ApiKeys/Create/Validator.cs
+++ b/src/Aquifer.API/Endpoints/Admin/ApiKeys/Create/Validator.cs
@@ -1,0 +1,23 @@
+using Aquifer.Data.Entities;
+using FastEndpoints;
+using FluentValidation;
+
+namespace Aquifer.API.Endpoints.Admin.ApiKeys.Create;
+
+public class Validator : Validator<Request>
+{
+    public Validator()
+    {
+        RuleFor(x => x.Scope).IsInEnum();
+        RuleFor(x => x.Scope).Must(scope => scope != ApiKeyScope.None).WithMessage("A valid scope is required.");
+        RuleFor(x => x.Organization).MaximumLength(64);
+        RuleFor(x => x.ContactName).MaximumLength(64);
+        RuleFor(x => x.Email).MaximumLength(64).EmailAddress().When(x => x.Email is not null);
+        RuleFor(x => x.Phone).MaximumLength(32);
+        RuleFor(x => x.UseCase).MaximumLength(256);
+
+        RuleFor(x => x)
+            .Must(x => !string.IsNullOrWhiteSpace(x.ContactName) || !string.IsNullOrWhiteSpace(x.Organization))
+            .WithMessage("Either ContactName or Organization is required.");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `POST /admin/api-keys`, gated by a new `create:apikey` permission, to create API keys (scope, organization/contact info, use case).
- Generates the key as `Guid.NewGuid().ToString("N")`, matching the historical SQL key generation (`LOWER(REPLACE(CAST(NEWID() AS NVARCHAR(36)), '-', ''))`), retrying on the unlikely event of a collision.
- Validates that either `ContactName` or `Organization` is provided, matching the existing DB check constraint on `ApiKeys`.

## Test plan
- [x] `dotnet build` succeeds
- [ ] Manually verify `POST /admin/api-keys` with the `create:apikey` permission assigned in Auth0 returns a generated key and persists the row
- [ ] Confirm a caller without `create:apikey` is rejected

Note: the `create:apikey` permission still needs to be created and assigned to the appropriate Auth0 role(s) in the Auth0 dashboard (no Auth0 config-as-code exists in this repo).